### PR TITLE
Add CDK Custom Resource to seed DynamoDB from pokemon.json

### DIFF
--- a/lambda/seed-pokemon.ts
+++ b/lambda/seed-pokemon.ts
@@ -1,0 +1,91 @@
+import { DynamoDBClient, BatchWriteItemCommand, BatchWriteItemCommandOutput, WriteRequest } from '@aws-sdk/client-dynamodb'
+import { marshall } from '@aws-sdk/util-dynamodb'
+import type { CloudFormationCustomResourceEvent, CloudFormationCustomResourceResponse } from 'aws-lambda'
+import * as fs from 'fs'
+import * as path from 'path'
+
+const client = new DynamoDBClient({})
+const TABLE_NAME = process.env.TABLE_NAME!
+
+const BATCH_SIZE = 25
+const MAX_RETRIES = 5
+const BASE_DELAY_MS = 100
+
+interface Pokemon {
+  readonly id: number
+  readonly name: string
+  readonly types: readonly string[]
+  readonly sprite: string
+  readonly height: number
+  readonly weight: number
+  readonly category: string
+  readonly description: string
+  readonly genderRate: number
+  readonly stats: {
+    readonly hp: number
+    readonly attack: number
+    readonly defense: number
+    readonly specialAttack: number
+    readonly specialDefense: number
+    readonly speed: number
+  }
+}
+
+function loadPokemonData(): Pokemon[] {
+  const dataPath = path.join(__dirname, '..', 'data', 'pokemon.json')
+  const raw = fs.readFileSync(dataPath, 'utf-8')
+  return JSON.parse(raw) as Pokemon[]
+}
+
+async function seedTable(pokemon: Pokemon[]): Promise<void> {
+  for (let i = 0; i < pokemon.length; i += BATCH_SIZE) {
+    const batch = pokemon.slice(i, i + BATCH_SIZE)
+    const writeRequests = batch.map(p => ({
+      PutRequest: {
+        Item: marshall(p, { removeUndefinedValues: true }),
+      },
+    }))
+
+    let unprocessed: WriteRequest[] | undefined = writeRequests
+    let retries = 0
+
+    while (unprocessed && unprocessed.length > 0 && retries <= MAX_RETRIES) {
+      if (retries > 0) {
+        const delay = BASE_DELAY_MS * Math.pow(2, retries - 1)
+        await new Promise(resolve => setTimeout(resolve, delay))
+      }
+
+      const result: BatchWriteItemCommandOutput = await client.send(new BatchWriteItemCommand({
+        RequestItems: { [TABLE_NAME]: unprocessed },
+      }))
+
+      const remaining = result.UnprocessedItems?.[TABLE_NAME]
+      unprocessed = remaining && remaining.length > 0 ? remaining : undefined
+      retries++
+    }
+
+    if (unprocessed && unprocessed.length > 0) {
+      throw new Error(`Failed to write all items after ${MAX_RETRIES} retries`)
+    }
+  }
+}
+
+export async function onEvent(
+  event: CloudFormationCustomResourceEvent,
+): Promise<Partial<CloudFormationCustomResourceResponse>> {
+  const requestType = event.RequestType
+
+  const physicalId = event.RequestType === 'Create'
+    ? 'seed-pokemon'
+    : event.PhysicalResourceId
+
+  if (requestType === 'Delete') {
+    return { PhysicalResourceId: physicalId }
+  }
+
+  // Create and Update both seed (idempotent — PutItem overwrites)
+  const pokemon = loadPokemonData()
+  await seedTable(pokemon)
+
+  return { PhysicalResourceId: physicalId }
+}

--- a/lib/pokedex-stack.ts
+++ b/lib/pokedex-stack.ts
@@ -1,10 +1,13 @@
-import { CfnOutput, Duration, Stack, StackProps, Tags } from 'aws-cdk-lib'
+import { CfnOutput, CustomResource, Duration, Stack, StackProps, Tags } from 'aws-cdk-lib'
 import { Construct } from 'constructs'
 import * as dynamodb from 'aws-cdk-lib/aws-dynamodb'
 import * as lambda from 'aws-cdk-lib/aws-lambda'
 import { NodejsFunction } from 'aws-cdk-lib/aws-lambda-nodejs'
 import { CorsHttpMethod, HttpApi, HttpMethod } from 'aws-cdk-lib/aws-apigatewayv2'
 import { HttpLambdaIntegration } from 'aws-cdk-lib/aws-apigatewayv2-integrations'
+import { Provider } from 'aws-cdk-lib/custom-resources'
+import * as crypto from 'crypto'
+import * as fs from 'fs'
 import * as path from 'path'
 
 export class PokedexStack extends Stack {
@@ -18,6 +21,37 @@ export class PokedexStack extends Stack {
       tableName: 'pokedex-pokemon',
       partitionKey: { name: 'id', type: dynamodb.AttributeType.NUMBER },
       billingMode: dynamodb.BillingMode.PAY_PER_REQUEST,
+    })
+
+    // Seed DynamoDB from data/pokemon.json via Custom Resource
+    const pokemonDataPath = path.join(__dirname, '..', 'data', 'pokemon.json')
+    const pokemonDataHash = crypto
+      .createHash('md5')
+      .update(fs.readFileSync(pokemonDataPath, 'utf-8'))
+      .digest('hex')
+
+    const seederFunction = new NodejsFunction(this, 'SeedPokemonHandler', {
+      runtime: lambda.Runtime.NODEJS_22_X,
+      memorySize: 256,
+      timeout: Duration.minutes(5),
+      entry: path.join(__dirname, '..', 'lambda', 'seed-pokemon.ts'),
+      handler: 'onEvent',
+      environment: {
+        TABLE_NAME: table.tableName,
+      },
+    })
+
+    table.grant(seederFunction, 'dynamodb:BatchWriteItem')
+
+    const seedProvider = new Provider(this, 'SeedPokemonProvider', {
+      onEventHandler: seederFunction,
+    })
+
+    new CustomResource(this, 'SeedPokemonResource', {
+      serviceToken: seedProvider.serviceToken,
+      properties: {
+        DataHash: pokemonDataHash,
+      },
     })
 
     this.pokemonFunction = new NodejsFunction(this, 'PokemonHandler', {

--- a/test/lambda/seed-pokemon.test.ts
+++ b/test/lambda/seed-pokemon.test.ts
@@ -1,0 +1,110 @@
+import { DynamoDBClient, BatchWriteItemCommand } from '@aws-sdk/client-dynamodb'
+import { mockClient } from 'aws-sdk-client-mock'
+import type { CloudFormationCustomResourceEvent } from 'aws-lambda'
+
+const ddbMock = mockClient(DynamoDBClient)
+
+process.env.TABLE_NAME = 'pokedex-pokemon'
+
+import { onEvent } from '../../lambda/seed-pokemon'
+
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const pokemonData: unknown[] = require('../../data/pokemon.json')
+
+function makeEvent(
+  requestType: 'Create' | 'Update' | 'Delete',
+  overrides: Partial<CloudFormationCustomResourceEvent> = {},
+): CloudFormationCustomResourceEvent {
+  return {
+    RequestType: requestType,
+    ServiceToken: 'arn:aws:lambda:eu-west-2:123456789012:function:test',
+    ResponseURL: 'https://cloudformation-custom-resource-response.s3.amazonaws.com/test',
+    StackId: 'arn:aws:cloudformation:eu-west-2:123456789012:stack/test/guid',
+    RequestId: 'test-request-id',
+    ResourceType: 'Custom::SeedPokemon',
+    LogicalResourceId: 'SeedPokemon',
+    ResourceProperties: {
+      ServiceToken: 'arn:aws:lambda:eu-west-2:123456789012:function:test',
+      DataHash: 'abc123',
+    },
+    PhysicalResourceId: 'seed-pokemon',
+    ...overrides,
+  } as CloudFormationCustomResourceEvent
+}
+
+describe('seed-pokemon onEvent', () => {
+  beforeEach(() => {
+    ddbMock.reset()
+  })
+
+  describe('Create event', () => {
+    it('calls BatchWriteItem with correct data from pokemon.json', async () => {
+      ddbMock.on(BatchWriteItemCommand).resolves({ UnprocessedItems: {} })
+
+      await onEvent(makeEvent('Create'))
+
+      const calls = ddbMock.commandCalls(BatchWriteItemCommand)
+      // 151 pokemon / 25 per batch = 7 batches (6 full + 1 partial)
+      expect(calls.length).toBe(Math.ceil(pokemonData.length / 25))
+
+      // Verify first batch contains first 25 pokemon
+      const firstCallInput = calls[0].args[0].input
+      const firstBatchRequests = firstCallInput.RequestItems!['pokedex-pokemon']
+      expect(firstBatchRequests).toHaveLength(25)
+    })
+  })
+
+  describe('Update event', () => {
+    it('calls BatchWriteItem (idempotent reseed)', async () => {
+      ddbMock.on(BatchWriteItemCommand).resolves({ UnprocessedItems: {} })
+
+      await onEvent(makeEvent('Update'))
+
+      const calls = ddbMock.commandCalls(BatchWriteItemCommand)
+      expect(calls.length).toBe(Math.ceil(pokemonData.length / 25))
+    })
+  })
+
+  describe('Delete event', () => {
+    it('is a no-op and returns success', async () => {
+      const result = await onEvent(makeEvent('Delete'))
+
+      expect(result.PhysicalResourceId).toBe('seed-pokemon')
+      const calls = ddbMock.commandCalls(BatchWriteItemCommand)
+      expect(calls.length).toBe(0)
+    })
+  })
+
+  describe('UnprocessedItems retry', () => {
+    it('retries when BatchWriteItem returns UnprocessedItems', async () => {
+      // First call for first batch returns unprocessed items, second call succeeds
+      const unprocessedItem = {
+        PutRequest: {
+          Item: { id: { N: '1' }, name: { S: 'Bulbasaur' } },
+        },
+      }
+
+      let firstBatchCallCount = 0
+      ddbMock.on(BatchWriteItemCommand).callsFake((input) => {
+        const requests = input.RequestItems!['pokedex-pokemon']
+        // Only simulate unprocessed items for the first batch (25 items)
+        if (requests.length === 25 && firstBatchCallCount === 0) {
+          firstBatchCallCount++
+          return {
+            UnprocessedItems: {
+              'pokedex-pokemon': [unprocessedItem],
+            },
+          }
+        }
+        return { UnprocessedItems: {} }
+      })
+
+      await onEvent(makeEvent('Create'))
+
+      const calls = ddbMock.commandCalls(BatchWriteItemCommand)
+      // Normal batches + 1 retry for the first batch
+      const expectedBatches = Math.ceil(pokemonData.length / 25)
+      expect(calls.length).toBe(expectedBatches + 1)
+    })
+  })
+})

--- a/test/pokedex-stack.test.ts
+++ b/test/pokedex-stack.test.ts
@@ -153,6 +153,39 @@ describe('PokedexStack', () => {
     })
   })
 
+  describe('DynamoDB seed Custom Resource', () => {
+    it('creates a CloudFormation Custom Resource', () => {
+      template.hasResourceProperties('AWS::CloudFormation::CustomResource', {})
+    })
+
+    it('has a DataHash property to trigger reseeding on data changes', () => {
+      template.hasResourceProperties('AWS::CloudFormation::CustomResource', {
+        DataHash: Match.stringLikeRegexp('^[a-f0-9]{32}$'),
+      })
+    })
+
+    it('creates a seeder Lambda function', () => {
+      // The seeder Lambda should exist alongside the API handler
+      const lambdas = template.findResources('AWS::Lambda::Function')
+      const lambdaCount = Object.keys(lambdas).length
+      // At least 2 Lambda functions: the API handler and the seeder (provider framework also creates Lambdas)
+      expect(lambdaCount).toBeGreaterThanOrEqual(2)
+    })
+
+    it('grants the seeder Lambda dynamodb:BatchWriteItem permission', () => {
+      template.hasResourceProperties('AWS::IAM::Policy', {
+        PolicyDocument: {
+          Statement: Match.arrayWith([
+            Match.objectLike({
+              Action: 'dynamodb:BatchWriteItem',
+              Effect: 'Allow',
+            }),
+          ]),
+        },
+      })
+    })
+  })
+
   describe('Tags', () => {
     it('tags all resources with Owner', () => {
       template.hasResourceProperties('AWS::DynamoDB::Table', {


### PR DESCRIPTION
Closes #18

## What changed
- Created `lambda/seed-pokemon.ts` — seeder Lambda that batch-writes all 151 Pokemon from `data/pokemon.json` to DynamoDB
- Added Provider-based Custom Resource to `PokedexStack` with MD5 hash of `pokemon.json` as a property to trigger reseeding on data changes
- Seeder handles `UnprocessedItems` with exponential backoff retries
- Delete events are a no-op (table is deleted with the stack)
- Seeder Lambda granted `dynamodb:BatchWriteItem` scoped to the Pokedex table

## Why
Automated data seeding — no manual steps needed when deploying or redeploying the stack.

## How to verify
- `pnpm test` — all 50 tests pass (4 new CDK assertions + 4 seeder unit tests + existing)

## Decisions made
- Used Provider construct from `aws-cdk-lib/custom-resources` for Custom Resource
- MD5 hash of pokemon.json ensures reseeding triggers only when data actually changes
- BatchWriteItem with 25 items per batch (DynamoDB limit), exponential backoff for retries
- Seeding is idempotent — PutItem overwrites existing items