### PR TITLE
Fix: remove CustomOriginConfig from Lambda origin for OAC signing

### DIFF
--- a/lib/akli-infrastructure-stack.ts
+++ b/lib/akli-infrastructure-stack.ts
@@ -214,6 +214,11 @@ export class AkliInfrastructureStack extends Stack {
       'DistributionConfig.Origins.0.OriginAccessControlId',
       lambdaOac.attrId,
     )
+    // Lambda OAC requires no CustomOriginConfig — CloudFront must treat it
+    // as a managed origin (like S3) for SigV4 signing to work correctly.
+    cfnDistribution.addPropertyDeletionOverride(
+      'DistributionConfig.Origins.0.CustomOriginConfig',
+    )
 
     // Grant CloudFront access to Lambda Function URL via OAC
     ssrFunction.addPermission('CloudFrontOACInvoke', {

--- a/test/akli-infrastructure.test.ts
+++ b/test/akli-infrastructure.test.ts
@@ -215,21 +215,22 @@ describe('AkliInfrastructureStack', () => {
   })
 
   describe('CloudFront Function URL origin', () => {
-    it('has the Lambda Function URL as a CloudFront origin', () => {
+    it('has the Lambda Function URL as a CloudFront origin with OAC', () => {
       const resources = template.toJSON().Resources
       const dist = Object.values(resources).find(
         (r: any) => r.Type === 'AWS::CloudFront::Distribution',
       ) as any
 
       const origins = dist.Properties.DistributionConfig.Origins
-      const customOrigin = origins.find((o: any) => o.CustomOriginConfig !== undefined)
+      // Find the Lambda origin by its domain (derived from the Function URL)
+      const lambdaOrigin = origins.find((o: any) => {
+        const fnGetAtt = o.DomainName?.['Fn::Select']?.[1]?.['Fn::Split']?.[1]?.['Fn::GetAtt']
+        return fnGetAtt && fnGetAtt[0]?.match(/SsrFunctionFunctionUrl/)
+      })
 
-      const domainName = customOrigin.DomainName
-      const fnGetAtt = domainName?.['Fn::Select']?.[1]?.['Fn::Split']?.[1]?.['Fn::GetAtt']
-
-      expect(fnGetAtt).toBeDefined()
-      expect(fnGetAtt[0]).toMatch(/SsrFunctionFunctionUrl/)
-      expect(fnGetAtt[1]).toBe('FunctionUrl')
+      expect(lambdaOrigin).toBeDefined()
+      expect(lambdaOrigin.OriginAccessControlId).toBeDefined()
+      expect(lambdaOrigin.CustomOriginConfig).toBeUndefined()
     })
 
     it('uses the Function URL origin as the primary in the OriginGroup failover', () => {


### PR DESCRIPTION
## Summary
Removes `CustomOriginConfig` from the Lambda Function URL origin using an L1 deletion override.

## Why
Lambda Function URL origins with OAC must **not** have `CustomOriginConfig`. When it's present, CloudFront treats it as a regular custom origin and doesn't apply SigV4 signing — the request reaches Lambda unsigned, and Lambda rejects it with 403.

CDK's `FunctionUrlOrigin` always sets `CustomOriginConfig` (https-only, TLSv1.2). This override removes it so CloudFront treats the origin as a managed origin and signs requests via OAC.

## What changed
- Added `cfnDistribution.addPropertyDeletionOverride('DistributionConfig.Origins.0.CustomOriginConfig')`
- Updated test to verify Lambda origin has OAC and no CustomOriginConfig

## Test plan
- [x] All 70 tests pass
- [ ] Deploy and verify akli.dev returns 200