### PR TITLE
Fix: grant CloudFront permission to invoke Lambda Function URL

### DIFF
--- a/lib/akli-infrastructure-stack.ts
+++ b/lib/akli-infrastructure-stack.ts
@@ -197,6 +197,13 @@ export class AkliInfrastructureStack extends Stack {
       },
     })
 
+    // Grant CloudFront access to Lambda Function URL via OAC
+    ssrFunction.addPermission('CloudFrontOACInvoke', {
+      principal: new iam.ServicePrincipal('cloudfront.amazonaws.com'),
+      action: 'lambda:InvokeFunctionUrl',
+      sourceArn: `arn:aws:cloudfront::${this.account}:distribution/${distribution.distributionId}`,
+    })
+
     // Grant CloudFront access to S3 bucket
     siteBucket.addToResourcePolicy(new iam.PolicyStatement({
       sid: 'AllowCloudFrontServicePrincipal',


### PR DESCRIPTION
## Summary
Adds `lambda:InvokeFunctionUrl` resource-based policy to the SSR Lambda, granting the CloudFront distribution permission to invoke it via OAC.

## Why
The previous PR (#35) switched to `AWS_IAM` auth with `FunctionUrlOrigin`, which set up the OAC on the CloudFront side. But `FunctionUrlOrigin` doesn't automatically add the Lambda resource-based policy — CloudFront's signed requests were being rejected with 403 because the Lambda had no policy allowing invocation.

## What changed
Added `ssrFunction.addPermission('CloudFrontOACInvoke', ...)` scoped to the distribution ARN.

## Test plan
- [x] All 70 tests pass (`pnpm test`)
- [ ] `cdk deploy --all` and verify akli.dev returns 200