### PR TITLE
Fix Function URL auth: switch to AWS_IAM with CloudFront OAC

### DIFF
--- a/lib/akli-infrastructure-stack.ts
+++ b/lib/akli-infrastructure-stack.ts
@@ -1,4 +1,4 @@
-import { Stack, StackProps, RemovalPolicy, CfnOutput, Duration, SecretValue, Fn } from 'aws-cdk-lib'
+import { Stack, StackProps, RemovalPolicy, CfnOutput, Duration, SecretValue } from 'aws-cdk-lib'
 import { Construct } from 'constructs'
 import * as s3 from 'aws-cdk-lib/aws-s3'
 import * as cloudfront from 'aws-cdk-lib/aws-cloudfront'
@@ -110,9 +110,9 @@ export class AkliInfrastructureStack extends Stack {
       description: 'SSR renderer for akli.dev — placeholder handler until the React server bundle is deployed',
     })
 
-    // Lambda Function URL — NONE auth (CloudFront handles protection), no additional cost
+    // Lambda Function URL — AWS_IAM auth, CloudFront signs requests via OAC
     const ssrFunctionUrl = ssrFunction.addFunctionUrl({
-      authType: lambda.FunctionUrlAuthType.NONE,
+      authType: lambda.FunctionUrlAuthType.AWS_IAM,
       invokeMode: lambda.InvokeMode.RESPONSE_STREAM,
     })
 
@@ -130,10 +130,8 @@ export class AkliInfrastructureStack extends Stack {
       originAccessControl: originAccessControl,
     })
 
-    // Function URL is "https://xxx.lambda-url.region.on.aws/" — extract the domain
-    const functionUrlOrigin = new origins.HttpOrigin(
-      Fn.select(2, Fn.split('/', ssrFunctionUrl.url)),
-    )
+    // CloudFront OAC for Lambda — signs requests so AWS_IAM auth passes
+    const functionUrlOrigin = new origins.FunctionUrlOrigin(ssrFunctionUrl)
 
     const ssrOriginGroup = new origins.OriginGroup({
       primaryOrigin: functionUrlOrigin,

--- a/test/akli-infrastructure.test.ts
+++ b/test/akli-infrastructure.test.ts
@@ -160,9 +160,9 @@ describe('AkliInfrastructureStack', () => {
       })
     })
 
-    it('uses NONE auth type (CloudFront handles protection)', () => {
+    it('uses AWS_IAM auth type (CloudFront signs via OAC)', () => {
       template.hasResourceProperties('AWS::Lambda::Url', {
-        AuthType: 'NONE',
+        AuthType: 'AWS_IAM',
       })
     })
 


### PR DESCRIPTION
## Summary
- Switched Lambda Function URL auth from `NONE` to `AWS_IAM`
- Replaced manual `HttpOrigin` with CDK's `FunctionUrlOrigin` which sets up CloudFront OAC for Lambda automatically
- CloudFront signs requests via OAC so the Lambda accepts them

## Why
The account's Lambda public access block policy was rejecting `NONE` auth Function URL requests with 403 Forbidden. `AWS_IAM` auth with CloudFront OAC is the AWS-recommended production pattern — it ensures only CloudFront can invoke the Lambda, not direct requests.

## Test plan
- [x] All 70 tests pass (`pnpm test`)
- [ ] `cdk deploy --all` and verify akli.dev returns 200