### PR TITLE
Fix: attach Lambda OAC to CloudFront origin

### DIFF
--- a/lib/akli-infrastructure-stack.ts
+++ b/lib/akli-infrastructure-stack.ts
@@ -130,7 +130,16 @@ export class AkliInfrastructureStack extends Stack {
       originAccessControl: originAccessControl,
     })
 
-    // CloudFront OAC for Lambda — signs requests so AWS_IAM auth passes
+    // OAC for Lambda — CloudFront signs requests so AWS_IAM auth passes
+    const lambdaOac = new cloudfront.CfnOriginAccessControl(this, 'LambdaOAC', {
+      originAccessControlConfig: {
+        name: 'LambdaFunctionUrlOAC',
+        originAccessControlOriginType: 'lambda',
+        signingBehavior: 'always',
+        signingProtocol: 'sigv4',
+      },
+    })
+
     const functionUrlOrigin = new origins.FunctionUrlOrigin(ssrFunctionUrl)
 
     const ssrOriginGroup = new origins.OriginGroup({
@@ -196,6 +205,15 @@ export class AkliInfrastructureStack extends Stack {
         },
       },
     })
+
+    // Attach Lambda OAC to the Function URL origin via L1 escape hatch.
+    // FunctionUrlOrigin + OriginGroup doesn't propagate OAC to CloudFormation.
+    // Origin index 0 is the Lambda Function URL (primary in the OriginGroup).
+    const cfnDistribution = distribution.node.defaultChild as cloudfront.CfnDistribution
+    cfnDistribution.addPropertyOverride(
+      'DistributionConfig.Origins.0.OriginAccessControlId',
+      lambdaOac.attrId,
+    )
 
     // Grant CloudFront access to Lambda Function URL via OAC
     ssrFunction.addPermission('CloudFrontOACInvoke', {


### PR DESCRIPTION
## Summary
Creates a Lambda-type Origin Access Control and attaches it to the Function URL origin in CloudFront using an L1 property override.

## Why
The previous two fixes set up `AWS_IAM` auth (#35) and added the Lambda resource policy (#36), but the OAC was never attached to the Lambda origin in CloudFront. `FunctionUrlOrigin` combined with `OriginGroup` doesn't propagate the OAC to CloudFormation — the synthesised template showed `OriginAccessControlId: ""` on the Lambda origin.

Without the OAC, CloudFront sends unsigned requests → Lambda rejects with 403.

## What changed
- Created a `CfnOriginAccessControl` with `originType: 'lambda'`, `signingBehavior: 'always'`, `signingProtocol: 'sigv4'`
- Used `cfnDistribution.addPropertyOverride` to set `OriginAccessControlId` on the Lambda origin (index 0)
- Verified via `cdk synth` that the Lambda origin now has the OAC attached

## Test plan
- [x] All 70 tests pass
- [x] Synthesised template shows OAC on Lambda origin
- [ ] Deploy and verify akli.dev returns 200