### PR TITLE
Configure CloudFront with SSR origin and failover group

### DIFF
--- a/lib/akli-infrastructure-stack.ts
+++ b/lib/akli-infrastructure-stack.ts
@@ -1,4 +1,4 @@
-import { Stack, StackProps, RemovalPolicy, CfnOutput, Duration, SecretValue } from 'aws-cdk-lib'
+import { Stack, StackProps, RemovalPolicy, CfnOutput, Duration, SecretValue, Fn } from 'aws-cdk-lib'
 import { Construct } from 'constructs'
 import * as s3 from 'aws-cdk-lib/aws-s3'
 import * as cloudfront from 'aws-cdk-lib/aws-cloudfront'
@@ -102,19 +102,66 @@ export class AkliInfrastructureStack extends Stack {
       `),
     });
 
+    // Lambda function for SSR
+    // 256 MB — sufficient for React SSR, ~$0.06/100K requests
+    const ssrFunction = new NodejsFunction(this, 'SsrFunction', {
+      runtime: lambda.Runtime.NODEJS_20_X,
+      entry: path.join(__dirname, '..', 'lambda', 'ssr-handler.ts'),
+      handler: 'handler',
+      memorySize: 256,
+      timeout: Duration.seconds(10),
+      description: 'SSR renderer for akli.dev — placeholder handler until the React server bundle is deployed',
+    })
+
+    // HTTP API Gateway — routes all requests to the SSR Lambda
+    // $1.00 per 1M requests (API Gateway v2 pricing)
+    const ssrIntegration = new HttpLambdaIntegration('SsrIntegration', ssrFunction)
+
+    const httpApi = new HttpApi(this, 'HttpApi', {
+      apiName: 'akli-dev-ssr',
+      description: 'HTTP API Gateway for SSR Lambda — serves as CloudFront origin',
+      defaultIntegration: ssrIntegration,
+    })
+
+    // SSR cache policy — 60s TTL, caches on full URI
+    const ssrCachePolicy = new cloudfront.CachePolicy(this, 'SsrCachePolicy', {
+      cachePolicyName: 'SsrCachePolicy',
+      defaultTtl: Duration.seconds(60),
+      maxTtl: Duration.seconds(60),
+      minTtl: Duration.seconds(0),
+      queryStringBehavior: cloudfront.CacheQueryStringBehavior.all(),
+      headerBehavior: cloudfront.CacheHeaderBehavior.none(),
+      cookieBehavior: cloudfront.CacheCookieBehavior.none(),
+    })
+
+    const s3Origin = origins.S3BucketOrigin.withOriginAccessControl(siteBucket, {
+      originAccessControl: originAccessControl,
+    })
+
+    // API Gateway origin — extract domain name from the full endpoint URL
+    const apiGatewayOrigin = new origins.HttpOrigin(
+      Fn.select(2, Fn.split('/', httpApi.apiEndpoint)),
+    )
+
+    // Origin failover group: API Gateway primary, S3 fallback on 5xx
+    const ssrOriginGroup = new origins.OriginGroup({
+      primaryOrigin: apiGatewayOrigin,
+      fallbackOrigin: s3Origin,
+      fallbackStatusCodes: [500, 502, 503, 504],
+    })
+
     // CloudFront distribution
     const distribution = new cloudfront.Distribution(this, 'SiteDistribution', {
       defaultRootObject: 'index.html',
-      domainNames: [DOMAIN_NAME, WWW_DOMAIN_NAME], // Add both domains
+      domainNames: [DOMAIN_NAME, WWW_DOMAIN_NAME],
       certificate,
       priceClass: cloudfront.PriceClass.PRICE_CLASS_100,
       defaultBehavior: {
-        origin: origins.S3BucketOrigin.withOriginAccessControl(siteBucket, {
-          originAccessControl: originAccessControl,
-        }),
+        origin: ssrOriginGroup,
         viewerProtocolPolicy: cloudfront.ViewerProtocolPolicy.REDIRECT_TO_HTTPS,
-        cachePolicy: cloudfront.CachePolicy.CACHING_OPTIMIZED,
+        cachePolicy: ssrCachePolicy,
         responseHeadersPolicy: securityHeadersPolicy,
+        allowedMethods: cloudfront.AllowedMethods.ALLOW_GET_HEAD,
         compress: true,
       },
       additionalBehaviors: {
@@ -124,7 +171,7 @@ export class AkliInfrastructureStack extends Stack {
             originAccessControl: originAccessControl,
           }),
           viewerProtocolPolicy: cloudfront.ViewerProtocolPolicy.REDIRECT_TO_HTTPS,
-          cachePolicy: imageCachePolicy, // Use our custom cache policy
+          cachePolicy: imageCachePolicy,
           responseHeadersPolicy: securityHeadersPolicy,
           compress: true,
         },
@@ -143,20 +190,6 @@ export class AkliInfrastructureStack extends Stack {
           }],
         },
       },
-      errorResponses: [
-        {
-          httpStatus: 404,
-          responseHttpStatus: 200,
-          responsePagePath: '/index.html', // SPA fallback
-          ttl: Duration.minutes(5),
-        },
-        {
-          httpStatus: 403,
-          responseHttpStatus: 200,
-          responsePagePath: '/index.html', // SPA fallback
-          ttl: Duration.minutes(5),
-        },
-      ],
     })
 
     // Grant CloudFront access to S3 bucket
@@ -257,27 +290,6 @@ export class AkliInfrastructureStack extends Stack {
         secretAccessKey: cdkAccessKey.secretAccessKey,
       },
       description: 'CDK GitHub Actions credentials',
-    })
-
-    // Lambda function for SSR
-    // 256 MB — sufficient for React SSR, ~$0.06/100K requests
-    const ssrFunction = new NodejsFunction(this, 'SsrFunction', {
-      runtime: lambda.Runtime.NODEJS_20_X,
-      entry: path.join(__dirname, '..', 'lambda', 'ssr-handler.ts'),
-      handler: 'handler',
-      memorySize: 256,
-      timeout: Duration.seconds(10),
-      description: 'SSR renderer for akli.dev — placeholder handler until the React server bundle is deployed',
-    })
-
-    // HTTP API Gateway — routes all requests to the SSR Lambda
-    // $1.00 per 1M requests (API Gateway v2 pricing)
-    const ssrIntegration = new HttpLambdaIntegration('SsrIntegration', ssrFunction)
-
-    const httpApi = new HttpApi(this, 'HttpApi', {
-      apiName: 'akli-dev-ssr',
-      description: 'HTTP API Gateway for SSR Lambda — serves as CloudFront origin',
-      defaultIntegration: ssrIntegration,
     })
 
     // CloudFormation outputs

--- a/test/akli-infrastructure.test.ts
+++ b/test/akli-infrastructure.test.ts
@@ -1,5 +1,5 @@
 import * as cdk from 'aws-cdk-lib'
-import { Template } from 'aws-cdk-lib/assertions'
+import { Match, Template } from 'aws-cdk-lib/assertions'
 import * as route53 from 'aws-cdk-lib/aws-route53'
 import * as certificatemanager from 'aws-cdk-lib/aws-certificatemanager'
 import { AkliInfrastructureStack } from '../lib/akli-infrastructure-stack'
@@ -91,6 +91,85 @@ describe('AkliInfrastructureStack', () => {
       template.hasResourceProperties('AWS::CloudFront::Distribution', {
         DistributionConfig: {
           Aliases: ['akli.dev', 'www.akli.dev'],
+        },
+      })
+    })
+
+    it('has the API Gateway as an origin', () => {
+      template.hasResourceProperties('AWS::CloudFront::Distribution', {
+        DistributionConfig: {
+          Origins: Match.arrayWith([
+            Match.objectLike({
+              CustomOriginConfig: Match.objectLike({
+                OriginProtocolPolicy: 'https-only',
+              }),
+            }),
+          ]),
+        },
+      })
+    })
+
+    it('configures an origin failover group', () => {
+      template.hasResourceProperties('AWS::CloudFront::Distribution', {
+        DistributionConfig: {
+          OriginGroups: Match.objectLike({
+            Quantity: 1,
+            Items: Match.arrayWith([
+              Match.objectLike({
+                FailoverCriteria: {
+                  StatusCodes: {
+                    Items: [500, 502, 503, 504],
+                    Quantity: 4,
+                  },
+                },
+                Members: {
+                  Quantity: 2,
+                  Items: Match.arrayWith([
+                    Match.objectLike({ OriginId: Match.anyValue() }),
+                  ]),
+                },
+              }),
+            ]),
+          }),
+        },
+      })
+    })
+
+    it('does not have SPA error responses', () => {
+      template.hasResourceProperties('AWS::CloudFront::Distribution', {
+        DistributionConfig: {
+          CustomErrorResponses: Match.absent(),
+        },
+      })
+    })
+  })
+
+  describe('SSR cache policy', () => {
+    it('creates a cache policy with 60-second TTL', () => {
+      template.hasResourceProperties('AWS::CloudFront::CachePolicy', {
+        CachePolicyConfig: {
+          Name: 'SsrCachePolicy',
+          DefaultTTL: 60,
+          MaxTTL: 60,
+        },
+      })
+    })
+  })
+
+  describe('Security headers', () => {
+    it('applies security headers policy to SSR responses', () => {
+      template.hasResourceProperties('AWS::CloudFront::ResponseHeadersPolicy', {
+        ResponseHeadersPolicyConfig: {
+          SecurityHeadersConfig: {
+            ContentTypeOptions: { Override: true },
+            FrameOptions: { FrameOption: 'DENY', Override: true },
+            StrictTransportSecurity: Match.objectLike({
+              AccessControlMaxAgeSec: 31536000,
+              IncludeSubdomains: true,
+              Preload: true,
+              Override: true,
+            }),
+          },
         },
       })
     })


### PR DESCRIPTION
Closes #3

## What changed
- Added API Gateway as a second CloudFront origin via `HttpOrigin`
- Created an origin failover group: API Gateway primary, S3 fallback on 500/502/503/504
- Updated the default behaviour to route through the failover group with a new SSR cache policy (60s TTL)
- Removed the SPA 404/403 → `/index.html` error responses (Lambda handles routing now)
- Existing `images/*` and `apps/sand-box*` behaviours remain unchanged, routing directly to S3
- Added 5 CDK assertion tests (12 total now passing)

## Why
Core piece of the SSR infrastructure. CloudFront now routes HTML page requests to Lambda (via API Gateway) with automatic fallback to the static S3 site if Lambda fails.

## How to verify
- `pnpm build` compiles without errors
- `pnpm test` — all 12 tests pass
- `cdk diff` shows the new origin, failover group, cache policy, and removed error responses

## Decisions made
- CDK's L2 `OriginGroup` construct natively supports failover — no escape hatches needed.
- API Gateway domain extracted from `httpApi.apiEndpoint` using `Fn.split`/`Fn.select` to strip the `https://` prefix.
- Failover triggers on 500, 502, 503, 504 — standard set for origin failover.
- Lambda and API Gateway definitions moved before the CloudFront distribution in the file to resolve declaration ordering.