### PR TITLE
Implement tags endpoint

### DIFF
--- a/lambda/recipe-handler.ts
+++ b/lambda/recipe-handler.ts
@@ -130,6 +130,8 @@ function lightweightRecipe(recipe: Record<string, unknown>): Record<string, unkn
 export async function handler(event: APIGatewayProxyEventV2): Promise<APIGatewayProxyStructuredResultV2> {
   try {
     switch (event.routeKey) {
+      case 'GET /recipes/tags':
+        return await handleListTags()
       case 'GET /recipes':
         return await handleListPublished()
       case 'GET /recipes/{slug}':
@@ -152,6 +154,32 @@ export async function handler(event: APIGatewayProxyEventV2): Promise<APIGateway
   } catch {
     return json(500, { error: 'Internal server error' })
   }
+}
+
+async function handleListTags(): Promise<APIGatewayProxyStructuredResultV2> {
+  const result = await docClient.send(
+    new ScanCommand({
+      TableName: TABLE_NAME,
+      FilterExpression: '#status = :status',
+      ExpressionAttributeNames: { '#status': 'status' },
+      ExpressionAttributeValues: { ':status': 'published' },
+      ProjectionExpression: 'tags',
+    }),
+  )
+
+  const countMap: Record<string, number> = {}
+  for (const item of result.Items ?? []) {
+    const tags = tagsToArray(item.tags)
+    for (const tag of tags) {
+      countMap[tag] = (countMap[tag] ?? 0) + 1
+    }
+  }
+
+  const sorted = Object.entries(countMap)
+    .map(([tag, count]) => ({ tag, count }))
+    .sort((a, b) => a.tag.localeCompare(b.tag))
+
+  return json(200, sorted)
 }
 
 async function handleListPublished(): Promise<APIGatewayProxyStructuredResultV2> {

--- a/test/lambda/recipe-handler.test.ts
+++ b/test/lambda/recipe-handler.test.ts
@@ -730,6 +730,100 @@ describe('Recipe Lambda handler', () => {
     })
   })
 
+  // ─── GET /recipes/tags — public tag aggregation ─────────────────────
+  describe('GET /recipes/tags — list tags with counts', () => {
+    it('returns 200 with tags sorted alphabetically with counts', async () => {
+      ddbMock.on(ScanCommand).resolves({
+        Items: [
+          { tags: { wrapperName: 'Set', values: ['Italian', 'Slow Cook'], type: 'String' }, status: 'published' },
+          { tags: { wrapperName: 'Set', values: ['Italian', 'Vegetarian'], type: 'String' }, status: 'published' },
+        ],
+      })
+
+      const event = makeEvent({
+        routeKey: 'GET /recipes/tags',
+        rawPath: '/recipes/tags',
+      })
+
+      const result = await handler(event)
+
+      expect(result.statusCode).toBe(200)
+      const body = JSON.parse(result.body as string)
+      expect(Array.isArray(body)).toBe(true)
+      expect(body).toEqual([
+        { tag: 'Italian', count: 2 },
+        { tag: 'Slow Cook', count: 1 },
+        { tag: 'Vegetarian', count: 1 },
+      ])
+    })
+
+    it('aggregates tag counts across multiple published recipes', async () => {
+      ddbMock.on(ScanCommand).resolves({
+        Items: [
+          { tags: { wrapperName: 'Set', values: ['Italian', 'Pasta'], type: 'String' }, status: 'published' },
+          { tags: { wrapperName: 'Set', values: ['Italian', 'Slow Cook'], type: 'String' }, status: 'published' },
+          { tags: { wrapperName: 'Set', values: ['Italian', 'Pasta', 'Vegetarian'], type: 'String' }, status: 'published' },
+        ],
+      })
+
+      const event = makeEvent({
+        routeKey: 'GET /recipes/tags',
+        rawPath: '/recipes/tags',
+      })
+
+      const result = await handler(event)
+
+      expect(result.statusCode).toBe(200)
+      const body = JSON.parse(result.body as string)
+      // Italian appears in all 3 recipes
+      expect(body.find((t: { tag: string }) => t.tag === 'Italian')).toEqual({ tag: 'Italian', count: 3 })
+      // Pasta appears in 2 recipes
+      expect(body.find((t: { tag: string }) => t.tag === 'Pasta')).toEqual({ tag: 'Pasta', count: 2 })
+      // Slow Cook and Vegetarian appear in 1 recipe each
+      expect(body.find((t: { tag: string }) => t.tag === 'Slow Cook')).toEqual({ tag: 'Slow Cook', count: 1 })
+      expect(body.find((t: { tag: string }) => t.tag === 'Vegetarian')).toEqual({ tag: 'Vegetarian', count: 1 })
+    })
+
+    it('excludes tags from draft recipes', async () => {
+      // The ScanCommand should filter on status = 'published', so drafts should not appear
+      ddbMock.on(ScanCommand).resolves({
+        Items: [
+          { tags: { wrapperName: 'Set', values: ['Italian'], type: 'String' }, status: 'published' },
+        ],
+      })
+
+      const event = makeEvent({
+        routeKey: 'GET /recipes/tags',
+        rawPath: '/recipes/tags',
+      })
+
+      const result = await handler(event)
+
+      expect(result.statusCode).toBe(200)
+      const body = JSON.parse(result.body as string)
+      expect(body).toEqual([{ tag: 'Italian', count: 1 }])
+      // Draft tags must not be included — the scan should only return published recipes
+    })
+
+    it('returns empty array when no published recipes exist', async () => {
+      ddbMock.on(ScanCommand).resolves({
+        Items: [],
+      })
+
+      const event = makeEvent({
+        routeKey: 'GET /recipes/tags',
+        rawPath: '/recipes/tags',
+      })
+
+      const result = await handler(event)
+
+      expect(result.statusCode).toBe(200)
+      const body = JSON.parse(result.body as string)
+      expect(Array.isArray(body)).toBe(true)
+      expect(body).toEqual([])
+    })
+  })
+
   // ─── Unknown route ──────────────────────────────────────────────────
   describe('Unknown route', () => {
     it('returns 404 for unmatched route', async () => {


### PR DESCRIPTION
Closes #54

## What changed
Added `GET /recipes/tags` route to the recipe handler. Scans published recipes for tags, aggregates counts, and returns sorted alphabetically as `[{ tag, count }]`.

## Why
Frontend needs tag data for autocomplete and filtering on the recipe listing page.

## How to verify
- `pnpm test -- test/lambda/recipe-handler` — 36/36 tests pass

## Decisions made
- Scan with ProjectionExpression for `tags` only (minimises read units)
- Filters for published recipes only (drafts excluded from tag counts)
- Reuses existing `tagsToArray` helper for DynamoDB StringSet conversion
- Agents: **test-engineer** (Write) + **backend-engineer**