### PR TITLE
Configure API Gateway and CloudFront for recipe routes

### DIFF
--- a/bin/akli-infrastructure.ts
+++ b/bin/akli-infrastructure.ts
@@ -5,6 +5,7 @@ import { CertificateStack } from '../lib/certificate-stack';
 import { PokedexStack } from '../lib/pokedex-stack';
 import { ApiStack } from '../lib/api-stack';
 import { AuthStack } from '../lib/auth-stack';
+import { RecipeStack } from '../lib/recipe-stack';
 
 const app = new cdk.App();
 
@@ -59,6 +60,19 @@ const authStack = new AuthStack(app, 'AuthStack', {
   },
 })
 
+const recipeStack = new RecipeStack(app, 'RecipeStack', {
+  env: { account, region: 'eu-west-2' },
+  description: 'Recipe API backend resources (DynamoDB, S3, Lambda, API Gateway)',
+  userPoolId: authStack.userPoolId,
+  userPoolClientId: authStack.userPoolClientId,
+  userPoolArn: authStack.userPoolArn,
+  tags: {
+    Project: 'recipes',
+    Environment: 'production',
+    ManagedBy: 'cdk',
+  },
+})
+
 new ApiStack(app, 'ApiStack', {
   env: { account, region: 'eu-west-2' },
   crossRegionReferences: true,
@@ -66,6 +80,7 @@ new ApiStack(app, 'ApiStack', {
   hostedZone: certStack.hostedZone,
   pokedexApiUrl: pokedexStack.httpApi.apiEndpoint,
   authApiUrl: authStack.httpApi.apiEndpoint,
+  recipeApiUrl: recipeStack.httpApi.apiEndpoint,
   description: 'Shared API infrastructure for api.akli.dev with CloudFront',
 
   tags: {

--- a/lambda/image-resizer.ts
+++ b/lambda/image-resizer.ts
@@ -1,0 +1,5 @@
+import type { S3Event } from 'aws-lambda'
+
+export async function handler(event: S3Event): Promise<void> {
+  // TODO: implement image resizing
+}

--- a/lambda/recipe-handler.ts
+++ b/lambda/recipe-handler.ts
@@ -1,0 +1,9 @@
+import type { APIGatewayProxyEventV2, APIGatewayProxyStructuredResultV2 } from 'aws-lambda'
+
+export async function handler(event: APIGatewayProxyEventV2): Promise<APIGatewayProxyStructuredResultV2> {
+  return {
+    statusCode: 501,
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ error: 'Not implemented' }),
+  }
+}

--- a/lambda/recipe-image-handler.ts
+++ b/lambda/recipe-image-handler.ts
@@ -1,0 +1,9 @@
+import type { APIGatewayProxyEventV2, APIGatewayProxyStructuredResultV2 } from 'aws-lambda'
+
+export async function handler(event: APIGatewayProxyEventV2): Promise<APIGatewayProxyStructuredResultV2> {
+  return {
+    statusCode: 501,
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ error: 'Not implemented' }),
+  }
+}

--- a/lib/api-stack.ts
+++ b/lib/api-stack.ts
@@ -14,6 +14,7 @@ interface ApiStackProps extends StackProps {
   apiCertificate: certificatemanager.ICertificate
   pokedexApiUrl: string
   authApiUrl: string
+  recipeApiUrl: string
 }
 
 /**
@@ -25,7 +26,7 @@ export class ApiStack extends Stack {
   constructor(scope: Construct, id: string, props: ApiStackProps) {
     super(scope, id, props)
 
-    const { hostedZone, apiCertificate, pokedexApiUrl, authApiUrl } = props
+    const { hostedZone, apiCertificate, pokedexApiUrl, authApiUrl, recipeApiUrl } = props
 
     // Extract the domain from the API Gateway URL (strip "https://")
     const pokedexApiDomain = Fn.select(2, Fn.split('/', pokedexApiUrl))
@@ -38,6 +39,13 @@ export class ApiStack extends Stack {
     const authApiDomain = Fn.select(2, Fn.split('/', authApiUrl))
 
     const authOrigin = new origins.HttpOrigin(authApiDomain, {
+      protocolPolicy: cloudfront.OriginProtocolPolicy.HTTPS_ONLY,
+    })
+
+    // Recipe API origin
+    const recipeApiDomain = Fn.select(2, Fn.split('/', recipeApiUrl))
+
+    const recipeOrigin = new origins.HttpOrigin(recipeApiDomain, {
       protocolPolicy: cloudfront.OriginProtocolPolicy.HTTPS_ONLY,
     })
 
@@ -86,6 +94,14 @@ export class ApiStack extends Stack {
           viewerProtocolPolicy: cloudfront.ViewerProtocolPolicy.REDIRECT_TO_HTTPS,
           cachePolicy: cloudfront.CachePolicy.CACHING_DISABLED,
           // AllViewerExceptHostHeader forwards all viewer headers (including Authorization) except Host
+          originRequestPolicy: cloudfront.OriginRequestPolicy.ALL_VIEWER_EXCEPT_HOST_HEADER,
+          allowedMethods: cloudfront.AllowedMethods.ALLOW_ALL,
+          compress: true,
+        },
+        '/recipes/*': {
+          origin: recipeOrigin,
+          viewerProtocolPolicy: cloudfront.ViewerProtocolPolicy.REDIRECT_TO_HTTPS,
+          cachePolicy: cloudfront.CachePolicy.CACHING_DISABLED,
           originRequestPolicy: cloudfront.OriginRequestPolicy.ALL_VIEWER_EXCEPT_HOST_HEADER,
           allowedMethods: cloudfront.AllowedMethods.ALLOW_ALL,
           compress: true,

--- a/lib/auth-stack.ts
+++ b/lib/auth-stack.ts
@@ -14,6 +14,9 @@ import { applyStackTags } from './utils'
 
 export class AuthStack extends Stack {
   public readonly httpApi: HttpApi
+  public readonly userPoolId: string
+  public readonly userPoolClientId: string
+  public readonly userPoolArn: string
 
   constructor(scope: Construct, id: string, props?: StackProps) {
     super(scope, id, props)
@@ -38,6 +41,9 @@ export class AuthStack extends Stack {
       removalPolicy: RemovalPolicy.RETAIN,
     })
 
+    this.userPoolId = userPool.userPoolId
+    this.userPoolArn = userPool.userPoolArn
+
     // User Pool Client
     const userPoolClient = new cognito.CfnUserPoolClient(this, 'AuthUserPoolClient', {
       userPoolId: userPool.userPoolId,
@@ -50,6 +56,8 @@ export class AuthStack extends Stack {
         refreshToken: 'days',
       },
     })
+
+    this.userPoolClientId = userPoolClient.ref
 
     // Cognito Groups
     new cognito.CfnUserPoolGroup(this, 'AdminGroup', {

--- a/lib/recipe-stack.ts
+++ b/lib/recipe-stack.ts
@@ -1,13 +1,31 @@
 import { Duration, RemovalPolicy, Stack, StackProps } from 'aws-cdk-lib'
 import { Construct } from 'constructs'
+import { CorsHttpMethod, HttpApi } from 'aws-cdk-lib/aws-apigatewayv2'
+import * as apigwv2 from 'aws-cdk-lib/aws-apigatewayv2'
 import * as dynamodb from 'aws-cdk-lib/aws-dynamodb'
+import * as iam from 'aws-cdk-lib/aws-iam'
+import * as lambda from 'aws-cdk-lib/aws-lambda'
+import { NodejsFunction } from 'aws-cdk-lib/aws-lambda-nodejs'
 import * as s3 from 'aws-cdk-lib/aws-s3'
+import * as s3n from 'aws-cdk-lib/aws-s3-notifications'
+import * as path from 'path'
 import { applyStackTags } from './utils'
 
+interface RecipeStackProps extends StackProps {
+  userPoolId: string
+  userPoolClientId: string
+  userPoolArn: string
+}
+
 export class RecipeStack extends Stack {
-  constructor(scope: Construct, id: string, props?: StackProps) {
+  public readonly httpApi: HttpApi
+
+  constructor(scope: Construct, id: string, props: RecipeStackProps) {
     super(scope, id, props)
 
+    const { userPoolId, userPoolClientId, userPoolArn } = props
+
+    // DynamoDB table
     const table = new dynamodb.Table(this, 'RecipesTable', {
       tableName: 'recipes',
       partitionKey: { name: 'id', type: dynamodb.AttributeType.STRING },
@@ -27,7 +45,8 @@ export class RecipeStack extends Stack {
       sortKey: { name: 'createdAt', type: dynamodb.AttributeType.STRING },
     })
 
-    new s3.Bucket(this, 'RecipeImagesBucket', {
+    // S3 image bucket
+    const imageBucket = new s3.Bucket(this, 'RecipeImagesBucket', {
       bucketName: `akli-recipe-images-${this.account}-${this.region}`,
       blockPublicAccess: s3.BlockPublicAccess.BLOCK_ALL,
       encryption: s3.BucketEncryption.S3_MANAGED,
@@ -46,6 +65,193 @@ export class RecipeStack extends Stack {
           allowedHeaders: ['*'],
         },
       ],
+    })
+
+    // HTTP API with CORS
+    this.httpApi = new HttpApi(this, 'RecipeHttpApi', {
+      apiName: 'recipe-api',
+      corsPreflight: {
+        allowOrigins: ['https://akli.dev'],
+        allowMethods: [
+          CorsHttpMethod.GET,
+          CorsHttpMethod.POST,
+          CorsHttpMethod.PUT,
+          CorsHttpMethod.PATCH,
+          CorsHttpMethod.DELETE,
+        ],
+        allowHeaders: ['Content-Type', 'Authorization'],
+      },
+    })
+
+    // Lambda functions
+    const recipeHandler = new NodejsFunction(this, 'RecipeHandler', {
+      runtime: lambda.Runtime.NODEJS_22_X,
+      memorySize: 256,
+      timeout: Duration.seconds(10),
+      entry: path.join(__dirname, '..', 'lambda', 'recipe-handler.ts'),
+      handler: 'handler',
+      functionName: 'akli-recipe-handler',
+      environment: {
+        TABLE_NAME: table.tableName,
+        IMAGE_BUCKET_NAME: imageBucket.bucketName,
+      },
+    })
+
+    table.grantReadWriteData(recipeHandler)
+    imageBucket.grantRead(recipeHandler)
+    imageBucket.grantDelete(recipeHandler)
+
+    const recipeImageHandler = new NodejsFunction(this, 'RecipeImageHandler', {
+      runtime: lambda.Runtime.NODEJS_22_X,
+      memorySize: 256,
+      timeout: Duration.seconds(10),
+      entry: path.join(__dirname, '..', 'lambda', 'recipe-image-handler.ts'),
+      handler: 'handler',
+      functionName: 'akli-recipe-image-handler',
+      environment: {
+        IMAGE_BUCKET_NAME: imageBucket.bucketName,
+      },
+    })
+
+    imageBucket.grantPut(recipeImageHandler)
+
+    const imageResizer = new NodejsFunction(this, 'ImageResizer', {
+      runtime: lambda.Runtime.NODEJS_22_X,
+      memorySize: 512,
+      timeout: Duration.seconds(30),
+      entry: path.join(__dirname, '..', 'lambda', 'image-resizer.ts'),
+      handler: 'handler',
+      functionName: 'akli-image-resizer',
+      environment: {
+        IMAGE_BUCKET_NAME: imageBucket.bucketName,
+      },
+    })
+
+    imageBucket.grantReadWrite(imageResizer)
+    imageBucket.grantDelete(imageResizer)
+
+    // S3 event notification for image uploads
+    imageBucket.addEventNotification(
+      s3.EventType.OBJECT_CREATED,
+      new s3n.LambdaDestination(imageResizer),
+      { prefix: 'uploads/' },
+    )
+
+    // JWT Authoriser — IdentitySource must be an array for CFN early validation
+    const jwtAuthorizer = new apigwv2.CfnAuthorizer(this, 'JwtAuthorizer', {
+      apiId: this.httpApi.httpApiId,
+      authorizerType: 'JWT',
+      identitySource: ['$request.header.Authorization'],
+      name: 'cognito-jwt',
+      jwtConfiguration: {
+        issuer: `https://cognito-idp.${this.region}.amazonaws.com/${userPoolId}`,
+        audience: [userPoolClientId],
+      },
+    })
+
+    // API Gateway Integrations
+    const recipeIntegration = new apigwv2.CfnIntegration(this, 'RecipeHandlerIntegration', {
+      apiId: this.httpApi.httpApiId,
+      integrationType: 'AWS_PROXY',
+      integrationUri: recipeHandler.functionArn,
+      payloadFormatVersion: '2.0',
+    })
+
+    const recipeImageIntegration = new apigwv2.CfnIntegration(this, 'RecipeImageHandlerIntegration', {
+      apiId: this.httpApi.httpApiId,
+      integrationType: 'AWS_PROXY',
+      integrationUri: recipeImageHandler.functionArn,
+      payloadFormatVersion: '2.0',
+    })
+
+    // Grant API Gateway invoke permissions
+    recipeHandler.addPermission('ApiGatewayInvoke', {
+      principal: new iam.ServicePrincipal('apigateway.amazonaws.com'),
+      sourceArn: `arn:aws:execute-api:${this.region}:${this.account}:${this.httpApi.httpApiId}/*/*`,
+    })
+
+    recipeImageHandler.addPermission('ApiGatewayInvoke', {
+      principal: new iam.ServicePrincipal('apigateway.amazonaws.com'),
+      sourceArn: `arn:aws:execute-api:${this.region}:${this.account}:${this.httpApi.httpApiId}/*/*`,
+    })
+
+    // Public Routes (AuthorizationType: NONE)
+    new apigwv2.CfnRoute(this, 'GetRecipesRoute', {
+      apiId: this.httpApi.httpApiId,
+      routeKey: 'GET /recipes',
+      target: `integrations/${recipeIntegration.ref}`,
+      authorizationType: 'NONE',
+    })
+
+    new apigwv2.CfnRoute(this, 'GetRecipeBySlugRoute', {
+      apiId: this.httpApi.httpApiId,
+      routeKey: 'GET /recipes/{slug}',
+      target: `integrations/${recipeIntegration.ref}`,
+      authorizationType: 'NONE',
+    })
+
+    new apigwv2.CfnRoute(this, 'GetRecipeTagsRoute', {
+      apiId: this.httpApi.httpApiId,
+      routeKey: 'GET /recipes/tags',
+      target: `integrations/${recipeIntegration.ref}`,
+      authorizationType: 'NONE',
+    })
+
+    // Protected Routes (AuthorizationType: JWT)
+    new apigwv2.CfnRoute(this, 'GetMyRecipesRoute', {
+      apiId: this.httpApi.httpApiId,
+      routeKey: 'GET /me/recipes',
+      target: `integrations/${recipeIntegration.ref}`,
+      authorizationType: 'JWT',
+      authorizerId: jwtAuthorizer.ref,
+    })
+
+    new apigwv2.CfnRoute(this, 'CreateRecipeRoute', {
+      apiId: this.httpApi.httpApiId,
+      routeKey: 'POST /recipes',
+      target: `integrations/${recipeIntegration.ref}`,
+      authorizationType: 'JWT',
+      authorizerId: jwtAuthorizer.ref,
+    })
+
+    new apigwv2.CfnRoute(this, 'UpdateRecipeRoute', {
+      apiId: this.httpApi.httpApiId,
+      routeKey: 'PUT /recipes/{id}',
+      target: `integrations/${recipeIntegration.ref}`,
+      authorizationType: 'JWT',
+      authorizerId: jwtAuthorizer.ref,
+    })
+
+    new apigwv2.CfnRoute(this, 'PublishRecipeRoute', {
+      apiId: this.httpApi.httpApiId,
+      routeKey: 'PATCH /recipes/{id}/publish',
+      target: `integrations/${recipeIntegration.ref}`,
+      authorizationType: 'JWT',
+      authorizerId: jwtAuthorizer.ref,
+    })
+
+    new apigwv2.CfnRoute(this, 'UnpublishRecipeRoute', {
+      apiId: this.httpApi.httpApiId,
+      routeKey: 'PATCH /recipes/{id}/unpublish',
+      target: `integrations/${recipeIntegration.ref}`,
+      authorizationType: 'JWT',
+      authorizerId: jwtAuthorizer.ref,
+    })
+
+    new apigwv2.CfnRoute(this, 'DeleteRecipeRoute', {
+      apiId: this.httpApi.httpApiId,
+      routeKey: 'DELETE /recipes/{id}',
+      target: `integrations/${recipeIntegration.ref}`,
+      authorizationType: 'JWT',
+      authorizerId: jwtAuthorizer.ref,
+    })
+
+    new apigwv2.CfnRoute(this, 'UploadImageUrlRoute', {
+      apiId: this.httpApi.httpApiId,
+      routeKey: 'POST /recipes/images/upload-url',
+      target: `integrations/${recipeImageIntegration.ref}`,
+      authorizationType: 'JWT',
+      authorizerId: jwtAuthorizer.ref,
     })
 
     applyStackTags(this, props)

--- a/lib/recipe-stack.ts
+++ b/lib/recipe-stack.ts
@@ -31,6 +31,7 @@ export class RecipeStack extends Stack {
       partitionKey: { name: 'id', type: dynamodb.AttributeType.STRING },
       billingMode: dynamodb.BillingMode.PAY_PER_REQUEST,
       pointInTimeRecoverySpecification: { pointInTimeRecoveryEnabled: true },
+      removalPolicy: RemovalPolicy.RETAIN,
     })
 
     table.addGlobalSecondaryIndex({

--- a/test/api-stack.test.ts
+++ b/test/api-stack.test.ts
@@ -30,6 +30,7 @@ function createTestStack(): Template {
     apiCertificate,
     pokedexApiUrl: 'https://abc123.execute-api.eu-west-2.amazonaws.com',
     authApiUrl: 'https://xyz789.execute-api.eu-west-2.amazonaws.com',
+    recipeApiUrl: 'https://recipe123.execute-api.eu-west-2.amazonaws.com',
     tags: {
       Project: 'akli-api',
       Environment: 'production',
@@ -162,6 +163,68 @@ describe('ApiStack', () => {
           CacheBehaviors: Match.arrayWith([
             Match.objectLike({
               PathPattern: '/auth/*',
+              OriginRequestPolicyId: Match.anyValue(),
+            }),
+          ]),
+        }),
+      })
+    })
+
+    it('has the recipe API Gateway as an origin', () => {
+      template.hasResourceProperties('AWS::CloudFront::Distribution', {
+        DistributionConfig: Match.objectLike({
+          Origins: Match.arrayWith([
+            Match.objectLike({
+              DomainName: 'recipe123.execute-api.eu-west-2.amazonaws.com',
+              CustomOriginConfig: Match.objectLike({
+                OriginProtocolPolicy: 'https-only',
+              }),
+            }),
+          ]),
+        }),
+      })
+    })
+
+    it('has a /recipes/* cache behaviour with caching disabled', () => {
+      template.hasResourceProperties('AWS::CloudFront::Distribution', {
+        DistributionConfig: Match.objectLike({
+          CacheBehaviors: Match.arrayWith([
+            Match.objectLike({
+              PathPattern: '/recipes/*',
+              CachePolicyId: '4135ea2d-6df8-44a3-9df3-4b5a84be39ad',
+            }),
+          ]),
+        }),
+      })
+    })
+
+    it('has a /recipes/* cache behaviour with AllowedMethods.ALLOW_ALL', () => {
+      template.hasResourceProperties('AWS::CloudFront::Distribution', {
+        DistributionConfig: Match.objectLike({
+          CacheBehaviors: Match.arrayWith([
+            Match.objectLike({
+              PathPattern: '/recipes/*',
+              AllowedMethods: [
+                'GET',
+                'HEAD',
+                'OPTIONS',
+                'PUT',
+                'PATCH',
+                'POST',
+                'DELETE',
+              ],
+            }),
+          ]),
+        }),
+      })
+    })
+
+    it('has a /recipes/* cache behaviour that forwards Authorization header', () => {
+      template.hasResourceProperties('AWS::CloudFront::Distribution', {
+        DistributionConfig: Match.objectLike({
+          CacheBehaviors: Match.arrayWith([
+            Match.objectLike({
+              PathPattern: '/recipes/*',
               OriginRequestPolicyId: Match.anyValue(),
             }),
           ]),

--- a/test/recipe-stack.test.ts
+++ b/test/recipe-stack.test.ts
@@ -10,6 +10,9 @@ function createTestStack(): Template {
 
   const stack = new RecipeStack(app, 'TestRecipeStack', {
     env: { account: '123456789012', region: 'eu-west-2' },
+    userPoolId: 'eu-west-2_TestPool123',
+    userPoolClientId: 'test-client-id-abc',
+    userPoolArn: 'arn:aws:cognito-idp:eu-west-2:123456789012:userpool/eu-west-2_TestPool123',
     tags: {
       Project: 'recipes',
       Environment: 'production',
@@ -191,6 +194,130 @@ describe('RecipeStack', () => {
             }),
           ]),
         },
+      })
+    })
+  })
+
+  describe('HTTP API Gateway', () => {
+    it('creates an HTTP API (ApiGatewayV2)', () => {
+      template.hasResourceProperties('AWS::ApiGatewayV2::Api', {
+        ProtocolType: 'HTTP',
+      })
+    })
+  })
+
+  describe('CORS', () => {
+    it('configures CORS to allow https://akli.dev', () => {
+      template.hasResourceProperties('AWS::ApiGatewayV2::Api', {
+        CorsConfiguration: Match.objectLike({
+          AllowOrigins: Match.arrayWith(['https://akli.dev']),
+        }),
+      })
+    })
+
+    it('allows GET, POST, PUT, PATCH, and DELETE methods', () => {
+      template.hasResourceProperties('AWS::ApiGatewayV2::Api', {
+        CorsConfiguration: Match.objectLike({
+          AllowMethods: Match.arrayWith(['GET', 'POST', 'PUT', 'PATCH', 'DELETE']),
+        }),
+      })
+    })
+
+    it('allows Content-Type and Authorization headers', () => {
+      template.hasResourceProperties('AWS::ApiGatewayV2::Api', {
+        CorsConfiguration: Match.objectLike({
+          AllowHeaders: Match.arrayWith(['Content-Type', 'Authorization']),
+        }),
+      })
+    })
+  })
+
+  describe('Routes', () => {
+    it('has a GET /recipes route (public)', () => {
+      template.hasResourceProperties('AWS::ApiGatewayV2::Route', {
+        RouteKey: 'GET /recipes',
+        AuthorizationType: 'NONE',
+      })
+    })
+
+    it('has a GET /recipes/{slug} route (public)', () => {
+      template.hasResourceProperties('AWS::ApiGatewayV2::Route', {
+        RouteKey: 'GET /recipes/{slug}',
+        AuthorizationType: 'NONE',
+      })
+    })
+
+    it('has a GET /recipes/tags route (public)', () => {
+      template.hasResourceProperties('AWS::ApiGatewayV2::Route', {
+        RouteKey: 'GET /recipes/tags',
+        AuthorizationType: 'NONE',
+      })
+    })
+
+    it('has a GET /me/recipes route (protected)', () => {
+      template.hasResourceProperties('AWS::ApiGatewayV2::Route', {
+        RouteKey: 'GET /me/recipes',
+        AuthorizationType: 'JWT',
+      })
+    })
+
+    it('has a POST /recipes route (protected)', () => {
+      template.hasResourceProperties('AWS::ApiGatewayV2::Route', {
+        RouteKey: 'POST /recipes',
+        AuthorizationType: 'JWT',
+      })
+    })
+
+    it('has a PUT /recipes/{id} route (protected)', () => {
+      template.hasResourceProperties('AWS::ApiGatewayV2::Route', {
+        RouteKey: 'PUT /recipes/{id}',
+        AuthorizationType: 'JWT',
+      })
+    })
+
+    it('has a PATCH /recipes/{id}/publish route (protected)', () => {
+      template.hasResourceProperties('AWS::ApiGatewayV2::Route', {
+        RouteKey: 'PATCH /recipes/{id}/publish',
+        AuthorizationType: 'JWT',
+      })
+    })
+
+    it('has a PATCH /recipes/{id}/unpublish route (protected)', () => {
+      template.hasResourceProperties('AWS::ApiGatewayV2::Route', {
+        RouteKey: 'PATCH /recipes/{id}/unpublish',
+        AuthorizationType: 'JWT',
+      })
+    })
+
+    it('has a DELETE /recipes/{id} route (protected)', () => {
+      template.hasResourceProperties('AWS::ApiGatewayV2::Route', {
+        RouteKey: 'DELETE /recipes/{id}',
+        AuthorizationType: 'JWT',
+      })
+    })
+
+    it('has a POST /recipes/images/upload-url route (protected)', () => {
+      template.hasResourceProperties('AWS::ApiGatewayV2::Route', {
+        RouteKey: 'POST /recipes/images/upload-url',
+        AuthorizationType: 'JWT',
+      })
+    })
+  })
+
+  describe('JWT Authoriser', () => {
+    it('creates a JWT authoriser', () => {
+      template.hasResourceProperties('AWS::ApiGatewayV2::Authorizer', {
+        AuthorizerType: 'JWT',
+        IdentitySource: Match.arrayWith(['$request.header.Authorization']),
+      })
+    })
+
+    it('configures the JWT authoriser with Issuer and Audience', () => {
+      template.hasResourceProperties('AWS::ApiGatewayV2::Authorizer', {
+        JwtConfiguration: Match.objectLike({
+          Issuer: Match.anyValue(),
+          Audience: Match.anyValue(),
+        }),
       })
     })
   })


### PR DESCRIPTION
Closes #52

## What changed
- **RecipeStack**: Added HTTP API with CORS (GET/POST/PUT/PATCH/DELETE), JWT authoriser using AuthStack Cognito props, 10 routes (3 public, 7 protected), 3 Lambda stubs (recipe-handler, recipe-image-handler, image-resizer), S3 event notification for uploads/ prefix triggering the resizer
- **ApiStack**: Added `recipeApiUrl` prop and `/recipes/*` CloudFront behaviour with caching disabled, ALLOW_ALL, ALL_VIEWER_EXCEPT_HOST_HEADER
- **AuthStack**: Exposed `userPoolId`, `userPoolClientId`, `userPoolArn` as public properties for cross-stack references
- **bin/akli-infrastructure.ts**: Wired RecipeStack between AuthStack and ApiStack
- **Simplify fix**: Added RemovalPolicy.RETAIN on DynamoDB recipes table

## Why
Recipe API needs HTTP API Gateway routes with JWT protection, CloudFront distribution integration, and Lambda integration targets for the CRUD handlers (implemented in later issues).

## How to verify
- `pnpm test -- recipe-stack` — 35/35 tests pass
- `pnpm test -- api-stack` — 22/22 tests pass

## Decisions made
- Used same L1 CfnRoute/CfnIntegration/CfnAuthorizer pattern as AuthStack for consistency
- Lambda stubs return 501 — actual handlers implemented in issues #53-#56
- Image resizer gets 512MB memory per PRD (image processing needs more than 256MB)
- S3 event filtered to `uploads/` prefix to prevent self-triggering
- Agents: **test-engineer** (Write) + **cdk-engineer**