### PR TITLE
Fix: use HttpOrigin with OAC for Lambda Function URL

### DIFF
--- a/lib/akli-infrastructure-stack.ts
+++ b/lib/akli-infrastructure-stack.ts
@@ -1,4 +1,4 @@
-import { Stack, StackProps, RemovalPolicy, CfnOutput, Duration, SecretValue } from 'aws-cdk-lib'
+import { Stack, StackProps, RemovalPolicy, CfnOutput, Duration, SecretValue, Fn } from 'aws-cdk-lib'
 import { Construct } from 'constructs'
 import * as s3 from 'aws-cdk-lib/aws-s3'
 import * as cloudfront from 'aws-cdk-lib/aws-cloudfront'
@@ -140,7 +140,10 @@ export class AkliInfrastructureStack extends Stack {
       },
     })
 
-    const functionUrlOrigin = new origins.FunctionUrlOrigin(ssrFunctionUrl)
+    // Use HttpOrigin for the Function URL domain — OAC is attached via L1 override below
+    const functionUrlOrigin = new origins.HttpOrigin(
+      Fn.select(2, Fn.split('/', ssrFunctionUrl.url)),
+    )
 
     const ssrOriginGroup = new origins.OriginGroup({
       primaryOrigin: functionUrlOrigin,
@@ -213,11 +216,6 @@ export class AkliInfrastructureStack extends Stack {
     cfnDistribution.addPropertyOverride(
       'DistributionConfig.Origins.0.OriginAccessControlId',
       lambdaOac.attrId,
-    )
-    // Lambda OAC requires no CustomOriginConfig — CloudFront must treat it
-    // as a managed origin (like S3) for SigV4 signing to work correctly.
-    cfnDistribution.addPropertyDeletionOverride(
-      'DistributionConfig.Origins.0.CustomOriginConfig',
     )
 
     // Grant CloudFront access to Lambda Function URL via OAC

--- a/test/akli-infrastructure.test.ts
+++ b/test/akli-infrastructure.test.ts
@@ -230,7 +230,7 @@ describe('AkliInfrastructureStack', () => {
 
       expect(lambdaOrigin).toBeDefined()
       expect(lambdaOrigin.OriginAccessControlId).toBeDefined()
-      expect(lambdaOrigin.CustomOriginConfig).toBeUndefined()
+      expect(lambdaOrigin.CustomOriginConfig).toBeDefined()
     })
 
     it('uses the Function URL origin as the primary in the OriginGroup failover', () => {


### PR DESCRIPTION
## Summary
Switches from `FunctionUrlOrigin` to `HttpOrigin` with manual domain extraction, keeping `CustomOriginConfig` alongside the Lambda OAC.

## Why
PR #38 tried to remove `CustomOriginConfig` which CloudFormation rejected ("Exactly one of CustomOriginConfig, VpcOriginConfig and S3OriginConfig must be specified"). Lambda Function URL origins with OAC **require** `CustomOriginConfig` — only S3 origins omit it.

`FunctionUrlOrigin` also didn't propagate OAC correctly through `OriginGroup`, so we switch to the explicit `HttpOrigin` approach where we have full control.

## What changed
- Replaced `FunctionUrlOrigin` with `HttpOrigin` using `Fn.select`/`Fn.split` for domain extraction
- Removed the `CustomOriginConfig` deletion override that caused the deploy failure
- OAC is still attached via `addPropertyOverride`

## Test plan
- [x] All 70 tests pass
- [x] Synthesised template has both `CustomOriginConfig` and `OriginAccessControlId` on the Lambda origin
- [ ] Deploy and verify akli.dev returns 200