### PR TITLE
Create S3 image bucket with upload CORS

### DIFF
--- a/lib/recipe-stack.ts
+++ b/lib/recipe-stack.ts
@@ -1,6 +1,7 @@
-import { Stack, StackProps } from 'aws-cdk-lib'
+import { Duration, RemovalPolicy, Stack, StackProps } from 'aws-cdk-lib'
 import { Construct } from 'constructs'
 import * as dynamodb from 'aws-cdk-lib/aws-dynamodb'
+import * as s3 from 'aws-cdk-lib/aws-s3'
 import { applyStackTags } from './utils'
 
 export class RecipeStack extends Stack {
@@ -24,6 +25,24 @@ export class RecipeStack extends Stack {
       indexName: 'authorId-createdAt-index',
       partitionKey: { name: 'authorId', type: dynamodb.AttributeType.STRING },
       sortKey: { name: 'createdAt', type: dynamodb.AttributeType.STRING },
+    })
+
+    new s3.Bucket(this, 'RecipeImagesBucket', {
+      bucketName: `akli-recipe-images-${this.account}-${this.region}`,
+      blockPublicAccess: s3.BlockPublicAccess.BLOCK_ALL,
+      removalPolicy: RemovalPolicy.RETAIN,
+      autoDeleteObjects: false,
+      lifecycleRules: [
+        {
+          abortIncompleteMultipartUploadAfter: Duration.days(1),
+        },
+      ],
+      cors: [
+        {
+          allowedMethods: [s3.HttpMethods.PUT],
+          allowedOrigins: ['https://akli.dev'],
+        },
+      ],
     })
 
     applyStackTags(this, props)

--- a/lib/recipe-stack.ts
+++ b/lib/recipe-stack.ts
@@ -30,6 +30,8 @@ export class RecipeStack extends Stack {
     new s3.Bucket(this, 'RecipeImagesBucket', {
       bucketName: `akli-recipe-images-${this.account}-${this.region}`,
       blockPublicAccess: s3.BlockPublicAccess.BLOCK_ALL,
+      encryption: s3.BucketEncryption.S3_MANAGED,
+      enforceSSL: true,
       removalPolicy: RemovalPolicy.RETAIN,
       autoDeleteObjects: false,
       lifecycleRules: [
@@ -41,6 +43,7 @@ export class RecipeStack extends Stack {
         {
           allowedMethods: [s3.HttpMethods.PUT],
           allowedOrigins: ['https://akli.dev'],
+          allowedHeaders: ['*'],
         },
       ],
     })

--- a/test/recipe-stack.test.ts
+++ b/test/recipe-stack.test.ts
@@ -148,6 +148,53 @@ describe('RecipeStack', () => {
     })
   })
 
+  describe('S3 image bucket', () => {
+    it('creates an S3 bucket named akli-recipe-images-{account-id}-eu-west-2', () => {
+      template.hasResourceProperties('AWS::S3::Bucket', {
+        BucketName: 'akli-recipe-images-123456789012-eu-west-2',
+      })
+    })
+
+    it('blocks all public access', () => {
+      template.hasResourceProperties('AWS::S3::Bucket', {
+        PublicAccessBlockConfiguration: {
+          BlockPublicAcls: true,
+          BlockPublicPolicy: true,
+          IgnorePublicAcls: true,
+          RestrictPublicBuckets: true,
+        },
+      })
+    })
+
+    it('has a lifecycle rule to abort incomplete multipart uploads after 1 day', () => {
+      template.hasResourceProperties('AWS::S3::Bucket', {
+        LifecycleConfiguration: {
+          Rules: Match.arrayWith([
+            Match.objectLike({
+              AbortIncompleteMultipartUpload: {
+                DaysAfterInitiation: 1,
+              },
+              Status: 'Enabled',
+            }),
+          ]),
+        },
+      })
+    })
+
+    it('allows PUT from https://akli.dev via CORS', () => {
+      template.hasResourceProperties('AWS::S3::Bucket', {
+        CorsConfiguration: {
+          CorsRules: Match.arrayWith([
+            Match.objectLike({
+              AllowedMethods: Match.arrayWith(['PUT']),
+              AllowedOrigins: Match.arrayWith(['https://akli.dev']),
+            }),
+          ]),
+        },
+      })
+    })
+  })
+
   describe('Tags', () => {
     it('tags the table with Owner', () => {
       template.hasResourceProperties('AWS::DynamoDB::Table', {


### PR DESCRIPTION
Closes #51

## What changed
Added S3 image bucket to `RecipeStack`:
- Bucket name: `akli-recipe-images-{account}-{region}`
- All public access blocked
- Lifecycle rule: abort incomplete multipart uploads after 1 day
- CORS: allow PUT from `https://akli.dev` for presigned URL uploads
- RemovalPolicy.RETAIN (user content)

## Why
Recipe images need a private S3 bucket for presigned URL uploads from the browser, with automatic cleanup of abandoned uploads.

## How to verify
- `pnpm test -- recipe-stack` — 19/19 tests pass

## Decisions made
- Used RETAIN removal policy since bucket contains user-uploaded images
- CORS limited to PUT only (no GET needed — images served via CloudFront OAC)
- Agents: **test-engineer** (Write mode) + **cdk-engineer**