### PR TITLE
Create DynamoDB recipes table with GSIs

### DIFF
--- a/lib/recipe-stack.ts
+++ b/lib/recipe-stack.ts
@@ -1,8 +1,31 @@
 import { Stack, StackProps } from 'aws-cdk-lib'
 import { Construct } from 'constructs'
+import * as dynamodb from 'aws-cdk-lib/aws-dynamodb'
+import { applyStackTags } from './utils'
 
 export class RecipeStack extends Stack {
   constructor(scope: Construct, id: string, props?: StackProps) {
     super(scope, id, props)
+
+    const table = new dynamodb.Table(this, 'RecipesTable', {
+      tableName: 'recipes',
+      partitionKey: { name: 'id', type: dynamodb.AttributeType.STRING },
+      billingMode: dynamodb.BillingMode.PAY_PER_REQUEST,
+      pointInTimeRecoverySpecification: { pointInTimeRecoveryEnabled: true },
+    })
+
+    table.addGlobalSecondaryIndex({
+      indexName: 'status-createdAt-index',
+      partitionKey: { name: 'status', type: dynamodb.AttributeType.STRING },
+      sortKey: { name: 'createdAt', type: dynamodb.AttributeType.STRING },
+    })
+
+    table.addGlobalSecondaryIndex({
+      indexName: 'authorId-createdAt-index',
+      partitionKey: { name: 'authorId', type: dynamodb.AttributeType.STRING },
+      sortKey: { name: 'createdAt', type: dynamodb.AttributeType.STRING },
+    })
+
+    applyStackTags(this, props)
   }
 }

--- a/lib/recipe-stack.ts
+++ b/lib/recipe-stack.ts
@@ -1,0 +1,8 @@
+import { Stack, StackProps } from 'aws-cdk-lib'
+import { Construct } from 'constructs'
+
+export class RecipeStack extends Stack {
+  constructor(scope: Construct, id: string, props?: StackProps) {
+    super(scope, id, props)
+  }
+}

--- a/test/recipe-stack.test.ts
+++ b/test/recipe-stack.test.ts
@@ -1,0 +1,192 @@
+import * as cdk from 'aws-cdk-lib'
+import { Match, Template } from 'aws-cdk-lib/assertions'
+import { RecipeStack } from '../lib/recipe-stack'
+
+function createTestStack(): Template {
+  const app = new cdk.App()
+
+  cdk.Tags.of(app).add('Owner', 'Akli')
+  cdk.Tags.of(app).add('CostCenter', 'Recipes')
+
+  const stack = new RecipeStack(app, 'TestRecipeStack', {
+    env: { account: '123456789012', region: 'eu-west-2' },
+    tags: {
+      Project: 'recipes',
+      Environment: 'production',
+      ManagedBy: 'cdk',
+    },
+  })
+
+  return Template.fromStack(stack)
+}
+
+describe('RecipeStack', () => {
+  let template: Template
+
+  beforeAll(() => {
+    template = createTestStack()
+  })
+
+  describe('DynamoDB table', () => {
+    it('creates a DynamoDB table named recipes', () => {
+      template.hasResourceProperties('AWS::DynamoDB::Table', {
+        TableName: 'recipes',
+      })
+    })
+
+    it('has partition key id of type String', () => {
+      template.hasResourceProperties('AWS::DynamoDB::Table', {
+        KeySchema: [
+          { AttributeName: 'id', KeyType: 'HASH' },
+        ],
+        AttributeDefinitions: Match.arrayWith([
+          { AttributeName: 'id', AttributeType: 'S' },
+        ]),
+      })
+    })
+
+    it('uses on-demand billing (PAY_PER_REQUEST)', () => {
+      template.hasResourceProperties('AWS::DynamoDB::Table', {
+        BillingMode: 'PAY_PER_REQUEST',
+      })
+    })
+
+    it('enables Point-in-Time Recovery', () => {
+      template.hasResourceProperties('AWS::DynamoDB::Table', {
+        PointInTimeRecoverySpecification: {
+          PointInTimeRecoveryEnabled: true,
+        },
+      })
+    })
+  })
+
+  describe('GSI status-createdAt-index', () => {
+    it('creates GSI with name status-createdAt-index', () => {
+      template.hasResourceProperties('AWS::DynamoDB::Table', {
+        GlobalSecondaryIndexes: Match.arrayWith([
+          Match.objectLike({
+            IndexName: 'status-createdAt-index',
+          }),
+        ]),
+      })
+    })
+
+    it('has partition key status (String)', () => {
+      template.hasResourceProperties('AWS::DynamoDB::Table', {
+        GlobalSecondaryIndexes: Match.arrayWith([
+          Match.objectLike({
+            IndexName: 'status-createdAt-index',
+            KeySchema: Match.arrayWith([
+              { AttributeName: 'status', KeyType: 'HASH' },
+            ]),
+          }),
+        ]),
+        AttributeDefinitions: Match.arrayWith([
+          { AttributeName: 'status', AttributeType: 'S' },
+        ]),
+      })
+    })
+
+    it('has sort key createdAt (String)', () => {
+      template.hasResourceProperties('AWS::DynamoDB::Table', {
+        GlobalSecondaryIndexes: Match.arrayWith([
+          Match.objectLike({
+            IndexName: 'status-createdAt-index',
+            KeySchema: Match.arrayWith([
+              { AttributeName: 'createdAt', KeyType: 'RANGE' },
+            ]),
+          }),
+        ]),
+        AttributeDefinitions: Match.arrayWith([
+          { AttributeName: 'createdAt', AttributeType: 'S' },
+        ]),
+      })
+    })
+  })
+
+  describe('GSI authorId-createdAt-index', () => {
+    it('creates GSI with name authorId-createdAt-index', () => {
+      template.hasResourceProperties('AWS::DynamoDB::Table', {
+        GlobalSecondaryIndexes: Match.arrayWith([
+          Match.objectLike({
+            IndexName: 'authorId-createdAt-index',
+          }),
+        ]),
+      })
+    })
+
+    it('has partition key authorId (String)', () => {
+      template.hasResourceProperties('AWS::DynamoDB::Table', {
+        GlobalSecondaryIndexes: Match.arrayWith([
+          Match.objectLike({
+            IndexName: 'authorId-createdAt-index',
+            KeySchema: Match.arrayWith([
+              { AttributeName: 'authorId', KeyType: 'HASH' },
+            ]),
+          }),
+        ]),
+        AttributeDefinitions: Match.arrayWith([
+          { AttributeName: 'authorId', AttributeType: 'S' },
+        ]),
+      })
+    })
+
+    it('has sort key createdAt (String)', () => {
+      template.hasResourceProperties('AWS::DynamoDB::Table', {
+        GlobalSecondaryIndexes: Match.arrayWith([
+          Match.objectLike({
+            IndexName: 'authorId-createdAt-index',
+            KeySchema: Match.arrayWith([
+              { AttributeName: 'createdAt', KeyType: 'RANGE' },
+            ]),
+          }),
+        ]),
+        AttributeDefinitions: Match.arrayWith([
+          { AttributeName: 'createdAt', AttributeType: 'S' },
+        ]),
+      })
+    })
+  })
+
+  describe('Tags', () => {
+    it('tags the table with Owner', () => {
+      template.hasResourceProperties('AWS::DynamoDB::Table', {
+        Tags: Match.arrayWith([
+          Match.objectLike({ Key: 'Owner', Value: 'Akli' }),
+        ]),
+      })
+    })
+
+    it('tags the table with CostCenter', () => {
+      template.hasResourceProperties('AWS::DynamoDB::Table', {
+        Tags: Match.arrayWith([
+          Match.objectLike({ Key: 'CostCenter', Value: 'Recipes' }),
+        ]),
+      })
+    })
+
+    it('tags the table with Project=recipes', () => {
+      template.hasResourceProperties('AWS::DynamoDB::Table', {
+        Tags: Match.arrayWith([
+          Match.objectLike({ Key: 'Project', Value: 'recipes' }),
+        ]),
+      })
+    })
+
+    it('tags the table with Environment=production', () => {
+      template.hasResourceProperties('AWS::DynamoDB::Table', {
+        Tags: Match.arrayWith([
+          Match.objectLike({ Key: 'Environment', Value: 'production' }),
+        ]),
+      })
+    })
+
+    it('tags the table with ManagedBy=cdk', () => {
+      template.hasResourceProperties('AWS::DynamoDB::Table', {
+        Tags: Match.arrayWith([
+          Match.objectLike({ Key: 'ManagedBy', Value: 'cdk' }),
+        ]),
+      })
+    })
+  })
+})


### PR DESCRIPTION
Closes #50

## What changed
Created `RecipeStack` with a DynamoDB `recipes` table:
- Partition key `id` (String), PAY_PER_REQUEST billing
- Point-in-Time Recovery enabled
- GSI `status-createdAt-index` for public recipe listings
- GSI `authorId-createdAt-index` for per-user recipe queries

## Why
Foundation table for the Recipe API — all CRUD operations and queries depend on this table and its GSIs.

## How to verify
- `pnpm test -- recipe-stack` — 15/15 tests pass

## Decisions made
- Used `pointInTimeRecoverySpecification` (non-deprecated API)
- Both GSIs use ALL projection (default) for flexibility in query patterns
- Agent: **cdk-engineer** specialist, **test-engineer** for TDD