### PR TITLE
Create HTTP API Gateway for Pokedex

### DIFF
--- a/lib/pokedex-stack.ts
+++ b/lib/pokedex-stack.ts
@@ -1,12 +1,15 @@
-import { Duration, Stack, StackProps, Tags } from 'aws-cdk-lib'
+import { CfnOutput, Duration, Stack, StackProps, Tags } from 'aws-cdk-lib'
 import { Construct } from 'constructs'
 import * as dynamodb from 'aws-cdk-lib/aws-dynamodb'
 import * as lambda from 'aws-cdk-lib/aws-lambda'
 import { NodejsFunction } from 'aws-cdk-lib/aws-lambda-nodejs'
+import { CorsHttpMethod, HttpApi, HttpMethod } from 'aws-cdk-lib/aws-apigatewayv2'
+import { HttpLambdaIntegration } from 'aws-cdk-lib/aws-apigatewayv2-integrations'
 import * as path from 'path'
 
 export class PokedexStack extends Stack {
   public readonly pokemonFunction: NodejsFunction
+  public readonly httpApi: HttpApi
 
   constructor(scope: Construct, id: string, props?: StackProps) {
     super(scope, id, props)
@@ -29,6 +32,36 @@ export class PokedexStack extends Stack {
     })
 
     table.grantReadData(this.pokemonFunction)
+
+    // HTTP API Gateway (v2) for the Pokedex API
+    const pokemonIntegration = new HttpLambdaIntegration('PokemonIntegration', this.pokemonFunction)
+
+    this.httpApi = new HttpApi(this, 'PokedexHttpApi', {
+      apiName: 'pokedex-api',
+      description: 'HTTP API Gateway for the Pokedex API',
+      corsPreflight: {
+        allowOrigins: ['https://akli.dev'],
+        allowMethods: [CorsHttpMethod.GET],
+        allowHeaders: ['Content-Type'],
+      },
+    })
+
+    this.httpApi.addRoutes({
+      path: '/pokedex/pokemon',
+      methods: [HttpMethod.GET],
+      integration: pokemonIntegration,
+    })
+
+    this.httpApi.addRoutes({
+      path: '/pokedex/pokemon/{id}',
+      methods: [HttpMethod.GET],
+      integration: pokemonIntegration,
+    })
+
+    new CfnOutput(this, 'PokedexApiUrl', {
+      value: this.httpApi.apiEndpoint,
+      description: 'Pokedex HTTP API Gateway endpoint URL',
+    })
 
     // StackProps.tags don't auto-propagate to resources — must apply explicitly
     if (props?.tags) {

--- a/test/pokedex-stack.test.ts
+++ b/test/pokedex-stack.test.ts
@@ -121,6 +121,38 @@ describe('PokedexStack', () => {
     })
   })
 
+  describe('HTTP API Gateway', () => {
+    it('creates an HTTP API (ApiGatewayV2)', () => {
+      template.hasResourceProperties('AWS::ApiGatewayV2::Api', {
+        ProtocolType: 'HTTP',
+      })
+    })
+
+    it('configures CORS to allow https://akli.dev', () => {
+      template.hasResourceProperties('AWS::ApiGatewayV2::Api', {
+        CorsConfiguration: Match.objectLike({
+          AllowOrigins: Match.arrayWith(['https://akli.dev']),
+        }),
+      })
+    })
+
+    it('has a GET /pokedex/pokemon route', () => {
+      template.hasResourceProperties('AWS::ApiGatewayV2::Route', {
+        RouteKey: 'GET /pokedex/pokemon',
+      })
+    })
+
+    it('has a GET /pokedex/pokemon/{id} route', () => {
+      template.hasResourceProperties('AWS::ApiGatewayV2::Route', {
+        RouteKey: 'GET /pokedex/pokemon/{id}',
+      })
+    })
+
+    it('exports the API URL as a CloudFormation output', () => {
+      template.hasOutput('PokedexApiUrl', {})
+    })
+  })
+
   describe('Tags', () => {
     it('tags all resources with Owner', () => {
       template.hasResourceProperties('AWS::DynamoDB::Table', {


### PR DESCRIPTION
Closes #17

## What changed
- Added HTTP API Gateway (v2) to `PokedexStack` with CORS configured for `https://akli.dev`
- Two routes: `GET /pokedex/pokemon` and `GET /pokedex/pokemon/{id}` via `HttpLambdaIntegration`
- API URL exported as CloudFormation output (`PokedexApiUrl`) for `ApiStack` consumption
- `httpApi` exposed as public property on the stack

## Why
Third issue in the Pokedex API & Data epic — the API Gateway routes HTTP requests to the Lambda handler.

## How to verify
- `pnpm test` — all 42 tests pass (5 new API Gateway assertions + existing)

## Decisions made
- Routes include `/pokedex` prefix matching the Lambda handler's `routeKey` parsing
- CORS allows only `https://akli.dev` (cross-origin since API is on `api.akli.dev`)
- Used `HttpLambdaIntegration` from `aws-cdk-lib/aws-apigatewayv2-integrations`