### PR TITLE
Implement presigned image upload handler

### DIFF
--- a/lambda/recipe-image-handler.ts
+++ b/lambda/recipe-image-handler.ts
@@ -1,9 +1,65 @@
 import type { APIGatewayProxyEventV2, APIGatewayProxyStructuredResultV2 } from 'aws-lambda'
+import { S3Client, PutObjectCommand } from '@aws-sdk/client-s3'
+import { getSignedUrl } from '@aws-sdk/s3-request-presigner'
+
+const s3 = new S3Client({})
+const IMAGE_BUCKET_NAME = process.env.IMAGE_BUCKET_NAME ?? ''
+
+function json(statusCode: number, body: Record<string, unknown>): APIGatewayProxyStructuredResultV2 {
+  return { statusCode, headers: { 'Content-Type': 'application/json' }, body: JSON.stringify(body) }
+}
+
+function decodeToken(event: APIGatewayProxyEventV2): Record<string, unknown> | undefined {
+  const authHeader = event.headers.authorization
+  if (!authHeader) return undefined
+
+  const token = authHeader.replace(/^bearer\s+/i, '')
+  if (!token) return undefined
+
+  try {
+    const parts = token.split('.')
+    if (parts.length < 2) return undefined
+    return JSON.parse(Buffer.from(parts[1], 'base64url').toString()) as Record<string, unknown>
+  } catch {
+    return undefined
+  }
+}
+
+interface UploadUrlBody {
+  readonly recipeId?: string
+  readonly imageType?: string
+  readonly stepOrder?: number
+}
 
 export async function handler(event: APIGatewayProxyEventV2): Promise<APIGatewayProxyStructuredResultV2> {
-  return {
-    statusCode: 501,
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ error: 'Not implemented' }),
+  try {
+    switch (event.routeKey) {
+      case 'POST /recipes/images/upload-url':
+        return await handleUploadUrl(event)
+      default:
+        return json(404, { error: 'Not found' })
+    }
+  } catch {
+    return json(500, { error: 'Internal server error' })
   }
+}
+
+async function handleUploadUrl(event: APIGatewayProxyEventV2): Promise<APIGatewayProxyStructuredResultV2> {
+  const payload = decodeToken(event)
+  if (!payload) return json(401, { error: 'Unauthorised' })
+
+  const { recipeId, imageType, stepOrder } = JSON.parse(event.body ?? '{}') as UploadUrlBody
+  if (!recipeId || !imageType) return json(400, { error: 'recipeId and imageType are required' })
+
+  const key = imageType === 'cover'
+    ? `uploads/recipes/${recipeId}/cover`
+    : `uploads/recipes/${recipeId}/step-${stepOrder}`
+
+  const uploadUrl = await getSignedUrl(
+    s3,
+    new PutObjectCommand({ Bucket: IMAGE_BUCKET_NAME, Key: key }),
+    { expiresIn: 900 },
+  )
+
+  return json(200, { uploadUrl, key })
 }

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "@aws-sdk/client-dynamodb": "^3.1027.0",
     "@aws-sdk/client-s3": "^3.1027.0",
     "@aws-sdk/lib-dynamodb": "^3.1027.0",
+    "@aws-sdk/s3-request-presigner": "^3.1028.0",
     "@aws-sdk/util-dynamodb": "^3.996.2",
     "@types/aws-lambda": "^8.10.161",
     "@types/jest": "^29.5.14",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -30,6 +30,9 @@ importers:
       '@aws-sdk/lib-dynamodb':
         specifier: ^3.1027.0
         version: 3.1027.0(@aws-sdk/client-dynamodb@3.1027.0)
+      '@aws-sdk/s3-request-presigner':
+        specifier: ^3.1028.0
+        version: 3.1028.0
       '@aws-sdk/util-dynamodb':
         specifier: ^3.996.2
         version: 3.996.2(@aws-sdk/client-dynamodb@3.1027.0)
@@ -228,6 +231,10 @@ packages:
     resolution: {integrity: sha512-6Q8B1dcx6BBqUTY1Mc/eROKA0FImEEY5VPSd6AGPEUf0ErjExz4snVqa9kNJSoVDV1rKaNf3qrWojgcKW+SdDg==}
     engines: {node: '>=20.0.0'}
 
+  '@aws-sdk/s3-request-presigner@3.1028.0':
+    resolution: {integrity: sha512-T46EyIIHUaF/I2zhjtSUO4/87QdhqobClCscJawrxe2h/8nZJoO3DQDVZ4tMDl5UV/B5SPz6+xwki8jGylTF4Q==}
+    engines: {node: '>=20.0.0'}
+
   '@aws-sdk/signature-v4-multi-region@3.996.16':
     resolution: {integrity: sha512-EMdXYB4r/k5RWq86fugjRhid5JA+Z6MpS7n4sij4u5/C+STrkvuf9aFu41rJA9MjUzxCLzv8U2XL8cH2GSRYpQ==}
     engines: {node: '>=20.0.0'}
@@ -252,6 +259,10 @@ packages:
 
   '@aws-sdk/util-endpoints@3.996.6':
     resolution: {integrity: sha512-2nUQ+2ih7CShuKHpGSIYvvAIOHy52dOZguYG36zptBukhw6iFwcvGfG0tes0oZFWQqEWvgZe9HLWaNlvXGdOrg==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/util-format-url@3.972.9':
+    resolution: {integrity: sha512-fNJXHrs0ZT7Wx0KGIqKv7zLxlDXt2vqjx9z6oKUQFmpE5o4xxnSryvVHfHpIifYHWKz94hFccIldJ0YSZjlCBw==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/util-locate-window@3.965.5':
@@ -2513,6 +2524,17 @@ snapshots:
       '@smithy/types': 4.14.0
       tslib: 2.8.1
 
+  '@aws-sdk/s3-request-presigner@3.1028.0':
+    dependencies:
+      '@aws-sdk/signature-v4-multi-region': 3.996.16
+      '@aws-sdk/types': 3.973.7
+      '@aws-sdk/util-format-url': 3.972.9
+      '@smithy/middleware-endpoint': 4.4.29
+      '@smithy/protocol-http': 5.3.13
+      '@smithy/smithy-client': 4.12.9
+      '@smithy/types': 4.14.0
+      tslib: 2.8.1
+
   '@aws-sdk/signature-v4-multi-region@3.996.16':
     dependencies:
       '@aws-sdk/middleware-sdk-s3': 3.972.28
@@ -2554,6 +2576,13 @@ snapshots:
       '@smithy/types': 4.14.0
       '@smithy/url-parser': 4.2.13
       '@smithy/util-endpoints': 3.3.4
+      tslib: 2.8.1
+
+  '@aws-sdk/util-format-url@3.972.9':
+    dependencies:
+      '@aws-sdk/types': 3.973.7
+      '@smithy/querystring-builder': 4.2.13
+      '@smithy/types': 4.14.0
       tslib: 2.8.1
 
   '@aws-sdk/util-locate-window@3.965.5':

--- a/test/lambda/recipe-image-handler.test.ts
+++ b/test/lambda/recipe-image-handler.test.ts
@@ -1,0 +1,182 @@
+import type { APIGatewayProxyEventV2 } from 'aws-lambda'
+import { S3Client } from '@aws-sdk/client-s3'
+import { mockClient } from 'aws-sdk-client-mock'
+
+// Mock getSignedUrl before importing the handler
+jest.mock('@aws-sdk/s3-request-presigner', () => ({
+  getSignedUrl: jest.fn().mockResolvedValue('https://mock-presigned-url.s3.amazonaws.com/test'),
+}))
+
+const s3Mock = mockClient(S3Client)
+
+// Set environment variables before importing handler
+process.env.IMAGE_BUCKET_NAME = 'test-recipe-images-bucket'
+
+// Import handler after mock setup
+import { handler } from '../../lambda/recipe-image-handler'
+import { getSignedUrl } from '@aws-sdk/s3-request-presigner'
+
+// Build a fake JWT with the given payload (header.payload.signature)
+function fakeJwt(payload: Record<string, unknown>): string {
+  const header = Buffer.from(JSON.stringify({ alg: 'RS256', typ: 'JWT' })).toString('base64url')
+  const body = Buffer.from(JSON.stringify(payload)).toString('base64url')
+  const signature = 'fake-signature'
+  return `${header}.${body}.${signature}`
+}
+
+const contributorToken = fakeJwt({ 'cognito:groups': ['contributor'], sub: 'contributor-user-id', email: 'contributor@example.com', name: 'Test Contributor' })
+
+function makeEvent(overrides: Partial<APIGatewayProxyEventV2> = {}): APIGatewayProxyEventV2 {
+  return {
+    version: '2.0',
+    routeKey: 'POST /recipes/images/upload-url',
+    rawPath: '/recipes/images/upload-url',
+    rawQueryString: '',
+    headers: {},
+    requestContext: {
+      accountId: '123456789012',
+      apiId: 'test-api',
+      domainName: 'test.execute-api.eu-west-2.amazonaws.com',
+      domainPrefix: 'test',
+      http: {
+        method: 'POST',
+        path: '/recipes/images/upload-url',
+        protocol: 'HTTP/1.1',
+        sourceIp: '127.0.0.1',
+        userAgent: 'test',
+      },
+      requestId: 'test-request-id',
+      routeKey: 'POST /recipes/images/upload-url',
+      stage: '$default',
+      time: '01/Jan/2026:00:00:00 +0000',
+      timeEpoch: 0,
+    },
+    isBase64Encoded: false,
+    ...overrides,
+  } as APIGatewayProxyEventV2
+}
+
+describe('Recipe Image handler', () => {
+  beforeEach(() => {
+    s3Mock.reset()
+    ;(getSignedUrl as jest.Mock).mockClear()
+    ;(getSignedUrl as jest.Mock).mockResolvedValue('https://mock-presigned-url.s3.amazonaws.com/test')
+  })
+
+  // ─── POST /recipes/images/upload-url — presigned URL generation ────
+  describe('POST /recipes/images/upload-url — presigned URL generation', () => {
+    it('returns 200 with uploadUrl and key', async () => {
+      const event = makeEvent({
+        headers: { authorization: `Bearer ${contributorToken}` },
+        body: JSON.stringify({ recipeId: 'abc', imageType: 'cover' }),
+      })
+
+      const result = await handler(event)
+
+      expect(result.statusCode).toBe(200)
+      const body = JSON.parse(result.body as string)
+      expect(typeof body.uploadUrl).toBe('string')
+      expect(typeof body.key).toBe('string')
+      expect(body.key).toMatch(/^uploads\/recipes\/[^/]+\//)
+    })
+
+    it('generates correct S3 key for cover image', async () => {
+      const event = makeEvent({
+        headers: { authorization: `Bearer ${contributorToken}` },
+        body: JSON.stringify({ recipeId: 'abc', imageType: 'cover' }),
+      })
+
+      const result = await handler(event)
+
+      expect(result.statusCode).toBe(200)
+      const body = JSON.parse(result.body as string)
+      expect(body.key).toBe('uploads/recipes/abc/cover')
+    })
+
+    it('generates correct S3 key for step image', async () => {
+      const event = makeEvent({
+        headers: { authorization: `Bearer ${contributorToken}` },
+        body: JSON.stringify({ recipeId: 'abc', imageType: 'step', stepOrder: 3 }),
+      })
+
+      const result = await handler(event)
+
+      expect(result.statusCode).toBe(200)
+      const body = JSON.parse(result.body as string)
+      expect(body.key).toBe('uploads/recipes/abc/step-3')
+    })
+
+    it('returns 401 without bearer token', async () => {
+      const event = makeEvent({
+        headers: {},
+        body: JSON.stringify({ recipeId: 'abc', imageType: 'cover' }),
+      })
+
+      const result = await handler(event)
+
+      expect(result.statusCode).toBe(401)
+      const body = JSON.parse(result.body as string)
+      expect(body).toHaveProperty('error')
+    })
+
+    it('returns 400 for missing recipeId', async () => {
+      const event = makeEvent({
+        headers: { authorization: `Bearer ${contributorToken}` },
+        body: JSON.stringify({ imageType: 'cover' }),
+      })
+
+      const result = await handler(event)
+
+      expect(result.statusCode).toBe(400)
+      const body = JSON.parse(result.body as string)
+      expect(body).toHaveProperty('error')
+    })
+
+    it('returns 400 for missing imageType', async () => {
+      const event = makeEvent({
+        headers: { authorization: `Bearer ${contributorToken}` },
+        body: JSON.stringify({ recipeId: 'abc' }),
+      })
+
+      const result = await handler(event)
+
+      expect(result.statusCode).toBe(400)
+      const body = JSON.parse(result.body as string)
+      expect(body).toHaveProperty('error')
+    })
+  })
+
+  // ─── Unknown route ──────────────────────────────────────────────────
+  describe('Unknown route', () => {
+    it('returns 404 for unmatched route', async () => {
+      const event = makeEvent({
+        routeKey: 'GET /unknown',
+        rawPath: '/unknown',
+        requestContext: {
+          accountId: '123456789012',
+          apiId: 'test-api',
+          domainName: 'test.execute-api.eu-west-2.amazonaws.com',
+          domainPrefix: 'test',
+          http: {
+            method: 'GET',
+            path: '/unknown',
+            protocol: 'HTTP/1.1',
+            sourceIp: '127.0.0.1',
+            userAgent: 'test',
+          },
+          requestId: 'test-request-id',
+          routeKey: 'GET /unknown',
+          stage: '$default',
+          time: '01/Jan/2026:00:00:00 +0000',
+          timeEpoch: 0,
+        },
+      })
+
+      const result = await handler(event)
+
+      expect(result.statusCode).toBe(404)
+      const body = JSON.parse(result.body as string)
+      expect(body).toHaveProperty('error')
+    })
+  })
+})


### PR DESCRIPTION
Closes #55

## What changed
Implemented `lambda/recipe-image-handler.ts` with the `POST /recipes/images/upload-url` route:
- Generates presigned S3 PUT URLs with 15-minute expiry
- S3 key format: `uploads/recipes/{recipeId}/cover` or `uploads/recipes/{recipeId}/step-{stepOrder}`
- JWT auth check, input validation for recipeId and imageType

## Why
Frontend needs presigned URLs to upload recipe images directly to S3 from the browser.

## How to verify
- `pnpm test -- test/lambda/recipe-image-handler` — 7/7 tests pass

## Decisions made
- Key prefix `uploads/` triggers the image resizer Lambda via S3 event (set up in #52)
- 15-minute expiry per PRD
- Agents: **test-engineer** (Write) + **backend-engineer**