### PR TITLE
Recipe API & Infrastructure

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,13 +14,14 @@ Before implementing any new feature, check `docs/prds/` for a relevant PRD. If o
 
 ## Architecture
 
-Five stacks deployed across regions:
+Six stacks deployed across regions:
 
 - **CertificateStack** (us-east-1): Route 53 hosted zone + ACM certificates (CloudFront requires us-east-1)
 - **AkliInfrastructureStack** (eu-west-2): S3, CloudFront, Route 53 records, IAM users, Secrets Manager
 - **PokedexStack** (eu-west-2): DynamoDB table, HTTP API Gateway, Lambda handlers
 - **AuthStack** (eu-west-2): Cognito user pool, HTTP API Gateway, Lambda handlers, JWT authoriser, CloudWatch alarms
-- **ApiStack** (eu-west-2): CloudFront distribution for api.akli.dev, routes to Pokedex and Auth APIs
+- **RecipeStack** (eu-west-2): DynamoDB table, S3 image bucket, HTTP API Gateway, Lambda handlers (CRUD, image upload, image resizer), JWT authoriser
+- **ApiStack** (eu-west-2): CloudFront distribution for api.akli.dev, routes to Pokedex, Auth, and Recipe APIs
 
 Cross-region references are enabled so the main stack can consume the certificate.
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ AWS CDK infrastructure for [akli.dev](https://akli.dev). Manages static site hos
 
 ## Architecture
 
-Five CDK stacks deployed across regions:
+Six CDK stacks deployed across regions:
 
 | Stack | Region | Resources |
 |-------|--------|-----------|
@@ -12,7 +12,8 @@ Five CDK stacks deployed across regions:
 | AkliInfrastructureStack | eu-west-2 | S3 bucket, CloudFront distribution, Route 53 records, IAM users |
 | PokedexStack | eu-west-2 | DynamoDB table, HTTP API Gateway, Lambda handlers |
 | AuthStack | eu-west-2 | Cognito user pool, HTTP API Gateway, Lambda handlers, JWT authoriser, CloudWatch alarms |
-| ApiStack | eu-west-2 | CloudFront distribution for api.akli.dev, routes to Pokedex and Auth APIs |
+| RecipeStack | eu-west-2 | DynamoDB table, S3 image bucket, HTTP API Gateway, Lambda handlers (CRUD, image upload, image resizer), JWT authoriser |
+| ApiStack | eu-west-2 | CloudFront distribution for api.akli.dev, routes to Pokedex, Auth, and Recipe APIs |
 
 ```
 Route 53 (akli.dev, www.akli.dev)

--- a/bin/akli-infrastructure.ts
+++ b/bin/akli-infrastructure.ts
@@ -63,6 +63,7 @@ const authStack = new AuthStack(app, 'AuthStack', {
 const recipeStack = new RecipeStack(app, 'RecipeStack', {
   env: { account, region: 'eu-west-2' },
   description: 'Recipe API backend resources (DynamoDB, S3, Lambda, API Gateway)',
+  terminationProtection: true,
   userPoolId: authStack.userPoolId,
   userPoolClientId: authStack.userPoolClientId,
   userPoolArn: authStack.userPoolArn,

--- a/bin/akli-infrastructure.ts
+++ b/bin/akli-infrastructure.ts
@@ -5,6 +5,7 @@ import { CertificateStack } from '../lib/certificate-stack';
 import { PokedexStack } from '../lib/pokedex-stack';
 import { ApiStack } from '../lib/api-stack';
 import { AuthStack } from '../lib/auth-stack';
+import { RecipeStack } from '../lib/recipe-stack';
 
 const app = new cdk.App();
 
@@ -59,6 +60,19 @@ const authStack = new AuthStack(app, 'AuthStack', {
   },
 })
 
+const recipeStack = new RecipeStack(app, 'RecipeStack', {
+  env: { account, region: 'eu-west-2' },
+  description: 'Recipe API backend resources (DynamoDB, S3, Lambda, API Gateway)',
+  userPoolId: authStack.userPoolId,
+  userPoolClientId: authStack.userPoolClientId,
+  userPoolArn: authStack.userPoolArn,
+  tags: {
+    Project: 'recipes',
+    Environment: 'production',
+    ManagedBy: 'cdk',
+  },
+})
+
 new ApiStack(app, 'ApiStack', {
   env: { account, region: 'eu-west-2' },
   crossRegionReferences: true,
@@ -66,6 +80,7 @@ new ApiStack(app, 'ApiStack', {
   hostedZone: certStack.hostedZone,
   pokedexApiUrl: pokedexStack.httpApi.apiEndpoint,
   authApiUrl: authStack.httpApi.apiEndpoint,
+  recipeApiUrl: recipeStack.httpApi.apiEndpoint,
   description: 'Shared API infrastructure for api.akli.dev with CloudFront',
 
   tags: {

--- a/lambda/image-resizer.ts
+++ b/lambda/image-resizer.ts
@@ -1,0 +1,5 @@
+import type { S3Event } from 'aws-lambda'
+
+export async function handler(event: S3Event): Promise<void> {
+  // TODO: implement image resizing
+}

--- a/lambda/image-resizer.ts
+++ b/lambda/image-resizer.ts
@@ -18,6 +18,7 @@ const VARIANTS: readonly ImageVariant[] = [
 
 export async function handler(event: S3Event): Promise<void> {
   const bucketName = process.env.IMAGE_BUCKET_NAME
+  if (!bucketName) throw new Error('IMAGE_BUCKET_NAME not set')
 
   for (const record of event.Records) {
     const key = record.s3.object.key
@@ -32,21 +33,23 @@ export async function handler(event: S3Event): Promise<void> {
 
     const processedKey = key.replace('uploads/', 'processed/')
 
-    for (const variant of VARIANTS) {
-      const variantBuffer = await sharp(imageBuffer)
-        .resize(variant.width)
-        .webp({ quality: variant.quality })
-        .toBuffer()
+    await Promise.all(
+      VARIANTS.map(async (variant) => {
+        const variantBuffer = await sharp(imageBuffer)
+          .resize(variant.width)
+          .webp({ quality: variant.quality })
+          .toBuffer()
 
-      await s3.send(
-        new PutObjectCommand({
-          Bucket: bucketName,
-          Key: `${processedKey}-${variant.suffix}.webp`,
-          ContentType: 'image/webp',
-          Body: variantBuffer,
-        }),
-      )
-    }
+        await s3.send(
+          new PutObjectCommand({
+            Bucket: bucketName,
+            Key: `${processedKey}-${variant.suffix}.webp`,
+            ContentType: 'image/webp',
+            Body: variantBuffer,
+          }),
+        )
+      }),
+    )
 
     await s3.send(
       new DeleteObjectCommand({ Bucket: sourceBucket, Key: key }),

--- a/lambda/image-resizer.ts
+++ b/lambda/image-resizer.ts
@@ -1,5 +1,55 @@
 import type { S3Event } from 'aws-lambda'
+import { S3Client, GetObjectCommand, PutObjectCommand, DeleteObjectCommand } from '@aws-sdk/client-s3'
+import sharp = require('sharp')
+
+const s3 = new S3Client({})
+
+interface ImageVariant {
+  readonly suffix: string
+  readonly width: number
+  readonly quality: number
+}
+
+const VARIANTS: readonly ImageVariant[] = [
+  { suffix: 'thumb', width: 400, quality: 80 },
+  { suffix: 'medium', width: 800, quality: 85 },
+  { suffix: 'full', width: 1200, quality: 90 },
+]
 
 export async function handler(event: S3Event): Promise<void> {
-  // TODO: implement image resizing
+  const bucketName = process.env.IMAGE_BUCKET_NAME
+
+  for (const record of event.Records) {
+    const key = record.s3.object.key
+    const sourceBucket = record.s3.bucket.name
+
+    const getResponse = await s3.send(
+      new GetObjectCommand({ Bucket: sourceBucket, Key: key }),
+    )
+
+    const bodyBytes = await getResponse.Body!.transformToByteArray()
+    const imageBuffer = Buffer.from(bodyBytes)
+
+    const processedKey = key.replace('uploads/', 'processed/')
+
+    for (const variant of VARIANTS) {
+      const variantBuffer = await sharp(imageBuffer)
+        .resize(variant.width)
+        .webp({ quality: variant.quality })
+        .toBuffer()
+
+      await s3.send(
+        new PutObjectCommand({
+          Bucket: bucketName,
+          Key: `${processedKey}-${variant.suffix}.webp`,
+          ContentType: 'image/webp',
+          Body: variantBuffer,
+        }),
+      )
+    }
+
+    await s3.send(
+      new DeleteObjectCommand({ Bucket: sourceBucket, Key: key }),
+    )
+  }
 }

--- a/lambda/recipe-handler.ts
+++ b/lambda/recipe-handler.ts
@@ -130,6 +130,8 @@ function lightweightRecipe(recipe: Record<string, unknown>): Record<string, unkn
 export async function handler(event: APIGatewayProxyEventV2): Promise<APIGatewayProxyStructuredResultV2> {
   try {
     switch (event.routeKey) {
+      case 'GET /recipes/tags':
+        return await handleListTags()
       case 'GET /recipes':
         return await handleListPublished()
       case 'GET /recipes/{slug}':
@@ -152,6 +154,32 @@ export async function handler(event: APIGatewayProxyEventV2): Promise<APIGateway
   } catch {
     return json(500, { error: 'Internal server error' })
   }
+}
+
+async function handleListTags(): Promise<APIGatewayProxyStructuredResultV2> {
+  const result = await docClient.send(
+    new ScanCommand({
+      TableName: TABLE_NAME,
+      FilterExpression: '#status = :status',
+      ExpressionAttributeNames: { '#status': 'status' },
+      ExpressionAttributeValues: { ':status': 'published' },
+      ProjectionExpression: 'tags',
+    }),
+  )
+
+  const countMap: Record<string, number> = {}
+  for (const item of result.Items ?? []) {
+    const tags = tagsToArray(item.tags)
+    for (const tag of tags) {
+      countMap[tag] = (countMap[tag] ?? 0) + 1
+    }
+  }
+
+  const sorted = Object.entries(countMap)
+    .map(([tag, count]) => ({ tag, count }))
+    .sort((a, b) => a.tag.localeCompare(b.tag))
+
+  return json(200, sorted)
 }
 
 async function handleListPublished(): Promise<APIGatewayProxyStructuredResultV2> {

--- a/lambda/recipe-handler.ts
+++ b/lambda/recipe-handler.ts
@@ -1,0 +1,9 @@
+import type { APIGatewayProxyEventV2, APIGatewayProxyStructuredResultV2 } from 'aws-lambda'
+
+export async function handler(event: APIGatewayProxyEventV2): Promise<APIGatewayProxyStructuredResultV2> {
+  return {
+    statusCode: 501,
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ error: 'Not implemented' }),
+  }
+}

--- a/lambda/recipe-handler.ts
+++ b/lambda/recipe-handler.ts
@@ -1,9 +1,402 @@
 import type { APIGatewayProxyEventV2, APIGatewayProxyStructuredResultV2 } from 'aws-lambda'
+import { DynamoDBClient } from '@aws-sdk/client-dynamodb'
+import { DynamoDBDocumentClient, QueryCommand, GetCommand, PutCommand, UpdateCommand, DeleteCommand, ScanCommand } from '@aws-sdk/lib-dynamodb'
+import { S3Client, ListObjectsV2Command, DeleteObjectsCommand } from '@aws-sdk/client-s3'
+import { randomUUID } from 'node:crypto'
+
+const ddbClient = new DynamoDBClient({})
+const docClient = DynamoDBDocumentClient.from(ddbClient)
+const s3Client = new S3Client({})
+
+const TABLE_NAME = process.env.TABLE_NAME ?? ''
+const IMAGE_BUCKET_NAME = process.env.IMAGE_BUCKET_NAME ?? ''
+
+interface JwtPayload {
+  readonly sub: string
+  readonly email?: string
+  readonly name?: string
+  readonly 'cognito:groups'?: readonly string[]
+}
+
+interface CoverImage {
+  readonly key: string
+  readonly alt: string
+}
+
+interface Ingredient {
+  readonly item: string
+  readonly quantity: string
+  readonly unit: string
+}
+
+interface Step {
+  readonly order: number
+  readonly text: string
+  readonly image?: { readonly key: string; readonly alt: string }
+}
+
+interface CreateRecipeInput {
+  readonly title?: string
+  readonly coverImage?: Partial<CoverImage>
+  readonly intro?: string
+  readonly ingredients?: readonly Ingredient[]
+  readonly steps?: readonly Step[]
+  readonly tags?: readonly string[]
+  readonly prepTime?: number
+  readonly cookTime?: number
+  readonly servings?: number
+}
+
+function json(statusCode: number, body: Record<string, unknown> | readonly Record<string, unknown>[]): APIGatewayProxyStructuredResultV2 {
+  return { statusCode, headers: { 'Content-Type': 'application/json' }, body: JSON.stringify(body) }
+}
+
+function decodeJwt(event: APIGatewayProxyEventV2): JwtPayload | undefined {
+  const authHeader = event.headers.authorization
+  if (!authHeader) return undefined
+
+  const token = authHeader.replace(/^bearer\s+/i, '')
+  if (!token) return undefined
+
+  try {
+    const parts = token.split('.')
+    if (parts.length < 2) return undefined
+    return JSON.parse(Buffer.from(parts[1], 'base64url').toString()) as JwtPayload
+  } catch {
+    return undefined
+  }
+}
+
+function isAdmin(event: APIGatewayProxyEventV2): boolean {
+  const payload = decodeJwt(event)
+  if (!payload) return false
+  const groups = payload['cognito:groups']
+  return Array.isArray(groups) && groups.includes('admin')
+}
+
+function tagsToArray(tags: unknown): string[] {
+  if (tags instanceof Set) return Array.from(tags) as string[]
+  if (Array.isArray(tags)) return tags as string[]
+  if (tags && typeof tags === 'object' && 'wrapperName' in tags && 'values' in tags) {
+    return (tags as { values: string[] }).values
+  }
+  return []
+}
+
+function generateSlug(title: string): string {
+  return title
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+}
+
+async function findUniqueSlug(baseSlug: string): Promise<string> {
+  let candidate = baseSlug
+  let suffix = 2
+
+  while (true) {
+    const result = await docClient.send(
+      new ScanCommand({
+        TableName: TABLE_NAME,
+        FilterExpression: 'slug = :slug',
+        ExpressionAttributeValues: { ':slug': candidate },
+      }),
+    )
+
+    if (!result.Items || result.Items.length === 0) return candidate
+    candidate = `${baseSlug}-${suffix}`
+    suffix += 1
+  }
+}
+
+function convertRecipeTags(recipe: Record<string, unknown>): Record<string, unknown> {
+  return { ...recipe, tags: tagsToArray(recipe.tags) }
+}
+
+function lightweightRecipe(recipe: Record<string, unknown>): Record<string, unknown> {
+  return {
+    id: recipe.id,
+    title: recipe.title,
+    slug: recipe.slug,
+    coverImage: recipe.coverImage,
+    tags: tagsToArray(recipe.tags),
+    prepTime: recipe.prepTime,
+    cookTime: recipe.cookTime,
+    servings: recipe.servings,
+    createdAt: recipe.createdAt,
+  }
+}
 
 export async function handler(event: APIGatewayProxyEventV2): Promise<APIGatewayProxyStructuredResultV2> {
-  return {
-    statusCode: 501,
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ error: 'Not implemented' }),
+  try {
+    switch (event.routeKey) {
+      case 'GET /recipes':
+        return await handleListPublished()
+      case 'GET /recipes/{slug}':
+        return await handleGetBySlug(event)
+      case 'GET /me/recipes':
+        return await handleListUserRecipes(event)
+      case 'POST /recipes':
+        return await handleCreateRecipe(event)
+      case 'PUT /recipes/{id}':
+        return await handleUpdateRecipe(event)
+      case 'PATCH /recipes/{id}/publish':
+        return await handlePublish(event)
+      case 'PATCH /recipes/{id}/unpublish':
+        return await handleUnpublish(event)
+      case 'DELETE /recipes/{id}':
+        return await handleDeleteRecipe(event)
+      default:
+        return json(404, { error: 'Not found' })
+    }
+  } catch {
+    return json(500, { error: 'Internal server error' })
   }
+}
+
+async function handleListPublished(): Promise<APIGatewayProxyStructuredResultV2> {
+  const result = await docClient.send(
+    new QueryCommand({
+      TableName: TABLE_NAME,
+      IndexName: 'status-createdAt-index',
+      KeyConditionExpression: '#status = :status',
+      ExpressionAttributeNames: { '#status': 'status' },
+      ExpressionAttributeValues: { ':status': 'published' },
+      ScanIndexForward: false,
+    }),
+  )
+
+  const recipes = (result.Items ?? []).map((item) => lightweightRecipe(item as Record<string, unknown>))
+  return json(200, recipes)
+}
+
+async function handleGetBySlug(event: APIGatewayProxyEventV2): Promise<APIGatewayProxyStructuredResultV2> {
+  const slug = event.pathParameters?.slug
+  if (!slug) return json(400, { error: 'slug is required' })
+
+  const result = await docClient.send(
+    new ScanCommand({
+      TableName: TABLE_NAME,
+      FilterExpression: 'slug = :slug',
+      ExpressionAttributeValues: { ':slug': slug },
+    }),
+  )
+
+  if (!result.Items || result.Items.length === 0) {
+    return json(404, { error: 'Recipe not found' })
+  }
+
+  const recipe = result.Items[0] as Record<string, unknown>
+  if (recipe.status !== 'published') {
+    return json(404, { error: 'Recipe not found' })
+  }
+
+  return json(200, convertRecipeTags(recipe))
+}
+
+async function handleListUserRecipes(event: APIGatewayProxyEventV2): Promise<APIGatewayProxyStructuredResultV2> {
+  const payload = decodeJwt(event)
+  if (!payload) return json(401, { error: 'Unauthorised' })
+
+  const result = await docClient.send(
+    new QueryCommand({
+      TableName: TABLE_NAME,
+      IndexName: 'authorId-createdAt-index',
+      KeyConditionExpression: 'authorId = :authorId',
+      ExpressionAttributeValues: { ':authorId': payload.sub },
+      ScanIndexForward: false,
+    }),
+  )
+
+  const recipes = (result.Items ?? []).map((item) => convertRecipeTags(item as Record<string, unknown>))
+  return json(200, recipes)
+}
+
+async function handleCreateRecipe(event: APIGatewayProxyEventV2): Promise<APIGatewayProxyStructuredResultV2> {
+  const payload = decodeJwt(event)
+  if (!payload) return json(401, { error: 'Unauthorised' })
+
+  const input = JSON.parse(event.body ?? '{}') as CreateRecipeInput
+  const errors = validateCreateInput(input)
+  if (errors.length > 0) return json(400, { error: errors.join(', ') })
+
+  const id = randomUUID()
+  const baseSlug = generateSlug(input.title as string)
+  const slug = await findUniqueSlug(baseSlug)
+  const now = new Date().toISOString()
+
+  const item: Record<string, unknown> = {
+    id,
+    slug,
+    title: input.title,
+    intro: input.intro,
+    coverImage: input.coverImage,
+    ingredients: input.ingredients,
+    steps: input.steps,
+    prepTime: input.prepTime,
+    cookTime: input.cookTime,
+    servings: input.servings,
+    status: 'draft',
+    authorId: payload.sub,
+    authorName: payload.name ?? payload.email ?? '',
+    createdAt: now,
+    updatedAt: now,
+  }
+
+  if (input.tags && input.tags.length > 0) {
+    item.tags = new Set(input.tags)
+  }
+
+  await docClient.send(new PutCommand({ TableName: TABLE_NAME, Item: item }))
+
+  return json(201, { ...item, tags: input.tags ?? [] })
+}
+
+function validateCreateInput(input: CreateRecipeInput): string[] {
+  const errors: string[] = []
+  if (!input.title) errors.push('title is required')
+  if (!input.coverImage) {
+    errors.push('coverImage is required')
+  } else {
+    if (!input.coverImage.key) errors.push('coverImage.key is required')
+    if (!input.coverImage.alt) errors.push('coverImage.alt is required')
+  }
+  if (!input.ingredients || input.ingredients.length === 0) errors.push('At least one ingredient is required')
+  if (!input.steps || input.steps.length === 0) errors.push('At least one step is required')
+  return errors
+}
+
+async function handleUpdateRecipe(event: APIGatewayProxyEventV2): Promise<APIGatewayProxyStructuredResultV2> {
+  const payload = decodeJwt(event)
+  if (!payload) return json(401, { error: 'Unauthorised' })
+
+  const id = event.pathParameters?.id
+  if (!id) return json(400, { error: 'id is required' })
+
+  const existing = await getRecipeById(id)
+  if (!existing) return json(404, { error: 'Recipe not found' })
+
+  if (!isOwnerOrAdmin(existing.authorId as string, payload.sub, event)) {
+    return json(403, { error: 'Forbidden' })
+  }
+
+  const updates = JSON.parse(event.body ?? '{}') as Record<string, unknown>
+  delete updates.slug
+  delete updates.id
+  delete updates.authorId
+  delete updates.createdAt
+
+  const now = new Date().toISOString()
+  const expressionParts: string[] = []
+  const expressionNames: Record<string, string> = {}
+  const expressionValues: Record<string, unknown> = {}
+
+  for (const [key, value] of Object.entries(updates)) {
+    const attrName = `#${key}`
+    const attrValue = `:${key}`
+    expressionParts.push(`${attrName} = ${attrValue}`)
+    expressionNames[attrName] = key
+    expressionValues[attrValue] = value
+  }
+
+  expressionParts.push('#updatedAt = :updatedAt')
+  expressionNames['#updatedAt'] = 'updatedAt'
+  expressionValues[':updatedAt'] = now
+
+  const result = await docClient.send(
+    new UpdateCommand({
+      TableName: TABLE_NAME,
+      Key: { id },
+      UpdateExpression: `SET ${expressionParts.join(', ')}`,
+      ExpressionAttributeNames: expressionNames,
+      ExpressionAttributeValues: expressionValues,
+      ReturnValues: 'ALL_NEW',
+    }),
+  )
+
+  return json(200, convertRecipeTags(result.Attributes as Record<string, unknown>))
+}
+
+async function handlePublish(event: APIGatewayProxyEventV2): Promise<APIGatewayProxyStructuredResultV2> {
+  return await handleStatusChange(event, 'published')
+}
+
+async function handleUnpublish(event: APIGatewayProxyEventV2): Promise<APIGatewayProxyStructuredResultV2> {
+  return await handleStatusChange(event, 'draft')
+}
+
+async function handleStatusChange(event: APIGatewayProxyEventV2, newStatus: string): Promise<APIGatewayProxyStructuredResultV2> {
+  const payload = decodeJwt(event)
+  if (!payload) return json(401, { error: 'Unauthorised' })
+
+  const id = event.pathParameters?.id
+  if (!id) return json(400, { error: 'id is required' })
+
+  const existing = await getRecipeById(id)
+  if (!existing) return json(404, { error: 'Recipe not found' })
+
+  if (!isOwnerOrAdmin(existing.authorId as string, payload.sub, event)) {
+    return json(403, { error: 'Forbidden' })
+  }
+
+  const now = new Date().toISOString()
+  const result = await docClient.send(
+    new UpdateCommand({
+      TableName: TABLE_NAME,
+      Key: { id },
+      UpdateExpression: 'SET #status = :status, #updatedAt = :updatedAt',
+      ExpressionAttributeNames: { '#status': 'status', '#updatedAt': 'updatedAt' },
+      ExpressionAttributeValues: { ':status': newStatus, ':updatedAt': now },
+      ReturnValues: 'ALL_NEW',
+    }),
+  )
+
+  return json(200, convertRecipeTags(result.Attributes as Record<string, unknown>))
+}
+
+async function handleDeleteRecipe(event: APIGatewayProxyEventV2): Promise<APIGatewayProxyStructuredResultV2> {
+  const payload = decodeJwt(event)
+  if (!payload) return json(401, { error: 'Unauthorised' })
+
+  const id = event.pathParameters?.id
+  if (!id) return json(400, { error: 'id is required' })
+
+  const existing = await getRecipeById(id)
+  if (!existing) return json(404, { error: 'Recipe not found' })
+
+  if (!isOwnerOrAdmin(existing.authorId as string, payload.sub, event)) {
+    return json(403, { error: 'Forbidden' })
+  }
+
+  const listResult = await s3Client.send(
+    new ListObjectsV2Command({
+      Bucket: IMAGE_BUCKET_NAME,
+      Prefix: `processed/recipes/${id}/`,
+    }),
+  )
+
+  if (listResult.Contents && listResult.Contents.length > 0) {
+    await s3Client.send(
+      new DeleteObjectsCommand({
+        Bucket: IMAGE_BUCKET_NAME,
+        Delete: {
+          Objects: listResult.Contents.map((obj) => ({ Key: obj.Key })),
+        },
+      }),
+    )
+  }
+
+  await docClient.send(new DeleteCommand({ TableName: TABLE_NAME, Key: { id } }))
+
+  return json(200, { message: 'Recipe deleted successfully' })
+}
+
+async function getRecipeById(id: string): Promise<Record<string, unknown> | undefined> {
+  const result = await docClient.send(new GetCommand({ TableName: TABLE_NAME, Key: { id } }))
+  return result.Item as Record<string, unknown> | undefined
+}
+
+function isOwnerOrAdmin(authorId: string, currentUserId: string, event: APIGatewayProxyEventV2): boolean {
+  if (authorId === currentUserId) return true
+  return isAdmin(event)
 }

--- a/lambda/recipe-image-handler.ts
+++ b/lambda/recipe-image-handler.ts
@@ -1,9 +1,65 @@
 import type { APIGatewayProxyEventV2, APIGatewayProxyStructuredResultV2 } from 'aws-lambda'
+import { S3Client, PutObjectCommand } from '@aws-sdk/client-s3'
+import { getSignedUrl } from '@aws-sdk/s3-request-presigner'
+
+const s3 = new S3Client({})
+const IMAGE_BUCKET_NAME = process.env.IMAGE_BUCKET_NAME ?? ''
+
+function json(statusCode: number, body: Record<string, unknown>): APIGatewayProxyStructuredResultV2 {
+  return { statusCode, headers: { 'Content-Type': 'application/json' }, body: JSON.stringify(body) }
+}
+
+function decodeToken(event: APIGatewayProxyEventV2): Record<string, unknown> | undefined {
+  const authHeader = event.headers.authorization
+  if (!authHeader) return undefined
+
+  const token = authHeader.replace(/^bearer\s+/i, '')
+  if (!token) return undefined
+
+  try {
+    const parts = token.split('.')
+    if (parts.length < 2) return undefined
+    return JSON.parse(Buffer.from(parts[1], 'base64url').toString()) as Record<string, unknown>
+  } catch {
+    return undefined
+  }
+}
+
+interface UploadUrlBody {
+  readonly recipeId?: string
+  readonly imageType?: string
+  readonly stepOrder?: number
+}
 
 export async function handler(event: APIGatewayProxyEventV2): Promise<APIGatewayProxyStructuredResultV2> {
-  return {
-    statusCode: 501,
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ error: 'Not implemented' }),
+  try {
+    switch (event.routeKey) {
+      case 'POST /recipes/images/upload-url':
+        return await handleUploadUrl(event)
+      default:
+        return json(404, { error: 'Not found' })
+    }
+  } catch {
+    return json(500, { error: 'Internal server error' })
   }
+}
+
+async function handleUploadUrl(event: APIGatewayProxyEventV2): Promise<APIGatewayProxyStructuredResultV2> {
+  const payload = decodeToken(event)
+  if (!payload) return json(401, { error: 'Unauthorised' })
+
+  const { recipeId, imageType, stepOrder } = JSON.parse(event.body ?? '{}') as UploadUrlBody
+  if (!recipeId || !imageType) return json(400, { error: 'recipeId and imageType are required' })
+
+  const key = imageType === 'cover'
+    ? `uploads/recipes/${recipeId}/cover`
+    : `uploads/recipes/${recipeId}/step-${stepOrder}`
+
+  const uploadUrl = await getSignedUrl(
+    s3,
+    new PutObjectCommand({ Bucket: IMAGE_BUCKET_NAME, Key: key }),
+    { expiresIn: 900 },
+  )
+
+  return json(200, { uploadUrl, key })
 }

--- a/lambda/recipe-image-handler.ts
+++ b/lambda/recipe-image-handler.ts
@@ -50,6 +50,7 @@ async function handleUploadUrl(event: APIGatewayProxyEventV2): Promise<APIGatewa
 
   const { recipeId, imageType, stepOrder } = JSON.parse(event.body ?? '{}') as UploadUrlBody
   if (!recipeId || !imageType) return json(400, { error: 'recipeId and imageType are required' })
+  if (imageType !== 'cover' && !stepOrder) return json(400, { error: 'stepOrder is required for step images' })
 
   const key = imageType === 'cover'
     ? `uploads/recipes/${recipeId}/cover`

--- a/lambda/recipe-image-handler.ts
+++ b/lambda/recipe-image-handler.ts
@@ -1,0 +1,9 @@
+import type { APIGatewayProxyEventV2, APIGatewayProxyStructuredResultV2 } from 'aws-lambda'
+
+export async function handler(event: APIGatewayProxyEventV2): Promise<APIGatewayProxyStructuredResultV2> {
+  return {
+    statusCode: 501,
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ error: 'Not implemented' }),
+  }
+}

--- a/lib/api-stack.ts
+++ b/lib/api-stack.ts
@@ -14,6 +14,7 @@ interface ApiStackProps extends StackProps {
   apiCertificate: certificatemanager.ICertificate
   pokedexApiUrl: string
   authApiUrl: string
+  recipeApiUrl: string
 }
 
 /**
@@ -25,7 +26,7 @@ export class ApiStack extends Stack {
   constructor(scope: Construct, id: string, props: ApiStackProps) {
     super(scope, id, props)
 
-    const { hostedZone, apiCertificate, pokedexApiUrl, authApiUrl } = props
+    const { hostedZone, apiCertificate, pokedexApiUrl, authApiUrl, recipeApiUrl } = props
 
     // Extract the domain from the API Gateway URL (strip "https://")
     const pokedexApiDomain = Fn.select(2, Fn.split('/', pokedexApiUrl))
@@ -38,6 +39,13 @@ export class ApiStack extends Stack {
     const authApiDomain = Fn.select(2, Fn.split('/', authApiUrl))
 
     const authOrigin = new origins.HttpOrigin(authApiDomain, {
+      protocolPolicy: cloudfront.OriginProtocolPolicy.HTTPS_ONLY,
+    })
+
+    // Recipe API origin
+    const recipeApiDomain = Fn.select(2, Fn.split('/', recipeApiUrl))
+
+    const recipeOrigin = new origins.HttpOrigin(recipeApiDomain, {
       protocolPolicy: cloudfront.OriginProtocolPolicy.HTTPS_ONLY,
     })
 
@@ -86,6 +94,14 @@ export class ApiStack extends Stack {
           viewerProtocolPolicy: cloudfront.ViewerProtocolPolicy.REDIRECT_TO_HTTPS,
           cachePolicy: cloudfront.CachePolicy.CACHING_DISABLED,
           // AllViewerExceptHostHeader forwards all viewer headers (including Authorization) except Host
+          originRequestPolicy: cloudfront.OriginRequestPolicy.ALL_VIEWER_EXCEPT_HOST_HEADER,
+          allowedMethods: cloudfront.AllowedMethods.ALLOW_ALL,
+          compress: true,
+        },
+        '/recipes/*': {
+          origin: recipeOrigin,
+          viewerProtocolPolicy: cloudfront.ViewerProtocolPolicy.REDIRECT_TO_HTTPS,
+          cachePolicy: cloudfront.CachePolicy.CACHING_DISABLED,
           originRequestPolicy: cloudfront.OriginRequestPolicy.ALL_VIEWER_EXCEPT_HOST_HEADER,
           allowedMethods: cloudfront.AllowedMethods.ALLOW_ALL,
           compress: true,

--- a/lib/auth-stack.ts
+++ b/lib/auth-stack.ts
@@ -14,6 +14,9 @@ import { applyStackTags } from './utils'
 
 export class AuthStack extends Stack {
   public readonly httpApi: HttpApi
+  public readonly userPoolId: string
+  public readonly userPoolClientId: string
+  public readonly userPoolArn: string
 
   constructor(scope: Construct, id: string, props?: StackProps) {
     super(scope, id, props)
@@ -38,6 +41,9 @@ export class AuthStack extends Stack {
       removalPolicy: RemovalPolicy.RETAIN,
     })
 
+    this.userPoolId = userPool.userPoolId
+    this.userPoolArn = userPool.userPoolArn
+
     // User Pool Client
     const userPoolClient = new cognito.CfnUserPoolClient(this, 'AuthUserPoolClient', {
       userPoolId: userPool.userPoolId,
@@ -50,6 +56,8 @@ export class AuthStack extends Stack {
         refreshToken: 'days',
       },
     })
+
+    this.userPoolClientId = userPoolClient.ref
 
     // Cognito Groups
     new cognito.CfnUserPoolGroup(this, 'AdminGroup', {

--- a/lib/recipe-stack.ts
+++ b/lib/recipe-stack.ts
@@ -1,8 +1,31 @@
 import { Stack, StackProps } from 'aws-cdk-lib'
 import { Construct } from 'constructs'
+import * as dynamodb from 'aws-cdk-lib/aws-dynamodb'
+import { applyStackTags } from './utils'
 
 export class RecipeStack extends Stack {
   constructor(scope: Construct, id: string, props?: StackProps) {
     super(scope, id, props)
+
+    const table = new dynamodb.Table(this, 'RecipesTable', {
+      tableName: 'recipes',
+      partitionKey: { name: 'id', type: dynamodb.AttributeType.STRING },
+      billingMode: dynamodb.BillingMode.PAY_PER_REQUEST,
+      pointInTimeRecoverySpecification: { pointInTimeRecoveryEnabled: true },
+    })
+
+    table.addGlobalSecondaryIndex({
+      indexName: 'status-createdAt-index',
+      partitionKey: { name: 'status', type: dynamodb.AttributeType.STRING },
+      sortKey: { name: 'createdAt', type: dynamodb.AttributeType.STRING },
+    })
+
+    table.addGlobalSecondaryIndex({
+      indexName: 'authorId-createdAt-index',
+      partitionKey: { name: 'authorId', type: dynamodb.AttributeType.STRING },
+      sortKey: { name: 'createdAt', type: dynamodb.AttributeType.STRING },
+    })
+
+    applyStackTags(this, props)
   }
 }

--- a/lib/recipe-stack.ts
+++ b/lib/recipe-stack.ts
@@ -1,6 +1,7 @@
-import { Stack, StackProps } from 'aws-cdk-lib'
+import { Duration, RemovalPolicy, Stack, StackProps } from 'aws-cdk-lib'
 import { Construct } from 'constructs'
 import * as dynamodb from 'aws-cdk-lib/aws-dynamodb'
+import * as s3 from 'aws-cdk-lib/aws-s3'
 import { applyStackTags } from './utils'
 
 export class RecipeStack extends Stack {
@@ -24,6 +25,24 @@ export class RecipeStack extends Stack {
       indexName: 'authorId-createdAt-index',
       partitionKey: { name: 'authorId', type: dynamodb.AttributeType.STRING },
       sortKey: { name: 'createdAt', type: dynamodb.AttributeType.STRING },
+    })
+
+    new s3.Bucket(this, 'RecipeImagesBucket', {
+      bucketName: `akli-recipe-images-${this.account}-${this.region}`,
+      blockPublicAccess: s3.BlockPublicAccess.BLOCK_ALL,
+      removalPolicy: RemovalPolicy.RETAIN,
+      autoDeleteObjects: false,
+      lifecycleRules: [
+        {
+          abortIncompleteMultipartUploadAfter: Duration.days(1),
+        },
+      ],
+      cors: [
+        {
+          allowedMethods: [s3.HttpMethods.PUT],
+          allowedOrigins: ['https://akli.dev'],
+        },
+      ],
     })
 
     applyStackTags(this, props)

--- a/lib/recipe-stack.ts
+++ b/lib/recipe-stack.ts
@@ -1,13 +1,31 @@
 import { Duration, RemovalPolicy, Stack, StackProps } from 'aws-cdk-lib'
 import { Construct } from 'constructs'
+import { CorsHttpMethod, HttpApi } from 'aws-cdk-lib/aws-apigatewayv2'
+import * as apigwv2 from 'aws-cdk-lib/aws-apigatewayv2'
 import * as dynamodb from 'aws-cdk-lib/aws-dynamodb'
+import * as iam from 'aws-cdk-lib/aws-iam'
+import * as lambda from 'aws-cdk-lib/aws-lambda'
+import { NodejsFunction } from 'aws-cdk-lib/aws-lambda-nodejs'
 import * as s3 from 'aws-cdk-lib/aws-s3'
+import * as s3n from 'aws-cdk-lib/aws-s3-notifications'
+import * as path from 'path'
 import { applyStackTags } from './utils'
 
+interface RecipeStackProps extends StackProps {
+  userPoolId: string
+  userPoolClientId: string
+  userPoolArn: string
+}
+
 export class RecipeStack extends Stack {
-  constructor(scope: Construct, id: string, props?: StackProps) {
+  public readonly httpApi: HttpApi
+
+  constructor(scope: Construct, id: string, props: RecipeStackProps) {
     super(scope, id, props)
 
+    const { userPoolId, userPoolClientId, userPoolArn } = props
+
+    // DynamoDB table
     const table = new dynamodb.Table(this, 'RecipesTable', {
       tableName: 'recipes',
       partitionKey: { name: 'id', type: dynamodb.AttributeType.STRING },
@@ -27,7 +45,8 @@ export class RecipeStack extends Stack {
       sortKey: { name: 'createdAt', type: dynamodb.AttributeType.STRING },
     })
 
-    new s3.Bucket(this, 'RecipeImagesBucket', {
+    // S3 image bucket
+    const imageBucket = new s3.Bucket(this, 'RecipeImagesBucket', {
       bucketName: `akli-recipe-images-${this.account}-${this.region}`,
       blockPublicAccess: s3.BlockPublicAccess.BLOCK_ALL,
       encryption: s3.BucketEncryption.S3_MANAGED,
@@ -46,6 +65,193 @@ export class RecipeStack extends Stack {
           allowedHeaders: ['*'],
         },
       ],
+    })
+
+    // HTTP API with CORS
+    this.httpApi = new HttpApi(this, 'RecipeHttpApi', {
+      apiName: 'recipe-api',
+      corsPreflight: {
+        allowOrigins: ['https://akli.dev'],
+        allowMethods: [
+          CorsHttpMethod.GET,
+          CorsHttpMethod.POST,
+          CorsHttpMethod.PUT,
+          CorsHttpMethod.PATCH,
+          CorsHttpMethod.DELETE,
+        ],
+        allowHeaders: ['Content-Type', 'Authorization'],
+      },
+    })
+
+    // Lambda functions
+    const recipeHandler = new NodejsFunction(this, 'RecipeHandler', {
+      runtime: lambda.Runtime.NODEJS_22_X,
+      memorySize: 256,
+      timeout: Duration.seconds(10),
+      entry: path.join(__dirname, '..', 'lambda', 'recipe-handler.ts'),
+      handler: 'handler',
+      functionName: 'akli-recipe-handler',
+      environment: {
+        TABLE_NAME: table.tableName,
+        IMAGE_BUCKET_NAME: imageBucket.bucketName,
+      },
+    })
+
+    table.grantReadWriteData(recipeHandler)
+    imageBucket.grantRead(recipeHandler)
+    imageBucket.grantDelete(recipeHandler)
+
+    const recipeImageHandler = new NodejsFunction(this, 'RecipeImageHandler', {
+      runtime: lambda.Runtime.NODEJS_22_X,
+      memorySize: 256,
+      timeout: Duration.seconds(10),
+      entry: path.join(__dirname, '..', 'lambda', 'recipe-image-handler.ts'),
+      handler: 'handler',
+      functionName: 'akli-recipe-image-handler',
+      environment: {
+        IMAGE_BUCKET_NAME: imageBucket.bucketName,
+      },
+    })
+
+    imageBucket.grantPut(recipeImageHandler)
+
+    const imageResizer = new NodejsFunction(this, 'ImageResizer', {
+      runtime: lambda.Runtime.NODEJS_22_X,
+      memorySize: 512,
+      timeout: Duration.seconds(30),
+      entry: path.join(__dirname, '..', 'lambda', 'image-resizer.ts'),
+      handler: 'handler',
+      functionName: 'akli-image-resizer',
+      environment: {
+        IMAGE_BUCKET_NAME: imageBucket.bucketName,
+      },
+    })
+
+    imageBucket.grantReadWrite(imageResizer)
+    imageBucket.grantDelete(imageResizer)
+
+    // S3 event notification for image uploads
+    imageBucket.addEventNotification(
+      s3.EventType.OBJECT_CREATED,
+      new s3n.LambdaDestination(imageResizer),
+      { prefix: 'uploads/' },
+    )
+
+    // JWT Authoriser — IdentitySource must be an array for CFN early validation
+    const jwtAuthorizer = new apigwv2.CfnAuthorizer(this, 'JwtAuthorizer', {
+      apiId: this.httpApi.httpApiId,
+      authorizerType: 'JWT',
+      identitySource: ['$request.header.Authorization'],
+      name: 'cognito-jwt',
+      jwtConfiguration: {
+        issuer: `https://cognito-idp.${this.region}.amazonaws.com/${userPoolId}`,
+        audience: [userPoolClientId],
+      },
+    })
+
+    // API Gateway Integrations
+    const recipeIntegration = new apigwv2.CfnIntegration(this, 'RecipeHandlerIntegration', {
+      apiId: this.httpApi.httpApiId,
+      integrationType: 'AWS_PROXY',
+      integrationUri: recipeHandler.functionArn,
+      payloadFormatVersion: '2.0',
+    })
+
+    const recipeImageIntegration = new apigwv2.CfnIntegration(this, 'RecipeImageHandlerIntegration', {
+      apiId: this.httpApi.httpApiId,
+      integrationType: 'AWS_PROXY',
+      integrationUri: recipeImageHandler.functionArn,
+      payloadFormatVersion: '2.0',
+    })
+
+    // Grant API Gateway invoke permissions
+    recipeHandler.addPermission('ApiGatewayInvoke', {
+      principal: new iam.ServicePrincipal('apigateway.amazonaws.com'),
+      sourceArn: `arn:aws:execute-api:${this.region}:${this.account}:${this.httpApi.httpApiId}/*/*`,
+    })
+
+    recipeImageHandler.addPermission('ApiGatewayInvoke', {
+      principal: new iam.ServicePrincipal('apigateway.amazonaws.com'),
+      sourceArn: `arn:aws:execute-api:${this.region}:${this.account}:${this.httpApi.httpApiId}/*/*`,
+    })
+
+    // Public Routes (AuthorizationType: NONE)
+    new apigwv2.CfnRoute(this, 'GetRecipesRoute', {
+      apiId: this.httpApi.httpApiId,
+      routeKey: 'GET /recipes',
+      target: `integrations/${recipeIntegration.ref}`,
+      authorizationType: 'NONE',
+    })
+
+    new apigwv2.CfnRoute(this, 'GetRecipeBySlugRoute', {
+      apiId: this.httpApi.httpApiId,
+      routeKey: 'GET /recipes/{slug}',
+      target: `integrations/${recipeIntegration.ref}`,
+      authorizationType: 'NONE',
+    })
+
+    new apigwv2.CfnRoute(this, 'GetRecipeTagsRoute', {
+      apiId: this.httpApi.httpApiId,
+      routeKey: 'GET /recipes/tags',
+      target: `integrations/${recipeIntegration.ref}`,
+      authorizationType: 'NONE',
+    })
+
+    // Protected Routes (AuthorizationType: JWT)
+    new apigwv2.CfnRoute(this, 'GetMyRecipesRoute', {
+      apiId: this.httpApi.httpApiId,
+      routeKey: 'GET /me/recipes',
+      target: `integrations/${recipeIntegration.ref}`,
+      authorizationType: 'JWT',
+      authorizerId: jwtAuthorizer.ref,
+    })
+
+    new apigwv2.CfnRoute(this, 'CreateRecipeRoute', {
+      apiId: this.httpApi.httpApiId,
+      routeKey: 'POST /recipes',
+      target: `integrations/${recipeIntegration.ref}`,
+      authorizationType: 'JWT',
+      authorizerId: jwtAuthorizer.ref,
+    })
+
+    new apigwv2.CfnRoute(this, 'UpdateRecipeRoute', {
+      apiId: this.httpApi.httpApiId,
+      routeKey: 'PUT /recipes/{id}',
+      target: `integrations/${recipeIntegration.ref}`,
+      authorizationType: 'JWT',
+      authorizerId: jwtAuthorizer.ref,
+    })
+
+    new apigwv2.CfnRoute(this, 'PublishRecipeRoute', {
+      apiId: this.httpApi.httpApiId,
+      routeKey: 'PATCH /recipes/{id}/publish',
+      target: `integrations/${recipeIntegration.ref}`,
+      authorizationType: 'JWT',
+      authorizerId: jwtAuthorizer.ref,
+    })
+
+    new apigwv2.CfnRoute(this, 'UnpublishRecipeRoute', {
+      apiId: this.httpApi.httpApiId,
+      routeKey: 'PATCH /recipes/{id}/unpublish',
+      target: `integrations/${recipeIntegration.ref}`,
+      authorizationType: 'JWT',
+      authorizerId: jwtAuthorizer.ref,
+    })
+
+    new apigwv2.CfnRoute(this, 'DeleteRecipeRoute', {
+      apiId: this.httpApi.httpApiId,
+      routeKey: 'DELETE /recipes/{id}',
+      target: `integrations/${recipeIntegration.ref}`,
+      authorizationType: 'JWT',
+      authorizerId: jwtAuthorizer.ref,
+    })
+
+    new apigwv2.CfnRoute(this, 'UploadImageUrlRoute', {
+      apiId: this.httpApi.httpApiId,
+      routeKey: 'POST /recipes/images/upload-url',
+      target: `integrations/${recipeImageIntegration.ref}`,
+      authorizationType: 'JWT',
+      authorizerId: jwtAuthorizer.ref,
     })
 
     applyStackTags(this, props)

--- a/lib/recipe-stack.ts
+++ b/lib/recipe-stack.ts
@@ -1,0 +1,8 @@
+import { Stack, StackProps } from 'aws-cdk-lib'
+import { Construct } from 'constructs'
+
+export class RecipeStack extends Stack {
+  constructor(scope: Construct, id: string, props?: StackProps) {
+    super(scope, id, props)
+  }
+}

--- a/lib/recipe-stack.ts
+++ b/lib/recipe-stack.ts
@@ -31,6 +31,7 @@ export class RecipeStack extends Stack {
       partitionKey: { name: 'id', type: dynamodb.AttributeType.STRING },
       billingMode: dynamodb.BillingMode.PAY_PER_REQUEST,
       pointInTimeRecoverySpecification: { pointInTimeRecoveryEnabled: true },
+      removalPolicy: RemovalPolicy.RETAIN,
     })
 
     table.addGlobalSecondaryIndex({

--- a/lib/recipe-stack.ts
+++ b/lib/recipe-stack.ts
@@ -30,6 +30,8 @@ export class RecipeStack extends Stack {
     new s3.Bucket(this, 'RecipeImagesBucket', {
       bucketName: `akli-recipe-images-${this.account}-${this.region}`,
       blockPublicAccess: s3.BlockPublicAccess.BLOCK_ALL,
+      encryption: s3.BucketEncryption.S3_MANAGED,
+      enforceSSL: true,
       removalPolicy: RemovalPolicy.RETAIN,
       autoDeleteObjects: false,
       lifecycleRules: [
@@ -41,6 +43,7 @@ export class RecipeStack extends Stack {
         {
           allowedMethods: [s3.HttpMethods.PUT],
           allowedOrigins: ['https://akli.dev'],
+          allowedHeaders: ['*'],
         },
       ],
     })

--- a/package.json
+++ b/package.json
@@ -13,8 +13,9 @@
   },
   "devDependencies": {
     "@aws-sdk/client-cognito-identity-provider": "^3.1026.0",
-    "@aws-sdk/client-dynamodb": "^3.1024.0",
-    "@aws-sdk/lib-dynamodb": "^3.1024.0",
+    "@aws-sdk/client-dynamodb": "^3.1027.0",
+    "@aws-sdk/client-s3": "^3.1027.0",
+    "@aws-sdk/lib-dynamodb": "^3.1027.0",
     "@aws-sdk/util-dynamodb": "^3.996.2",
     "@types/aws-lambda": "^8.10.161",
     "@types/jest": "^29.5.14",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "akli-infrastructure",
   "description": "Infrastructure as Code for akli.dev",
-  "version": "1.4.0",
+  "version": "1.5.0",
   "bin": {
     "akli-cdk": "bin/akli-cdk.js"
   },

--- a/package.json
+++ b/package.json
@@ -21,10 +21,12 @@
     "@types/aws-lambda": "^8.10.161",
     "@types/jest": "^29.5.14",
     "@types/node": "22.7.9",
+    "@types/sharp": "^0.32.0",
     "aws-cdk": "2.1016.1",
     "aws-sdk-client-mock": "^4.1.0",
     "esbuild": "^0.28.0",
     "jest": "^29.7.0",
+    "sharp": "^0.34.5",
     "ts-jest": "^29.2.5",
     "ts-node": "^10.9.2",
     "typescript": "~5.6.3"

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "@aws-sdk/client-dynamodb": "^3.1027.0",
     "@aws-sdk/client-s3": "^3.1027.0",
     "@aws-sdk/lib-dynamodb": "^3.1027.0",
+    "@aws-sdk/s3-request-presigner": "^3.1028.0",
     "@aws-sdk/util-dynamodb": "^3.996.2",
     "@types/aws-lambda": "^8.10.161",
     "@types/jest": "^29.5.14",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -30,6 +30,9 @@ importers:
       '@aws-sdk/lib-dynamodb':
         specifier: ^3.1027.0
         version: 3.1027.0(@aws-sdk/client-dynamodb@3.1027.0)
+      '@aws-sdk/s3-request-presigner':
+        specifier: ^3.1028.0
+        version: 3.1028.0
       '@aws-sdk/util-dynamodb':
         specifier: ^3.996.2
         version: 3.996.2(@aws-sdk/client-dynamodb@3.1027.0)
@@ -228,6 +231,10 @@ packages:
     resolution: {integrity: sha512-6Q8B1dcx6BBqUTY1Mc/eROKA0FImEEY5VPSd6AGPEUf0ErjExz4snVqa9kNJSoVDV1rKaNf3qrWojgcKW+SdDg==}
     engines: {node: '>=20.0.0'}
 
+  '@aws-sdk/s3-request-presigner@3.1028.0':
+    resolution: {integrity: sha512-T46EyIIHUaF/I2zhjtSUO4/87QdhqobClCscJawrxe2h/8nZJoO3DQDVZ4tMDl5UV/B5SPz6+xwki8jGylTF4Q==}
+    engines: {node: '>=20.0.0'}
+
   '@aws-sdk/signature-v4-multi-region@3.996.16':
     resolution: {integrity: sha512-EMdXYB4r/k5RWq86fugjRhid5JA+Z6MpS7n4sij4u5/C+STrkvuf9aFu41rJA9MjUzxCLzv8U2XL8cH2GSRYpQ==}
     engines: {node: '>=20.0.0'}
@@ -252,6 +259,10 @@ packages:
 
   '@aws-sdk/util-endpoints@3.996.6':
     resolution: {integrity: sha512-2nUQ+2ih7CShuKHpGSIYvvAIOHy52dOZguYG36zptBukhw6iFwcvGfG0tes0oZFWQqEWvgZe9HLWaNlvXGdOrg==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/util-format-url@3.972.9':
+    resolution: {integrity: sha512-fNJXHrs0ZT7Wx0KGIqKv7zLxlDXt2vqjx9z6oKUQFmpE5o4xxnSryvVHfHpIifYHWKz94hFccIldJ0YSZjlCBw==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/util-locate-window@3.965.5':
@@ -2513,6 +2524,17 @@ snapshots:
       '@smithy/types': 4.14.0
       tslib: 2.8.1
 
+  '@aws-sdk/s3-request-presigner@3.1028.0':
+    dependencies:
+      '@aws-sdk/signature-v4-multi-region': 3.996.16
+      '@aws-sdk/types': 3.973.7
+      '@aws-sdk/util-format-url': 3.972.9
+      '@smithy/middleware-endpoint': 4.4.29
+      '@smithy/protocol-http': 5.3.13
+      '@smithy/smithy-client': 4.12.9
+      '@smithy/types': 4.14.0
+      tslib: 2.8.1
+
   '@aws-sdk/signature-v4-multi-region@3.996.16':
     dependencies:
       '@aws-sdk/middleware-sdk-s3': 3.972.28
@@ -2554,6 +2576,13 @@ snapshots:
       '@smithy/types': 4.14.0
       '@smithy/url-parser': 4.2.13
       '@smithy/util-endpoints': 3.3.4
+      tslib: 2.8.1
+
+  '@aws-sdk/util-format-url@3.972.9':
+    dependencies:
+      '@aws-sdk/types': 3.973.7
+      '@smithy/querystring-builder': 4.2.13
+      '@smithy/types': 4.14.0
       tslib: 2.8.1
 
   '@aws-sdk/util-locate-window@3.965.5':

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -22,14 +22,17 @@ importers:
         specifier: ^3.1026.0
         version: 3.1026.0
       '@aws-sdk/client-dynamodb':
-        specifier: ^3.1024.0
-        version: 3.1024.0
+        specifier: ^3.1027.0
+        version: 3.1027.0
+      '@aws-sdk/client-s3':
+        specifier: ^3.1027.0
+        version: 3.1027.0
       '@aws-sdk/lib-dynamodb':
-        specifier: ^3.1024.0
-        version: 3.1024.0(@aws-sdk/client-dynamodb@3.1024.0)
+        specifier: ^3.1027.0
+        version: 3.1027.0(@aws-sdk/client-dynamodb@3.1027.0)
       '@aws-sdk/util-dynamodb':
         specifier: ^3.996.2
-        version: 3.996.2(@aws-sdk/client-dynamodb@3.1024.0)
+        version: 3.996.2(@aws-sdk/client-dynamodb@3.1027.0)
       '@types/aws-lambda':
         specifier: ^8.10.161
         version: 8.10.161
@@ -80,6 +83,16 @@ packages:
       - jsonschema
       - semver
 
+  '@aws-crypto/crc32@5.2.0':
+    resolution: {integrity: sha512-nLbCWqQNgUiwwtFsen1AdzAtvuLRsQS8rYgMuxCrdKf9kOssamGLuPwyTY9wyYblNr9+1XM8v6zoDTPPSIeANg==}
+    engines: {node: '>=16.0.0'}
+
+  '@aws-crypto/crc32c@5.2.0':
+    resolution: {integrity: sha512-+iWb8qaHLYKrNvGRbiYRHSdKRWhto5XlZUEBwDjYNf+ly5SVYG6zEoYIdxvf5R3zyeP16w4PLBn3rH1xc74Rag==}
+
+  '@aws-crypto/sha1-browser@5.2.0':
+    resolution: {integrity: sha512-OH6lveCFfcDjX4dbAvCFSYUjJZjDr/3XJ3xHtjn3Oj5b9RjojQo8npoLeA/bNwkOkrSQ0wgrHzXk4tDRxGKJeg==}
+
   '@aws-crypto/sha256-browser@5.2.0':
     resolution: {integrity: sha512-AXfN/lGotSQwu6HNcEsIASo7kWXZ5HYWvfOmSNKDsEqC4OashTp8alTmaz+F7TC2L083SFv5RdB+qU3Vs1kZqw==}
 
@@ -97,114 +110,94 @@ packages:
     resolution: {integrity: sha512-MXsI5MdbeF5AGxoJg0SZUnEXeEPK/Tj9xb8onSsK7uKQIoFM66wEBYQywc8KzqaOJEyqyZXoGUQ/R5XtJpwI5A==}
     engines: {node: '>=20.0.0'}
 
-  '@aws-sdk/client-dynamodb@3.1024.0':
-    resolution: {integrity: sha512-IJ4uM5i8z6hO7FRT7kngl/boqrZdyczxLKobCSHaxbFtxDu68QEfhn9D95FdkOENMmC2TIglnSlBqn5cG8qMTQ==}
+  '@aws-sdk/client-dynamodb@3.1027.0':
+    resolution: {integrity: sha512-tB+4nzxpfvUA7ZgIu/FaYFS9WPnRIf5KNVIuJnxxm5JXXx6nOnmcmHjsbFH9W9uye6AH2HcQtgSqZlKd8dR+IQ==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/client-s3@3.1027.0':
+    resolution: {integrity: sha512-g6kaFE/pW0Tsoq/BYg8PfXa1hIZQBmyoKtmJTgcbdyzYWiOOu8vj4PZUE2kS8myita6avaY8Ama5IodHJ39lPA==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/client-secrets-manager@3.1027.0':
     resolution: {integrity: sha512-LGg1htIt7/hx2WgQQjqsx+K0zyQytbZNSA6e96j4b20RuJU9g0VLpn8DItNPHNA+MDTseMr1lJizisY7eHgyLQ==}
     engines: {node: '>=20.0.0'}
 
-  '@aws-sdk/core@3.973.26':
-    resolution: {integrity: sha512-A/E6n2W42ruU+sfWk+mMUOyVXbsSgGrY3MJ9/0Az5qUdG67y8I6HYzzoAa+e/lzxxl1uCYmEL6BTMi9ZiZnplQ==}
-    engines: {node: '>=20.0.0'}
-
   '@aws-sdk/core@3.973.27':
     resolution: {integrity: sha512-CUZ5m8hwMCH6OYI4Li/WgMfIEx10Q2PLI9Y3XOUTPGZJ53aZ0007jCv+X/ywsaERyKPdw5MRZWk877roQksQ4A==}
     engines: {node: '>=20.0.0'}
 
-  '@aws-sdk/credential-provider-env@3.972.24':
-    resolution: {integrity: sha512-FWg8uFmT6vQM7VuzELzwVo5bzExGaKHdubn0StjgrcU5FvuLExUe+k06kn/40uKv59rYzhez8eFNM4yYE/Yb/w==}
+  '@aws-sdk/crc64-nvme@3.972.6':
+    resolution: {integrity: sha512-NMbiqKdruhwwgI6nzBVe2jWMkXjaoQz2YOs3rFX+2F3gGyrJDkDPwMpV/RsTFeq2vAQ055wZNtOXFK4NYSkM8g==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/credential-provider-env@3.972.25':
     resolution: {integrity: sha512-6QfI0wv4jpG5CrdO/AO0JfZ2ux+tKwJPrUwmvxXF50vI5KIypKVGNF6b4vlkYEnKumDTI1NX2zUBi8JoU5QU3A==}
     engines: {node: '>=20.0.0'}
 
-  '@aws-sdk/credential-provider-http@3.972.26':
-    resolution: {integrity: sha512-CY4ppZ+qHYqcXqBVi//sdHST1QK3KzOEiLtpLsc9W2k2vfZPKExGaQIsOwcyvjpjUEolotitmd3mUNY56IwDEA==}
-    engines: {node: '>=20.0.0'}
-
   '@aws-sdk/credential-provider-http@3.972.27':
     resolution: {integrity: sha512-3V3Usj9Gs93h865DqN4M2NWJhC5kXU9BvZskfN3+69omuYlE3TZxOEcVQtBGLOloJB7BVfJKXVLqeNhOzHqSlQ==}
-    engines: {node: '>=20.0.0'}
-
-  '@aws-sdk/credential-provider-ini@3.972.28':
-    resolution: {integrity: sha512-wXYvq3+uQcZV7k+bE4yDXCTBdzWTU9x/nMiKBfzInmv6yYK1veMK0AKvRfRBd72nGWYKcL6AxwiPg9z/pYlgpw==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/credential-provider-ini@3.972.29':
     resolution: {integrity: sha512-SiBuAnXecCbT/OpAf3vqyI/AVE3mTaYr9ShXLybxZiPLBiPCCOIWSGAtYYGQWMRvobBTiqOewaB+wcgMMZI2Aw==}
     engines: {node: '>=20.0.0'}
 
-  '@aws-sdk/credential-provider-login@3.972.28':
-    resolution: {integrity: sha512-ZSTfO6jqUTCysbdBPtEX5OUR//3rbD0lN7jO3sQeS2Gjr/Y+DT6SbIJ0oT2cemNw3UzKu97sNONd1CwNMthuZQ==}
-    engines: {node: '>=20.0.0'}
-
   '@aws-sdk/credential-provider-login@3.972.29':
     resolution: {integrity: sha512-OGOslTbOlxXexKMqhxCEbBQbUIfuhGxU5UXw3Fm56ypXHvrXH4aTt/xb5Y884LOoteP1QST1lVZzHfcTnWhiPQ==}
-    engines: {node: '>=20.0.0'}
-
-  '@aws-sdk/credential-provider-node@3.972.29':
-    resolution: {integrity: sha512-clSzDcvndpFJAggLDnDb36sPdlZYyEs5Zm6zgZjjUhwsJgSWiWKwFIXUVBcbruidNyBdbpOv2tNDL9sX8y3/0g==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/credential-provider-node@3.972.30':
     resolution: {integrity: sha512-FMnAnWxc8PG+ZrZ2OBKzY4luCUJhe9CG0B9YwYr4pzrYGLXBS2rl+UoUvjGbAwiptxRL6hyA3lFn03Bv1TLqTw==}
     engines: {node: '>=20.0.0'}
 
-  '@aws-sdk/credential-provider-process@3.972.24':
-    resolution: {integrity: sha512-Q2k/XLrFXhEztPHqj4SLCNID3hEPdlhh1CDLBpNnM+1L8fq7P+yON9/9M1IGN/dA5W45v44ylERfXtDAlmMNmw==}
-    engines: {node: '>=20.0.0'}
-
   '@aws-sdk/credential-provider-process@3.972.25':
     resolution: {integrity: sha512-HR7ynNRdNhNsdVCOCegy1HsfsRzozCOPtD3RzzT1JouuaHobWyRfJzCBue/3jP7gECHt+kQyZUvwg/cYLWurNQ==}
-    engines: {node: '>=20.0.0'}
-
-  '@aws-sdk/credential-provider-sso@3.972.28':
-    resolution: {integrity: sha512-IoUlmKMLEITFn1SiCTjPfR6KrE799FBo5baWyk/5Ppar2yXZoUdaRqZzJzK6TcJxx450M8m8DbpddRVYlp5R/A==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/credential-provider-sso@3.972.29':
     resolution: {integrity: sha512-HWv4SEq3jZDYPlwryZVef97+U8CxxRos5mK8sgGO1dQaFZpV5giZLzqGE5hkDmh2csYcBO2uf5XHjPTpZcJlig==}
     engines: {node: '>=20.0.0'}
 
-  '@aws-sdk/credential-provider-web-identity@3.972.28':
-    resolution: {integrity: sha512-d+6h0SD8GGERzKe27v5rOzNGKOl0D+l0bWJdqrxH8WSQzHzjsQFIAPgIeOTUwBHVsKKwtSxc91K/SWax6XgswQ==}
-    engines: {node: '>=20.0.0'}
-
   '@aws-sdk/credential-provider-web-identity@3.972.29':
     resolution: {integrity: sha512-PdMBza1WEKEUPFEmMGCfnU2RYCz9MskU2e8JxjyUOsMKku7j9YaDKvbDi2dzC0ihFoM6ods2SbhfAAro+Gwlew==}
     engines: {node: '>=20.0.0'}
 
-  '@aws-sdk/dynamodb-codec@3.972.27':
-    resolution: {integrity: sha512-S7IWE0K+aqbvjP8PHnOyDJK1fzrazAismH5XutJtS3YBvRvmfLb8Ac7Z1ZC4LBWvO8Gx1t/szFe46K51FqZn/A==}
+  '@aws-sdk/dynamodb-codec@3.972.28':
+    resolution: {integrity: sha512-wx5jKLKPVJRsr/dwK9Xp26+SDb95xHlZU9Bgm2AglnMxQ0DlRlq3PyKlGi9y0OCuWZ7hLNcQJ7uDSN+PgsiuGg==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/endpoint-cache@3.972.5':
     resolution: {integrity: sha512-itVdge0NozgtgmtbZ25FVwWU3vGlE7x7feE/aOEJNkQfEpbkrF8Rj1QmnK+2blFfYE1xWt/iU+6/jUp/pv1+MA==}
     engines: {node: '>=20.0.0'}
 
-  '@aws-sdk/lib-dynamodb@3.1024.0':
-    resolution: {integrity: sha512-J4OX8F/XUZK+njHQnFXL+geZ/JPOMm67kKuKPy8duve31TwpyOhNMEgYQj8AympS+SWPKxmTw6W1RmkXLimuGA==}
+  '@aws-sdk/lib-dynamodb@3.1027.0':
+    resolution: {integrity: sha512-YOgLnzMOYHaZj+XstObbRDDrQSDr8n+xFMNAGX28fF2H9aUKilQGG5z8Jjk0t0HbCI1kJR4fULMFjAnFERfDFQ==}
     engines: {node: '>=20.0.0'}
     peerDependencies:
-      '@aws-sdk/client-dynamodb': ^3.1024.0
+      '@aws-sdk/client-dynamodb': ^3.1027.0
 
-  '@aws-sdk/middleware-endpoint-discovery@3.972.9':
-    resolution: {integrity: sha512-1503Y5Xk14SdXY0ucXwc08CY+aVuoY1tmQxsR/apwAVAwcLT7FFzqjYJYLq8JOkKJyzIB8M6J27e1ZcagGK+Fg==}
+  '@aws-sdk/middleware-bucket-endpoint@3.972.9':
+    resolution: {integrity: sha512-COToYKgquDyligbcAep7ygs48RK+mwe/IYprq4+TSrVFzNOYmzWvHf6werpnKV5VYpRiwdn+Wa5ZXkPqLVwcTg==}
     engines: {node: '>=20.0.0'}
 
-  '@aws-sdk/middleware-host-header@3.972.8':
-    resolution: {integrity: sha512-wAr2REfKsqoKQ+OkNqvOShnBoh+nkPurDKW7uAeVSu6kUECnWlSJiPvnoqxGlfousEY/v9LfS9sNc46hjSYDIQ==}
+  '@aws-sdk/middleware-endpoint-discovery@3.972.10':
+    resolution: {integrity: sha512-b3hf8dPxWonxFKgxBijMehVblgbY0gPprTvyuHYMxnOPfiCIY467kZltPoeOCQYLr9v0v0HuL9fIGtT6utd15w==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/middleware-expect-continue@3.972.9':
+    resolution: {integrity: sha512-V/FNCjFxnh4VGu+HdSiW4Yg5GELihA1MIDSAdsEPvuayXBVmr0Jaa6jdLAZLH38KYXl/vVjri9DQJWnTAujHEA==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/middleware-flexible-checksums@3.974.7':
+    resolution: {integrity: sha512-uU4/ch2CLHB8Phu1oTKnnQ4e8Ujqi49zEnQYBhWYT53zfFvtJCdGsaOoypBr8Fm/pmCBssRmGoIQ4sixgdLP9w==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/middleware-host-header@3.972.9':
     resolution: {integrity: sha512-je5vRdNw4SkuTnmRbFZLdye4sQ0faLt8kwka5wnnSU30q1mHO4X+idGEJOOE+Tn1ME7Oryn05xxkDvIb3UaLaQ==}
     engines: {node: '>=20.0.0'}
 
-  '@aws-sdk/middleware-logger@3.972.8':
-    resolution: {integrity: sha512-CWl5UCM57WUFaFi5kB7IBY1UmOeLvNZAZ2/OZ5l20ldiJ3TiIz1pC65gYj8X0BCPWkeR1E32mpsCk1L1I4n+lA==}
+  '@aws-sdk/middleware-location-constraint@3.972.9':
+    resolution: {integrity: sha512-TyfOi2XNdOZpNKeTJwRUsVAGa+14nkyMb2VVGG+eDgcWG/ed6+NUo72N3hT6QJioxym80NSinErD+LBRF0Ir1w==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/middleware-logger@3.972.9':
@@ -215,48 +208,40 @@ packages:
     resolution: {integrity: sha512-RVQQbq5orQ/GHUnXvqEOj2HHPBJm+mM+ySwZKS5UaLBwra5ugRtiH09PLUoOZRl7a1YzaOzXSuGbn9iD5j60WQ==}
     engines: {node: '>=20.0.0'}
 
-  '@aws-sdk/middleware-recursion-detection@3.972.9':
-    resolution: {integrity: sha512-/Wt5+CT8dpTFQxEJ9iGy/UGrXr7p2wlIOEHvIr/YcHYByzoLjrqkYqXdJjd9UIgWjv7eqV2HnFJen93UTuwfTQ==}
+  '@aws-sdk/middleware-sdk-s3@3.972.28':
+    resolution: {integrity: sha512-qJHcJQH9UNPUrnPlRtCozKjtqAaypQ5IgQxTNoPsVYIQeuwNIA8Rwt3NvGij1vCDYDfCmZaPLpnJEHlZXeFqmg==}
     engines: {node: '>=20.0.0'}
 
-  '@aws-sdk/middleware-user-agent@3.972.28':
-    resolution: {integrity: sha512-cfWZFlVh7Va9lRay4PN2A9ARFzaBYcA097InT5M2CdRS05ECF5yaz86jET8Wsl2WcyKYEvVr/QNmKtYtafUHtQ==}
+  '@aws-sdk/middleware-ssec@3.972.9':
+    resolution: {integrity: sha512-wSA2BR7L0CyBNDJeSrleIIzC+DzL93YNTdfU0KPGLiocK6YsRv1nPAzPF+BFSdcs0Qa5ku5Kcf4KvQcWwKGenQ==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/middleware-user-agent@3.972.29':
     resolution: {integrity: sha512-f/sIRzuTfEjg6NsbMYvye2VsmnQoNgntntleQyx5uGacUYzszbfIlO3GcI6G6daWUmTm0IDZc11qMHWwF0o0mQ==}
     engines: {node: '>=20.0.0'}
 
-  '@aws-sdk/nested-clients@3.996.18':
-    resolution: {integrity: sha512-c7ZSIXrESxHKx2Mcopgd8AlzZgoXMr20fkx5ViPWPOLBvmyhw9VwJx/Govg8Ef/IhEon5R9l53Z8fdYSEmp6VA==}
-    engines: {node: '>=20.0.0'}
-
   '@aws-sdk/nested-clients@3.996.19':
     resolution: {integrity: sha512-uFkmCDXvmQYLanlYdOFS0+MQWkrj9wPMt/ZCc/0J0fjPim6F5jBVBmEomvGY/j77ILW6GTPwN22Jc174Mhkw6Q==}
-    engines: {node: '>=20.0.0'}
-
-  '@aws-sdk/region-config-resolver@3.972.10':
-    resolution: {integrity: sha512-1dq9ToC6e070QvnVhhbAs3bb5r6cQ10gTVc6cyRV5uvQe7P138TV2uG2i6+Yok4bAkVAcx5AqkTEBUvWEtBlsQ==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/region-config-resolver@3.972.11':
     resolution: {integrity: sha512-6Q8B1dcx6BBqUTY1Mc/eROKA0FImEEY5VPSd6AGPEUf0ErjExz4snVqa9kNJSoVDV1rKaNf3qrWojgcKW+SdDg==}
     engines: {node: '>=20.0.0'}
 
-  '@aws-sdk/token-providers@3.1021.0':
-    resolution: {integrity: sha512-TKY6h9spUk3OLs5v1oAgW9mAeBE3LAGNBwJokLy96wwmd4W2v/tYlXseProyed9ValDj2u1jK/4Rg1T+1NXyJA==}
+  '@aws-sdk/signature-v4-multi-region@3.996.16':
+    resolution: {integrity: sha512-EMdXYB4r/k5RWq86fugjRhid5JA+Z6MpS7n4sij4u5/C+STrkvuf9aFu41rJA9MjUzxCLzv8U2XL8cH2GSRYpQ==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/token-providers@3.1026.0':
     resolution: {integrity: sha512-Ieq/HiRrbEtrYP387Nes0XlR7H1pJiJOZKv+QyQzMYpvTiDs0VKy2ZB3E2Zf+aFovWmeE7lRE4lXyF7dYM6GgA==}
     engines: {node: '>=20.0.0'}
 
-  '@aws-sdk/types@3.973.6':
-    resolution: {integrity: sha512-Atfcy4E++beKtwJHiDln2Nby8W/mam64opFPTiHEqgsthqeydFS1pY+OUlN1ouNOmf8ArPU/6cDS65anOP3KQw==}
-    engines: {node: '>=20.0.0'}
-
   '@aws-sdk/types@3.973.7':
     resolution: {integrity: sha512-reXRwoJ6CfChoqAsBszUYajAF8Z2LRE+CRcKocvFSMpIiLOtYU3aJ9trmn6VVPAzbbY5LXF+FfmUslbXk1SYFg==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/util-arn-parser@3.972.3':
+    resolution: {integrity: sha512-HzSD8PMFrvgi2Kserxuff5VitNq2sgf3w9qxmskKDiDTThWfVteJxuCS9JXiPIPtmCrp+7N9asfIaVhBFORllA==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/util-dynamodb@3.996.2':
@@ -264,10 +249,6 @@ packages:
     engines: {node: '>=20.0.0'}
     peerDependencies:
       '@aws-sdk/client-dynamodb': ^3.1003.0
-
-  '@aws-sdk/util-endpoints@3.996.5':
-    resolution: {integrity: sha512-Uh93L5sXFNbyR5sEPMzUU8tJ++Ku97EY4udmC01nB8Zu+xfBPwpIwJ6F7snqQeq8h2pf+8SGN5/NoytfKgYPIw==}
-    engines: {node: '>=20.0.0'}
 
   '@aws-sdk/util-endpoints@3.996.6':
     resolution: {integrity: sha512-2nUQ+2ih7CShuKHpGSIYvvAIOHy52dOZguYG36zptBukhw6iFwcvGfG0tes0oZFWQqEWvgZe9HLWaNlvXGdOrg==}
@@ -277,20 +258,8 @@ packages:
     resolution: {integrity: sha512-WhlJNNINQB+9qtLtZJcpQdgZw3SCDCpXdUJP7cToGwHbCWCnRckGlc6Bx/OhWwIYFNAn+FIydY8SZ0QmVu3xTQ==}
     engines: {node: '>=20.0.0'}
 
-  '@aws-sdk/util-user-agent-browser@3.972.8':
-    resolution: {integrity: sha512-B3KGXJviV2u6Cdw2SDY2aDhoJkVfY/Q/Trwk2CMSkikE1Oi6gRzxhvhIfiRpHfmIsAhV4EA54TVEX8K6CbHbkA==}
-
   '@aws-sdk/util-user-agent-browser@3.972.9':
     resolution: {integrity: sha512-sn/LMzTbGjYqCCF24390WxPd6hkpoSptiUn5DzVp4cD71yqw+yGEGm1YCxyEoPXyc8qciM8UzLJcZBFslxo5Uw==}
-
-  '@aws-sdk/util-user-agent-node@3.973.14':
-    resolution: {integrity: sha512-vNSB/DYaPOyujVZBg/zUznH9QC142MaTHVmaFlF7uzzfg3CgT9f/l4C0Yi+vU/tbBhxVcXVB90Oohk5+o+ZbWw==}
-    engines: {node: '>=20.0.0'}
-    peerDependencies:
-      aws-crt: '>=1.0.0'
-    peerDependenciesMeta:
-      aws-crt:
-        optional: true
 
   '@aws-sdk/util-user-agent-node@3.973.15':
     resolution: {integrity: sha512-fYn3s9PtKdgQkczGZCFMgkNEe8aq1JCVbnRqjqN9RSVW43xn2RV9xdcZ3z01a48Jpkuh/xCmBKJxdLOo4Ozg7w==}
@@ -300,10 +269,6 @@ packages:
     peerDependenciesMeta:
       aws-crt:
         optional: true
-
-  '@aws-sdk/xml-builder@3.972.16':
-    resolution: {integrity: sha512-iu2pyvaqmeatIJLURLqx9D+4jKAdTH20ntzB6BFwjyN7V960r4jK32mx0Zf7YbtOYAbmbtQfDNuL60ONinyw7A==}
-    engines: {node: '>=20.0.0'}
 
   '@aws-sdk/xml-builder@3.972.17':
     resolution: {integrity: sha512-Ra7hjqAZf1OXRRMueB13qex7mFJRDK/pgCvdSFemXBT8KCGnQDPoKzHY1SjN+TjJVmnpSF14W5tJ1vDamFu+Gg==}
@@ -747,48 +712,60 @@ packages:
   '@sinonjs/samsam@8.0.3':
     resolution: {integrity: sha512-hw6HbX+GyVZzmaYNh82Ecj1vdGZrqVIn/keDTg63IgAwiQPO+xCz99uG6Woqgb4tM0mUiFENKZ4cqd7IX94AXQ==}
 
-  '@smithy/config-resolver@4.4.13':
-    resolution: {integrity: sha512-iIzMC5NmOUP6WL6o8iPBjFhUhBZ9pPjpUpQYWMUFQqKyXXzOftbfK8zcQCz/jFV1Psmf05BK5ypx4K2r4Tnwdg==}
+  '@smithy/chunked-blob-reader-native@4.2.3':
+    resolution: {integrity: sha512-jA5k5Udn7Y5717L86h4EIv06wIr3xn8GM1qHRi/Nf31annXcXHJjBKvgztnbn2TxH3xWrPBfgwHsOwZf0UmQWw==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/chunked-blob-reader@5.2.2':
+    resolution: {integrity: sha512-St+kVicSyayWQca+I1rGitaOEH6uKgE8IUWoYnnEX26SWdWQcL6LvMSD19Lg+vYHKdT9B2Zuu7rd3i6Wnyb/iw==}
     engines: {node: '>=18.0.0'}
 
   '@smithy/config-resolver@4.4.14':
     resolution: {integrity: sha512-N55f8mPEccpzKetUagdvmAy8oohf0J5cuj9jLI1TaSceRlq0pJsIZepY3kmAXAhyxqXPV6hDerDQhqQPKWgAoQ==}
     engines: {node: '>=18.0.0'}
 
-  '@smithy/core@3.23.13':
-    resolution: {integrity: sha512-J+2TT9D6oGsUVXVEMvz8h2EmdVnkBiy2auCie4aSJMvKlzUtO5hqjEzXhoCUkIMo7gAYjbQcN0g/MMSXEhDs1Q==}
-    engines: {node: '>=18.0.0'}
-
   '@smithy/core@3.23.14':
     resolution: {integrity: sha512-vJ0IhpZxZAkFYOegMKSrxw7ujhhT2pass/1UEcZ4kfl5srTAqtPU5I7MdYQoreVas3204ykCiNhY1o7Xlz6Yyg==}
-    engines: {node: '>=18.0.0'}
-
-  '@smithy/credential-provider-imds@4.2.12':
-    resolution: {integrity: sha512-cr2lR792vNZcYMriSIj+Um3x9KWrjcu98kn234xA6reOAFMmbRpQMOv8KPgEmLLtx3eldU6c5wALKFqNOhugmg==}
     engines: {node: '>=18.0.0'}
 
   '@smithy/credential-provider-imds@4.2.13':
     resolution: {integrity: sha512-wboCPijzf6RJKLOvnjDAiBxGSmSnGXj35o5ZAWKDaHa/cvQ5U3ZJ13D4tMCE8JG4dxVAZFy/P0x/V9CwwdfULQ==}
     engines: {node: '>=18.0.0'}
 
-  '@smithy/fetch-http-handler@5.3.15':
-    resolution: {integrity: sha512-T4jFU5N/yiIfrtrsb9uOQn7RdELdM/7HbyLNr6uO/mpkj1ctiVs7CihVr51w4LyQlXWDpXFn4BElf1WmQvZu/A==}
+  '@smithy/eventstream-codec@4.2.13':
+    resolution: {integrity: sha512-vYahwBAtRaAcFbOmE9aLr12z7RiHYDSLcnogSdxfm7kKfsNa3wH+NU5r7vTeB5rKvLsWyPjVX8iH94brP7umiQ==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/eventstream-serde-browser@4.2.13':
+    resolution: {integrity: sha512-wwybfcOX0tLqCcBP378TIU9IqrDuZq/tDV48LlZNydMpCnqnYr+hWBAYbRE+rFFf/p7IkDJySM3bgiMKP2ihPg==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/eventstream-serde-config-resolver@4.3.13':
+    resolution: {integrity: sha512-ied1lO559PtAsMJzg2TKRlctLnEi1PfkNeMMpdwXDImk1zV9uvS/Oxoy/vcy9uv1GKZAjDAB5xT6ziE9fzm5wA==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/eventstream-serde-node@4.2.13':
+    resolution: {integrity: sha512-hFyK+ORJrxAN3RYoaD6+gsGDQjeix8HOEkosoajvXYZ4VeqonM3G4jd9IIRm/sWGXUKmudkY9KdYjzosUqdM8A==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/eventstream-serde-universal@4.2.13':
+    resolution: {integrity: sha512-kRrq4EKLGeOxhC2CBEhRNcu1KSzNJzYY7RK3S7CxMPgB5dRrv55WqQOtRwQxQLC04xqORFLUgnDlc6xrNUULaA==}
     engines: {node: '>=18.0.0'}
 
   '@smithy/fetch-http-handler@5.3.16':
     resolution: {integrity: sha512-nYDRUIvNd4mFmuXraRWt6w5UsZTNqtj4hXJA/iiOD4tuseIdLP9Lq38teH/SZTcIFCa2f+27o7hYpIsWktJKEQ==}
     engines: {node: '>=18.0.0'}
 
-  '@smithy/hash-node@4.2.12':
-    resolution: {integrity: sha512-QhBYbGrbxTkZ43QoTPrK72DoYviDeg6YKDrHTMJbbC+A0sml3kSjzFtXP7BtbyJnXojLfTQldGdUR0RGD8dA3w==}
+  '@smithy/hash-blob-browser@4.2.14':
+    resolution: {integrity: sha512-rtQ5es8r/5v4rav7q5QTsfx9CtCyzrz/g7ZZZBH2xtMmd6G/KQrLOWfSHTvFOUPlVy59RQvxeBYJaLRoybMEyA==}
     engines: {node: '>=18.0.0'}
 
   '@smithy/hash-node@4.2.13':
     resolution: {integrity: sha512-4/oy9h0jjmY80a2gOIo75iLl8TOPhmtx4E2Hz+PfMjvx/vLtGY4TMU/35WRyH2JHPfT5CVB38u4JRow7gnmzJA==}
     engines: {node: '>=18.0.0'}
 
-  '@smithy/invalid-dependency@4.2.12':
-    resolution: {integrity: sha512-/4F1zb7Z8LOu1PalTdESFHR0RbPwHd3FcaG1sI3UEIriQTWakysgJr65lc1jj6QY5ye7aFsisajotH6UhWfm/g==}
+  '@smithy/hash-stream-node@4.2.13':
+    resolution: {integrity: sha512-WdQ7HwUjINXETeh6dqUeob1UHIYx8kAn9PSp1HhM2WWegiZBYVy2WXIs1lB07SZLan/udys9SBnQGt9MQbDpdg==}
     engines: {node: '>=18.0.0'}
 
   '@smithy/invalid-dependency@4.2.13':
@@ -803,136 +780,72 @@ packages:
     resolution: {integrity: sha512-n6rQ4N8Jj4YTQO3YFrlgZuwKodf4zUFs7EJIWH86pSCWBaAtAGBFfCM7Wx6D2bBJ2xqFNxGBSrUWswT3M0VJow==}
     engines: {node: '>=18.0.0'}
 
-  '@smithy/middleware-content-length@4.2.12':
-    resolution: {integrity: sha512-YE58Yz+cvFInWI/wOTrB+DbvUVz/pLn5mC5MvOV4fdRUc6qGwygyngcucRQjAhiCEbmfLOXX0gntSIcgMvAjmA==}
+  '@smithy/md5-js@4.2.13':
+    resolution: {integrity: sha512-cNm7I9NXolFxtS20ojROddOEpSAeI1Obq6pd1Kj5HtHws3s9Fkk8DdHDfQSs5KuxCewZuVK6UqrJnfJmiMzDuQ==}
     engines: {node: '>=18.0.0'}
 
   '@smithy/middleware-content-length@4.2.13':
     resolution: {integrity: sha512-IPMLm/LE4AZwu6qiE8Rr8vJsWhs9AtOdySRXrOM7xnvclp77Tyh7hMs/FRrMf26kgIe67vFJXXOSmVxS7oKeig==}
     engines: {node: '>=18.0.0'}
 
-  '@smithy/middleware-endpoint@4.4.28':
-    resolution: {integrity: sha512-p1gfYpi91CHcs5cBq982UlGlDrxoYUX6XdHSo91cQ2KFuz6QloHosO7Jc60pJiVmkWrKOV8kFYlGFFbQ2WUKKQ==}
-    engines: {node: '>=18.0.0'}
-
   '@smithy/middleware-endpoint@4.4.29':
     resolution: {integrity: sha512-R9Q/58U+qBiSARGWbAbFLczECg/RmysRksX6Q8BaQEpt75I7LI6WGDZnjuC9GXSGKljEbA7N118LhGaMbfrTXw==}
-    engines: {node: '>=18.0.0'}
-
-  '@smithy/middleware-retry@4.4.46':
-    resolution: {integrity: sha512-SpvWNNOPOrKQGUqZbEPO+es+FRXMWvIyzUKUOYdDgdlA6BdZj/R58p4umoQ76c2oJC44PiM7mKizyyex1IJzow==}
     engines: {node: '>=18.0.0'}
 
   '@smithy/middleware-retry@4.5.0':
     resolution: {integrity: sha512-/NzISn4grj/BRFVua/xnQwF+7fakYZgimpw2dfmlPgcqecBMKxpB9g5mLYRrmBD5OrPoODokw4Vi1hrSR4zRyw==}
     engines: {node: '>=18.0.0'}
 
-  '@smithy/middleware-serde@4.2.16':
-    resolution: {integrity: sha512-beqfV+RZ9RSv+sQqor3xroUUYgRFCGRw6niGstPG8zO9LgTl0B0MCucxjmrH/2WwksQN7UUgI7KNANoZv+KALA==}
-    engines: {node: '>=18.0.0'}
-
   '@smithy/middleware-serde@4.2.17':
     resolution: {integrity: sha512-0T2mcaM6v9W1xku86Dk0bEW7aEseG6KenFkPK98XNw0ZhOqOiD1MrMsdnQw9QsL3/Oa85T53iSMlm0SZdSuIEQ==}
-    engines: {node: '>=18.0.0'}
-
-  '@smithy/middleware-stack@4.2.12':
-    resolution: {integrity: sha512-kruC5gRHwsCOuyCd4ouQxYjgRAym2uDlCvQ5acuMtRrcdfg7mFBg6blaxcJ09STpt3ziEkis6bhg1uwrWU7txw==}
     engines: {node: '>=18.0.0'}
 
   '@smithy/middleware-stack@4.2.13':
     resolution: {integrity: sha512-g72jN/sGDLyTanrCLH9fhg3oysO3f7tQa6eWWsMyn2BiYNCgjF24n4/I9wff/5XidFvjj9ilipAoQrurTUrLvw==}
     engines: {node: '>=18.0.0'}
 
-  '@smithy/node-config-provider@4.3.12':
-    resolution: {integrity: sha512-tr2oKX2xMcO+rBOjobSwVAkV05SIfUKz8iI53rzxEmgW3GOOPOv0UioSDk+J8OpRQnpnhsO3Af6IEBabQBVmiw==}
-    engines: {node: '>=18.0.0'}
-
   '@smithy/node-config-provider@4.3.13':
     resolution: {integrity: sha512-iGxQ04DsKXLckbgnX4ipElrOTk+IHgTyu0q0WssZfYhDm9CQWHmu6cOeI5wmWRxpXbBDhIIfXMWz5tPEtcVqbw==}
-    engines: {node: '>=18.0.0'}
-
-  '@smithy/node-http-handler@4.5.1':
-    resolution: {integrity: sha512-ejjxdAXjkPIs9lyYyVutOGNOraqUE9v/NjGMKwwFrfOM354wfSD8lmlj8hVwUzQmlLLF4+udhfCX9Exnbmvfzw==}
     engines: {node: '>=18.0.0'}
 
   '@smithy/node-http-handler@4.5.2':
     resolution: {integrity: sha512-/oD7u8M0oj2ZTFw7GkuuHWpIxtWdLlnyNkbrWcyVYhd5RJNDuczdkb0wfnQICyNFrVPlr8YHOhamjNy3zidhmA==}
     engines: {node: '>=18.0.0'}
 
-  '@smithy/property-provider@4.2.12':
-    resolution: {integrity: sha512-jqve46eYU1v7pZ5BM+fmkbq3DerkSluPr5EhvOcHxygxzD05ByDRppRwRPPpFrsFo5yDtCYLKu+kreHKVrvc7A==}
-    engines: {node: '>=18.0.0'}
-
   '@smithy/property-provider@4.2.13':
     resolution: {integrity: sha512-bGzUCthxRmezuxkbu9wD33wWg9KX3hJpCXpQ93vVkPrHn9ZW6KNNdY5xAUWNuRCwQ+VyboFuWirG1lZhhkcyRQ==}
-    engines: {node: '>=18.0.0'}
-
-  '@smithy/protocol-http@5.3.12':
-    resolution: {integrity: sha512-fit0GZK9I1xoRlR4jXmbLhoN0OdEpa96ul8M65XdmXnxXkuMxM0Y8HDT0Fh0Xb4I85MBvBClOzgSrV1X2s1Hxw==}
     engines: {node: '>=18.0.0'}
 
   '@smithy/protocol-http@5.3.13':
     resolution: {integrity: sha512-+HsmuJUF4u8POo6s8/a2Yb/AQ5t/YgLovCuHF9oxbocqv+SZ6gd8lC2duBFiCA/vFHoHQhoq7QjqJqZC6xOxxg==}
     engines: {node: '>=18.0.0'}
 
-  '@smithy/querystring-builder@4.2.12':
-    resolution: {integrity: sha512-6wTZjGABQufekycfDGMEB84BgtdOE/rCVTov+EDXQ8NHKTUNIp/j27IliwP7tjIU9LR+sSzyGBOXjeEtVgzCHg==}
-    engines: {node: '>=18.0.0'}
-
   '@smithy/querystring-builder@4.2.13':
     resolution: {integrity: sha512-tG4aOYFCZdPMjbgfhnIQ322H//ojujldp1SrHPHpBSb3NqgUp3dwiUGRJzie87hS1DYwWGqDuPaowoDF+rYCbQ==}
-    engines: {node: '>=18.0.0'}
-
-  '@smithy/querystring-parser@4.2.12':
-    resolution: {integrity: sha512-P2OdvrgiAKpkPNKlKUtWbNZKB1XjPxM086NeVhK+W+wI46pIKdWBe5QyXvhUm3MEcyS/rkLvY8rZzyUdmyDZBw==}
     engines: {node: '>=18.0.0'}
 
   '@smithy/querystring-parser@4.2.13':
     resolution: {integrity: sha512-hqW3Q4P+CDzUyQ87GrboGMeD7XYNMOF+CuTwu936UQRB/zeYn3jys8C3w+wMkDfY7CyyyVwZQ5cNFoG0x1pYmA==}
     engines: {node: '>=18.0.0'}
 
-  '@smithy/service-error-classification@4.2.12':
-    resolution: {integrity: sha512-LlP29oSQN0Tw0b6D0Xo6BIikBswuIiGYbRACy5ujw/JgWSzTdYj46U83ssf6Ux0GyNJVivs2uReU8pt7Eu9okQ==}
-    engines: {node: '>=18.0.0'}
-
   '@smithy/service-error-classification@4.2.13':
     resolution: {integrity: sha512-a0s8XZMfOC/qpqq7RCPvJlk93rWFrElH6O++8WJKz0FqnA4Y7fkNi/0mnGgSH1C4x6MFsuBA8VKu4zxFrMe5Vw==}
-    engines: {node: '>=18.0.0'}
-
-  '@smithy/shared-ini-file-loader@4.4.7':
-    resolution: {integrity: sha512-HrOKWsUb+otTeo1HxVWeEb99t5ER1XrBi/xka2Wv6NVmTbuCUC1dvlrksdvxFtODLBjsC+PHK+fuy2x/7Ynyiw==}
     engines: {node: '>=18.0.0'}
 
   '@smithy/shared-ini-file-loader@4.4.8':
     resolution: {integrity: sha512-VZCZx2bZasxdqxVgEAhREvDSlkatTPnkdWy1+Kiy8w7kYPBosW0V5IeDwzDUMvWBt56zpK658rx1cOBFOYaPaw==}
     engines: {node: '>=18.0.0'}
 
-  '@smithy/signature-v4@5.3.12':
-    resolution: {integrity: sha512-B/FBwO3MVOL00DaRSXfXfa/TRXRheagt/q5A2NM13u7q+sHS59EOVGQNfG7DkmVtdQm5m3vOosoKAXSqn/OEgw==}
-    engines: {node: '>=18.0.0'}
-
   '@smithy/signature-v4@5.3.13':
     resolution: {integrity: sha512-YpYSyM0vMDwKbHD/JA7bVOF6kToVRpa+FM5ateEVRpsTNu564g1muBlkTubXhSKKYXInhpADF46FPyrZcTLpXg==}
-    engines: {node: '>=18.0.0'}
-
-  '@smithy/smithy-client@4.12.8':
-    resolution: {integrity: sha512-aJaAX7vHe5i66smoSSID7t4rKY08PbD8EBU7DOloixvhOozfYWdcSYE4l6/tjkZ0vBZhGjheWzB2mh31sLgCMA==}
     engines: {node: '>=18.0.0'}
 
   '@smithy/smithy-client@4.12.9':
     resolution: {integrity: sha512-ovaLEcTU5olSeHcRXcxV6viaKtpkHZumn6Ps0yn7dRf2rRSfy794vpjOtrWDO0d1auDSvAqxO+lyhERSXQ03EQ==}
     engines: {node: '>=18.0.0'}
 
-  '@smithy/types@4.13.1':
-    resolution: {integrity: sha512-787F3yzE2UiJIQ+wYW1CVg2odHjmaWLGksnKQHUrK/lYZSEcy1msuLVvxaR/sI2/aDe9U+TBuLsXnr3vod1g0g==}
-    engines: {node: '>=18.0.0'}
-
   '@smithy/types@4.14.0':
     resolution: {integrity: sha512-OWgntFLW88kx2qvf/c/67Vno1yuXm/f9M7QFAtVkkO29IJXGBIg0ycEaBTH0kvCtwmvZxRujrgP5a86RvsXJAQ==}
-    engines: {node: '>=18.0.0'}
-
-  '@smithy/url-parser@4.2.12':
-    resolution: {integrity: sha512-wOPKPEpso+doCZGIlr+e1lVI6+9VAKfL4kZWFgzVgGWY2hZxshNKod4l2LXS3PRC9otH/JRSjtEHqQ/7eLciRA==}
     engines: {node: '>=18.0.0'}
 
   '@smithy/url-parser@4.2.13':
@@ -963,24 +876,12 @@ packages:
     resolution: {integrity: sha512-dWU03V3XUprJwaUIFVv4iOnS1FC9HnMHDfUrlNDSh4315v0cWyaIErP8KiqGVbf5z+JupoVpNM7ZB3jFiTejvQ==}
     engines: {node: '>=18.0.0'}
 
-  '@smithy/util-defaults-mode-browser@4.3.44':
-    resolution: {integrity: sha512-eZg6XzaCbVr2S5cAErU5eGBDaOVTuTo1I65i4tQcHENRcZ8rMWhQy1DaIYUSLyZjsfXvmCqZrstSMYyGFocvHA==}
-    engines: {node: '>=18.0.0'}
-
   '@smithy/util-defaults-mode-browser@4.3.45':
     resolution: {integrity: sha512-ag9sWc6/nWZAuK3Wm9KlFJUnRkXLrXn33RFjIAmCTFThqLHY+7wCst10BGq56FxslsDrjhSie46c8OULS+BiIw==}
     engines: {node: '>=18.0.0'}
 
-  '@smithy/util-defaults-mode-node@4.2.48':
-    resolution: {integrity: sha512-FqOKTlqSaoV3nzO55pMs5NBnZX8EhoI0DGmn9kbYeXWppgHD6dchyuj2HLqp4INJDJbSrj6OFYJkAh/WhSzZPg==}
-    engines: {node: '>=18.0.0'}
-
   '@smithy/util-defaults-mode-node@4.2.49':
     resolution: {integrity: sha512-jlN6vHwE8gY5AfiFBavtD3QtCX2f7lM3BKkz7nFKSNfFR5nXLXLg6sqXTJEEyDwtxbztIDBQCfjsGVXlIru2lQ==}
-    engines: {node: '>=18.0.0'}
-
-  '@smithy/util-endpoints@3.3.3':
-    resolution: {integrity: sha512-VACQVe50j0HZPjpwWcjyT51KUQ4AnsvEaQ2lKHOSL4mNLD0G9BjEniQ+yCt1qqfKfiAHRAts26ud7hBjamrwig==}
     engines: {node: '>=18.0.0'}
 
   '@smithy/util-endpoints@3.3.4':
@@ -991,24 +892,12 @@ packages:
     resolution: {integrity: sha512-Qcz3W5vuHK4sLQdyT93k/rfrUwdJ8/HZ+nMUOyGdpeGA1Wxt65zYwi3oEl9kOM+RswvYq90fzkNDahPS8K0OIg==}
     engines: {node: '>=18.0.0'}
 
-  '@smithy/util-middleware@4.2.12':
-    resolution: {integrity: sha512-Er805uFUOvgc0l8nv0e0su0VFISoxhJ/AwOn3gL2NWNY2LUEldP5WtVcRYSQBcjg0y9NfG8JYrCJaYDpupBHJQ==}
-    engines: {node: '>=18.0.0'}
-
   '@smithy/util-middleware@4.2.13':
     resolution: {integrity: sha512-GTooyrlmRTqvUen4eK7/K1p6kryF7bnDfq6XsAbIsf2mo51B/utaH+XThY6dKgNCWzMAaH/+OLmqaBuLhLWRow==}
     engines: {node: '>=18.0.0'}
 
-  '@smithy/util-retry@4.2.13':
-    resolution: {integrity: sha512-qQQsIvL0MGIbUjeSrg0/VlQ3jGNKyM3/2iU3FPNgy01z+Sp4OvcaxbgIoFOTvB61ZoohtutuOvOcgmhbD0katQ==}
-    engines: {node: '>=18.0.0'}
-
   '@smithy/util-retry@4.3.0':
     resolution: {integrity: sha512-tSOPQNT/4KfbvqeMovWC3g23KSYy8czHd3tlN+tOYVNIDLSfxIsrPJihYi5TpNcoV789KWtgChUVedh2y6dDPg==}
-    engines: {node: '>=18.0.0'}
-
-  '@smithy/util-stream@4.5.21':
-    resolution: {integrity: sha512-KzSg+7KKywLnkoKejRtIBXDmwBfjGvg1U1i/etkC7XSWUyFCoLno1IohV2c74IzQqdhX5y3uE44r/8/wuK+A7Q==}
     engines: {node: '>=18.0.0'}
 
   '@smithy/util-stream@4.5.22':
@@ -1027,8 +916,8 @@ packages:
     resolution: {integrity: sha512-75MeYpjdWRe8M5E3AW0O4Cx3UadweS+cwdXjwYGBW5h/gxxnbeZ877sLPX/ZJA9GVTlL/qG0dXP29JWFCD1Ayw==}
     engines: {node: '>=18.0.0'}
 
-  '@smithy/util-waiter@4.2.14':
-    resolution: {integrity: sha512-2zqq5o/oizvMaFUlNiTyZ7dbgYv1a893aGut2uaxtbzTx/VYYnRxWzDHuD/ftgcw94ffenua+ZNLrbqwUYE+Bg==}
+  '@smithy/util-waiter@4.2.15':
+    resolution: {integrity: sha512-oUt9o7n8hBv3BL56sLSneL0XeigZSuem0Hr78JaoK33D9oKieyCvVP8eTSe3j7g2mm/S1DvzxKieG7JEWNJUNg==}
     engines: {node: '>=18.0.0'}
 
   '@smithy/uuid@1.1.2':
@@ -2078,6 +1967,27 @@ snapshots:
 
   '@aws-cdk/cloud-assembly-schema@41.2.0': {}
 
+  '@aws-crypto/crc32@5.2.0':
+    dependencies:
+      '@aws-crypto/util': 5.2.0
+      '@aws-sdk/types': 3.973.7
+      tslib: 2.8.1
+
+  '@aws-crypto/crc32c@5.2.0':
+    dependencies:
+      '@aws-crypto/util': 5.2.0
+      '@aws-sdk/types': 3.973.7
+      tslib: 2.8.1
+
+  '@aws-crypto/sha1-browser@5.2.0':
+    dependencies:
+      '@aws-crypto/supports-web-crypto': 5.2.0
+      '@aws-crypto/util': 5.2.0
+      '@aws-sdk/types': 3.973.7
+      '@aws-sdk/util-locate-window': 3.965.5
+      '@smithy/util-utf8': 2.3.0
+      tslib: 2.8.1
+
   '@aws-crypto/sha256-browser@5.2.0':
     dependencies:
       '@aws-crypto/sha256-js': 5.2.0
@@ -2148,49 +2058,109 @@ snapshots:
     transitivePeerDependencies:
       - aws-crt
 
-  '@aws-sdk/client-dynamodb@3.1024.0':
+  '@aws-sdk/client-dynamodb@3.1027.0':
     dependencies:
       '@aws-crypto/sha256-browser': 5.2.0
       '@aws-crypto/sha256-js': 5.2.0
-      '@aws-sdk/core': 3.973.26
-      '@aws-sdk/credential-provider-node': 3.972.29
-      '@aws-sdk/dynamodb-codec': 3.972.27
-      '@aws-sdk/middleware-endpoint-discovery': 3.972.9
-      '@aws-sdk/middleware-host-header': 3.972.8
-      '@aws-sdk/middleware-logger': 3.972.8
-      '@aws-sdk/middleware-recursion-detection': 3.972.9
-      '@aws-sdk/middleware-user-agent': 3.972.28
-      '@aws-sdk/region-config-resolver': 3.972.10
-      '@aws-sdk/types': 3.973.6
-      '@aws-sdk/util-endpoints': 3.996.5
-      '@aws-sdk/util-user-agent-browser': 3.972.8
-      '@aws-sdk/util-user-agent-node': 3.973.14
-      '@smithy/config-resolver': 4.4.13
-      '@smithy/core': 3.23.13
-      '@smithy/fetch-http-handler': 5.3.15
-      '@smithy/hash-node': 4.2.12
-      '@smithy/invalid-dependency': 4.2.12
-      '@smithy/middleware-content-length': 4.2.12
-      '@smithy/middleware-endpoint': 4.4.28
-      '@smithy/middleware-retry': 4.4.46
-      '@smithy/middleware-serde': 4.2.16
-      '@smithy/middleware-stack': 4.2.12
-      '@smithy/node-config-provider': 4.3.12
-      '@smithy/node-http-handler': 4.5.1
-      '@smithy/protocol-http': 5.3.12
-      '@smithy/smithy-client': 4.12.8
-      '@smithy/types': 4.13.1
-      '@smithy/url-parser': 4.2.12
+      '@aws-sdk/core': 3.973.27
+      '@aws-sdk/credential-provider-node': 3.972.30
+      '@aws-sdk/dynamodb-codec': 3.972.28
+      '@aws-sdk/middleware-endpoint-discovery': 3.972.10
+      '@aws-sdk/middleware-host-header': 3.972.9
+      '@aws-sdk/middleware-logger': 3.972.9
+      '@aws-sdk/middleware-recursion-detection': 3.972.10
+      '@aws-sdk/middleware-user-agent': 3.972.29
+      '@aws-sdk/region-config-resolver': 3.972.11
+      '@aws-sdk/types': 3.973.7
+      '@aws-sdk/util-endpoints': 3.996.6
+      '@aws-sdk/util-user-agent-browser': 3.972.9
+      '@aws-sdk/util-user-agent-node': 3.973.15
+      '@smithy/config-resolver': 4.4.14
+      '@smithy/core': 3.23.14
+      '@smithy/fetch-http-handler': 5.3.16
+      '@smithy/hash-node': 4.2.13
+      '@smithy/invalid-dependency': 4.2.13
+      '@smithy/middleware-content-length': 4.2.13
+      '@smithy/middleware-endpoint': 4.4.29
+      '@smithy/middleware-retry': 4.5.0
+      '@smithy/middleware-serde': 4.2.17
+      '@smithy/middleware-stack': 4.2.13
+      '@smithy/node-config-provider': 4.3.13
+      '@smithy/node-http-handler': 4.5.2
+      '@smithy/protocol-http': 5.3.13
+      '@smithy/smithy-client': 4.12.9
+      '@smithy/types': 4.14.0
+      '@smithy/url-parser': 4.2.13
       '@smithy/util-base64': 4.3.2
       '@smithy/util-body-length-browser': 4.2.2
       '@smithy/util-body-length-node': 4.2.3
-      '@smithy/util-defaults-mode-browser': 4.3.44
-      '@smithy/util-defaults-mode-node': 4.2.48
-      '@smithy/util-endpoints': 3.3.3
-      '@smithy/util-middleware': 4.2.12
-      '@smithy/util-retry': 4.2.13
+      '@smithy/util-defaults-mode-browser': 4.3.45
+      '@smithy/util-defaults-mode-node': 4.2.49
+      '@smithy/util-endpoints': 3.3.4
+      '@smithy/util-middleware': 4.2.13
+      '@smithy/util-retry': 4.3.0
       '@smithy/util-utf8': 4.2.2
-      '@smithy/util-waiter': 4.2.14
+      '@smithy/util-waiter': 4.2.15
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - aws-crt
+
+  '@aws-sdk/client-s3@3.1027.0':
+    dependencies:
+      '@aws-crypto/sha1-browser': 5.2.0
+      '@aws-crypto/sha256-browser': 5.2.0
+      '@aws-crypto/sha256-js': 5.2.0
+      '@aws-sdk/core': 3.973.27
+      '@aws-sdk/credential-provider-node': 3.972.30
+      '@aws-sdk/middleware-bucket-endpoint': 3.972.9
+      '@aws-sdk/middleware-expect-continue': 3.972.9
+      '@aws-sdk/middleware-flexible-checksums': 3.974.7
+      '@aws-sdk/middleware-host-header': 3.972.9
+      '@aws-sdk/middleware-location-constraint': 3.972.9
+      '@aws-sdk/middleware-logger': 3.972.9
+      '@aws-sdk/middleware-recursion-detection': 3.972.10
+      '@aws-sdk/middleware-sdk-s3': 3.972.28
+      '@aws-sdk/middleware-ssec': 3.972.9
+      '@aws-sdk/middleware-user-agent': 3.972.29
+      '@aws-sdk/region-config-resolver': 3.972.11
+      '@aws-sdk/signature-v4-multi-region': 3.996.16
+      '@aws-sdk/types': 3.973.7
+      '@aws-sdk/util-endpoints': 3.996.6
+      '@aws-sdk/util-user-agent-browser': 3.972.9
+      '@aws-sdk/util-user-agent-node': 3.973.15
+      '@smithy/config-resolver': 4.4.14
+      '@smithy/core': 3.23.14
+      '@smithy/eventstream-serde-browser': 4.2.13
+      '@smithy/eventstream-serde-config-resolver': 4.3.13
+      '@smithy/eventstream-serde-node': 4.2.13
+      '@smithy/fetch-http-handler': 5.3.16
+      '@smithy/hash-blob-browser': 4.2.14
+      '@smithy/hash-node': 4.2.13
+      '@smithy/hash-stream-node': 4.2.13
+      '@smithy/invalid-dependency': 4.2.13
+      '@smithy/md5-js': 4.2.13
+      '@smithy/middleware-content-length': 4.2.13
+      '@smithy/middleware-endpoint': 4.4.29
+      '@smithy/middleware-retry': 4.5.0
+      '@smithy/middleware-serde': 4.2.17
+      '@smithy/middleware-stack': 4.2.13
+      '@smithy/node-config-provider': 4.3.13
+      '@smithy/node-http-handler': 4.5.2
+      '@smithy/protocol-http': 5.3.13
+      '@smithy/smithy-client': 4.12.9
+      '@smithy/types': 4.14.0
+      '@smithy/url-parser': 4.2.13
+      '@smithy/util-base64': 4.3.2
+      '@smithy/util-body-length-browser': 4.2.2
+      '@smithy/util-body-length-node': 4.2.3
+      '@smithy/util-defaults-mode-browser': 4.3.45
+      '@smithy/util-defaults-mode-node': 4.2.49
+      '@smithy/util-endpoints': 3.3.4
+      '@smithy/util-middleware': 4.2.13
+      '@smithy/util-retry': 4.3.0
+      '@smithy/util-stream': 4.5.22
+      '@smithy/util-utf8': 4.2.2
+      '@smithy/util-waiter': 4.2.15
       tslib: 2.8.1
     transitivePeerDependencies:
       - aws-crt
@@ -2239,22 +2209,6 @@ snapshots:
     transitivePeerDependencies:
       - aws-crt
 
-  '@aws-sdk/core@3.973.26':
-    dependencies:
-      '@aws-sdk/types': 3.973.6
-      '@aws-sdk/xml-builder': 3.972.16
-      '@smithy/core': 3.23.13
-      '@smithy/node-config-provider': 4.3.12
-      '@smithy/property-provider': 4.2.12
-      '@smithy/protocol-http': 5.3.12
-      '@smithy/signature-v4': 5.3.12
-      '@smithy/smithy-client': 4.12.8
-      '@smithy/types': 4.13.1
-      '@smithy/util-base64': 4.3.2
-      '@smithy/util-middleware': 4.2.12
-      '@smithy/util-utf8': 4.2.2
-      tslib: 2.8.1
-
   '@aws-sdk/core@3.973.27':
     dependencies:
       '@aws-sdk/types': 3.973.7
@@ -2271,12 +2225,9 @@ snapshots:
       '@smithy/util-utf8': 4.2.2
       tslib: 2.8.1
 
-  '@aws-sdk/credential-provider-env@3.972.24':
+  '@aws-sdk/crc64-nvme@3.972.6':
     dependencies:
-      '@aws-sdk/core': 3.973.26
-      '@aws-sdk/types': 3.973.6
-      '@smithy/property-provider': 4.2.12
-      '@smithy/types': 4.13.1
+      '@smithy/types': 4.14.0
       tslib: 2.8.1
 
   '@aws-sdk/credential-provider-env@3.972.25':
@@ -2285,19 +2236,6 @@ snapshots:
       '@aws-sdk/types': 3.973.7
       '@smithy/property-provider': 4.2.13
       '@smithy/types': 4.14.0
-      tslib: 2.8.1
-
-  '@aws-sdk/credential-provider-http@3.972.26':
-    dependencies:
-      '@aws-sdk/core': 3.973.26
-      '@aws-sdk/types': 3.973.6
-      '@smithy/fetch-http-handler': 5.3.15
-      '@smithy/node-http-handler': 4.5.1
-      '@smithy/property-provider': 4.2.12
-      '@smithy/protocol-http': 5.3.12
-      '@smithy/smithy-client': 4.12.8
-      '@smithy/types': 4.13.1
-      '@smithy/util-stream': 4.5.21
       tslib: 2.8.1
 
   '@aws-sdk/credential-provider-http@3.972.27':
@@ -2312,25 +2250,6 @@ snapshots:
       '@smithy/types': 4.14.0
       '@smithy/util-stream': 4.5.22
       tslib: 2.8.1
-
-  '@aws-sdk/credential-provider-ini@3.972.28':
-    dependencies:
-      '@aws-sdk/core': 3.973.26
-      '@aws-sdk/credential-provider-env': 3.972.24
-      '@aws-sdk/credential-provider-http': 3.972.26
-      '@aws-sdk/credential-provider-login': 3.972.28
-      '@aws-sdk/credential-provider-process': 3.972.24
-      '@aws-sdk/credential-provider-sso': 3.972.28
-      '@aws-sdk/credential-provider-web-identity': 3.972.28
-      '@aws-sdk/nested-clients': 3.996.18
-      '@aws-sdk/types': 3.973.6
-      '@smithy/credential-provider-imds': 4.2.12
-      '@smithy/property-provider': 4.2.12
-      '@smithy/shared-ini-file-loader': 4.4.7
-      '@smithy/types': 4.13.1
-      tslib: 2.8.1
-    transitivePeerDependencies:
-      - aws-crt
 
   '@aws-sdk/credential-provider-ini@3.972.29':
     dependencies:
@@ -2351,19 +2270,6 @@ snapshots:
     transitivePeerDependencies:
       - aws-crt
 
-  '@aws-sdk/credential-provider-login@3.972.28':
-    dependencies:
-      '@aws-sdk/core': 3.973.26
-      '@aws-sdk/nested-clients': 3.996.18
-      '@aws-sdk/types': 3.973.6
-      '@smithy/property-provider': 4.2.12
-      '@smithy/protocol-http': 5.3.12
-      '@smithy/shared-ini-file-loader': 4.4.7
-      '@smithy/types': 4.13.1
-      tslib: 2.8.1
-    transitivePeerDependencies:
-      - aws-crt
-
   '@aws-sdk/credential-provider-login@3.972.29':
     dependencies:
       '@aws-sdk/core': 3.973.27
@@ -2373,23 +2279,6 @@ snapshots:
       '@smithy/protocol-http': 5.3.13
       '@smithy/shared-ini-file-loader': 4.4.8
       '@smithy/types': 4.14.0
-      tslib: 2.8.1
-    transitivePeerDependencies:
-      - aws-crt
-
-  '@aws-sdk/credential-provider-node@3.972.29':
-    dependencies:
-      '@aws-sdk/credential-provider-env': 3.972.24
-      '@aws-sdk/credential-provider-http': 3.972.26
-      '@aws-sdk/credential-provider-ini': 3.972.28
-      '@aws-sdk/credential-provider-process': 3.972.24
-      '@aws-sdk/credential-provider-sso': 3.972.28
-      '@aws-sdk/credential-provider-web-identity': 3.972.28
-      '@aws-sdk/types': 3.973.6
-      '@smithy/credential-provider-imds': 4.2.12
-      '@smithy/property-provider': 4.2.12
-      '@smithy/shared-ini-file-loader': 4.4.7
-      '@smithy/types': 4.13.1
       tslib: 2.8.1
     transitivePeerDependencies:
       - aws-crt
@@ -2411,15 +2300,6 @@ snapshots:
     transitivePeerDependencies:
       - aws-crt
 
-  '@aws-sdk/credential-provider-process@3.972.24':
-    dependencies:
-      '@aws-sdk/core': 3.973.26
-      '@aws-sdk/types': 3.973.6
-      '@smithy/property-provider': 4.2.12
-      '@smithy/shared-ini-file-loader': 4.4.7
-      '@smithy/types': 4.13.1
-      tslib: 2.8.1
-
   '@aws-sdk/credential-provider-process@3.972.25':
     dependencies:
       '@aws-sdk/core': 3.973.27
@@ -2428,19 +2308,6 @@ snapshots:
       '@smithy/shared-ini-file-loader': 4.4.8
       '@smithy/types': 4.14.0
       tslib: 2.8.1
-
-  '@aws-sdk/credential-provider-sso@3.972.28':
-    dependencies:
-      '@aws-sdk/core': 3.973.26
-      '@aws-sdk/nested-clients': 3.996.18
-      '@aws-sdk/token-providers': 3.1021.0
-      '@aws-sdk/types': 3.973.6
-      '@smithy/property-provider': 4.2.12
-      '@smithy/shared-ini-file-loader': 4.4.7
-      '@smithy/types': 4.13.1
-      tslib: 2.8.1
-    transitivePeerDependencies:
-      - aws-crt
 
   '@aws-sdk/credential-provider-sso@3.972.29':
     dependencies:
@@ -2451,18 +2318,6 @@ snapshots:
       '@smithy/property-provider': 4.2.13
       '@smithy/shared-ini-file-loader': 4.4.8
       '@smithy/types': 4.14.0
-      tslib: 2.8.1
-    transitivePeerDependencies:
-      - aws-crt
-
-  '@aws-sdk/credential-provider-web-identity@3.972.28':
-    dependencies:
-      '@aws-sdk/core': 3.973.26
-      '@aws-sdk/nested-clients': 3.996.18
-      '@aws-sdk/types': 3.973.6
-      '@smithy/property-provider': 4.2.12
-      '@smithy/shared-ini-file-loader': 4.4.7
-      '@smithy/types': 4.13.1
       tslib: 2.8.1
     transitivePeerDependencies:
       - aws-crt
@@ -2479,12 +2334,12 @@ snapshots:
     transitivePeerDependencies:
       - aws-crt
 
-  '@aws-sdk/dynamodb-codec@3.972.27':
+  '@aws-sdk/dynamodb-codec@3.972.28':
     dependencies:
-      '@aws-sdk/core': 3.973.26
-      '@smithy/core': 3.23.13
-      '@smithy/smithy-client': 4.12.8
-      '@smithy/types': 4.13.1
+      '@aws-sdk/core': 3.973.27
+      '@smithy/core': 3.23.14
+      '@smithy/smithy-client': 4.12.9
+      '@smithy/types': 4.14.0
       '@smithy/util-base64': 4.3.2
       tslib: 2.8.1
 
@@ -2493,30 +2348,57 @@ snapshots:
       mnemonist: 0.38.3
       tslib: 2.8.1
 
-  '@aws-sdk/lib-dynamodb@3.1024.0(@aws-sdk/client-dynamodb@3.1024.0)':
+  '@aws-sdk/lib-dynamodb@3.1027.0(@aws-sdk/client-dynamodb@3.1027.0)':
     dependencies:
-      '@aws-sdk/client-dynamodb': 3.1024.0
-      '@aws-sdk/core': 3.973.26
-      '@aws-sdk/util-dynamodb': 3.996.2(@aws-sdk/client-dynamodb@3.1024.0)
-      '@smithy/core': 3.23.13
-      '@smithy/smithy-client': 4.12.8
-      '@smithy/types': 4.13.1
+      '@aws-sdk/client-dynamodb': 3.1027.0
+      '@aws-sdk/core': 3.973.27
+      '@aws-sdk/util-dynamodb': 3.996.2(@aws-sdk/client-dynamodb@3.1027.0)
+      '@smithy/core': 3.23.14
+      '@smithy/smithy-client': 4.12.9
+      '@smithy/types': 4.14.0
       tslib: 2.8.1
 
-  '@aws-sdk/middleware-endpoint-discovery@3.972.9':
+  '@aws-sdk/middleware-bucket-endpoint@3.972.9':
+    dependencies:
+      '@aws-sdk/types': 3.973.7
+      '@aws-sdk/util-arn-parser': 3.972.3
+      '@smithy/node-config-provider': 4.3.13
+      '@smithy/protocol-http': 5.3.13
+      '@smithy/types': 4.14.0
+      '@smithy/util-config-provider': 4.2.2
+      tslib: 2.8.1
+
+  '@aws-sdk/middleware-endpoint-discovery@3.972.10':
     dependencies:
       '@aws-sdk/endpoint-cache': 3.972.5
-      '@aws-sdk/types': 3.973.6
-      '@smithy/node-config-provider': 4.3.12
-      '@smithy/protocol-http': 5.3.12
-      '@smithy/types': 4.13.1
+      '@aws-sdk/types': 3.973.7
+      '@smithy/node-config-provider': 4.3.13
+      '@smithy/protocol-http': 5.3.13
+      '@smithy/types': 4.14.0
       tslib: 2.8.1
 
-  '@aws-sdk/middleware-host-header@3.972.8':
+  '@aws-sdk/middleware-expect-continue@3.972.9':
     dependencies:
-      '@aws-sdk/types': 3.973.6
-      '@smithy/protocol-http': 5.3.12
-      '@smithy/types': 4.13.1
+      '@aws-sdk/types': 3.973.7
+      '@smithy/protocol-http': 5.3.13
+      '@smithy/types': 4.14.0
+      tslib: 2.8.1
+
+  '@aws-sdk/middleware-flexible-checksums@3.974.7':
+    dependencies:
+      '@aws-crypto/crc32': 5.2.0
+      '@aws-crypto/crc32c': 5.2.0
+      '@aws-crypto/util': 5.2.0
+      '@aws-sdk/core': 3.973.27
+      '@aws-sdk/crc64-nvme': 3.972.6
+      '@aws-sdk/types': 3.973.7
+      '@smithy/is-array-buffer': 4.2.2
+      '@smithy/node-config-provider': 4.3.13
+      '@smithy/protocol-http': 5.3.13
+      '@smithy/types': 4.14.0
+      '@smithy/util-middleware': 4.2.13
+      '@smithy/util-stream': 4.5.22
+      '@smithy/util-utf8': 4.2.2
       tslib: 2.8.1
 
   '@aws-sdk/middleware-host-header@3.972.9':
@@ -2526,10 +2408,10 @@ snapshots:
       '@smithy/types': 4.14.0
       tslib: 2.8.1
 
-  '@aws-sdk/middleware-logger@3.972.8':
+  '@aws-sdk/middleware-location-constraint@3.972.9':
     dependencies:
-      '@aws-sdk/types': 3.973.6
-      '@smithy/types': 4.13.1
+      '@aws-sdk/types': 3.973.7
+      '@smithy/types': 4.14.0
       tslib: 2.8.1
 
   '@aws-sdk/middleware-logger@3.972.9':
@@ -2546,23 +2428,27 @@ snapshots:
       '@smithy/types': 4.14.0
       tslib: 2.8.1
 
-  '@aws-sdk/middleware-recursion-detection@3.972.9':
+  '@aws-sdk/middleware-sdk-s3@3.972.28':
     dependencies:
-      '@aws-sdk/types': 3.973.6
-      '@aws/lambda-invoke-store': 0.2.4
-      '@smithy/protocol-http': 5.3.12
-      '@smithy/types': 4.13.1
+      '@aws-sdk/core': 3.973.27
+      '@aws-sdk/types': 3.973.7
+      '@aws-sdk/util-arn-parser': 3.972.3
+      '@smithy/core': 3.23.14
+      '@smithy/node-config-provider': 4.3.13
+      '@smithy/protocol-http': 5.3.13
+      '@smithy/signature-v4': 5.3.13
+      '@smithy/smithy-client': 4.12.9
+      '@smithy/types': 4.14.0
+      '@smithy/util-config-provider': 4.2.2
+      '@smithy/util-middleware': 4.2.13
+      '@smithy/util-stream': 4.5.22
+      '@smithy/util-utf8': 4.2.2
       tslib: 2.8.1
 
-  '@aws-sdk/middleware-user-agent@3.972.28':
+  '@aws-sdk/middleware-ssec@3.972.9':
     dependencies:
-      '@aws-sdk/core': 3.973.26
-      '@aws-sdk/types': 3.973.6
-      '@aws-sdk/util-endpoints': 3.996.5
-      '@smithy/core': 3.23.13
-      '@smithy/protocol-http': 5.3.12
-      '@smithy/types': 4.13.1
-      '@smithy/util-retry': 4.2.13
+      '@aws-sdk/types': 3.973.7
+      '@smithy/types': 4.14.0
       tslib: 2.8.1
 
   '@aws-sdk/middleware-user-agent@3.972.29':
@@ -2575,49 +2461,6 @@ snapshots:
       '@smithy/types': 4.14.0
       '@smithy/util-retry': 4.3.0
       tslib: 2.8.1
-
-  '@aws-sdk/nested-clients@3.996.18':
-    dependencies:
-      '@aws-crypto/sha256-browser': 5.2.0
-      '@aws-crypto/sha256-js': 5.2.0
-      '@aws-sdk/core': 3.973.26
-      '@aws-sdk/middleware-host-header': 3.972.8
-      '@aws-sdk/middleware-logger': 3.972.8
-      '@aws-sdk/middleware-recursion-detection': 3.972.9
-      '@aws-sdk/middleware-user-agent': 3.972.28
-      '@aws-sdk/region-config-resolver': 3.972.10
-      '@aws-sdk/types': 3.973.6
-      '@aws-sdk/util-endpoints': 3.996.5
-      '@aws-sdk/util-user-agent-browser': 3.972.8
-      '@aws-sdk/util-user-agent-node': 3.973.14
-      '@smithy/config-resolver': 4.4.13
-      '@smithy/core': 3.23.13
-      '@smithy/fetch-http-handler': 5.3.15
-      '@smithy/hash-node': 4.2.12
-      '@smithy/invalid-dependency': 4.2.12
-      '@smithy/middleware-content-length': 4.2.12
-      '@smithy/middleware-endpoint': 4.4.28
-      '@smithy/middleware-retry': 4.4.46
-      '@smithy/middleware-serde': 4.2.16
-      '@smithy/middleware-stack': 4.2.12
-      '@smithy/node-config-provider': 4.3.12
-      '@smithy/node-http-handler': 4.5.1
-      '@smithy/protocol-http': 5.3.12
-      '@smithy/smithy-client': 4.12.8
-      '@smithy/types': 4.13.1
-      '@smithy/url-parser': 4.2.12
-      '@smithy/util-base64': 4.3.2
-      '@smithy/util-body-length-browser': 4.2.2
-      '@smithy/util-body-length-node': 4.2.3
-      '@smithy/util-defaults-mode-browser': 4.3.44
-      '@smithy/util-defaults-mode-node': 4.2.48
-      '@smithy/util-endpoints': 3.3.3
-      '@smithy/util-middleware': 4.2.12
-      '@smithy/util-retry': 4.2.13
-      '@smithy/util-utf8': 4.2.2
-      tslib: 2.8.1
-    transitivePeerDependencies:
-      - aws-crt
 
   '@aws-sdk/nested-clients@3.996.19':
     dependencies:
@@ -2662,14 +2505,6 @@ snapshots:
     transitivePeerDependencies:
       - aws-crt
 
-  '@aws-sdk/region-config-resolver@3.972.10':
-    dependencies:
-      '@aws-sdk/types': 3.973.6
-      '@smithy/config-resolver': 4.4.13
-      '@smithy/node-config-provider': 4.3.12
-      '@smithy/types': 4.13.1
-      tslib: 2.8.1
-
   '@aws-sdk/region-config-resolver@3.972.11':
     dependencies:
       '@aws-sdk/types': 3.973.7
@@ -2678,17 +2513,14 @@ snapshots:
       '@smithy/types': 4.14.0
       tslib: 2.8.1
 
-  '@aws-sdk/token-providers@3.1021.0':
+  '@aws-sdk/signature-v4-multi-region@3.996.16':
     dependencies:
-      '@aws-sdk/core': 3.973.26
-      '@aws-sdk/nested-clients': 3.996.18
-      '@aws-sdk/types': 3.973.6
-      '@smithy/property-provider': 4.2.12
-      '@smithy/shared-ini-file-loader': 4.4.7
-      '@smithy/types': 4.13.1
+      '@aws-sdk/middleware-sdk-s3': 3.972.28
+      '@aws-sdk/types': 3.973.7
+      '@smithy/protocol-http': 5.3.13
+      '@smithy/signature-v4': 5.3.13
+      '@smithy/types': 4.14.0
       tslib: 2.8.1
-    transitivePeerDependencies:
-      - aws-crt
 
   '@aws-sdk/token-providers@3.1026.0':
     dependencies:
@@ -2702,27 +2534,18 @@ snapshots:
     transitivePeerDependencies:
       - aws-crt
 
-  '@aws-sdk/types@3.973.6':
-    dependencies:
-      '@smithy/types': 4.13.1
-      tslib: 2.8.1
-
   '@aws-sdk/types@3.973.7':
     dependencies:
       '@smithy/types': 4.14.0
       tslib: 2.8.1
 
-  '@aws-sdk/util-dynamodb@3.996.2(@aws-sdk/client-dynamodb@3.1024.0)':
+  '@aws-sdk/util-arn-parser@3.972.3':
     dependencies:
-      '@aws-sdk/client-dynamodb': 3.1024.0
       tslib: 2.8.1
 
-  '@aws-sdk/util-endpoints@3.996.5':
+  '@aws-sdk/util-dynamodb@3.996.2(@aws-sdk/client-dynamodb@3.1027.0)':
     dependencies:
-      '@aws-sdk/types': 3.973.6
-      '@smithy/types': 4.13.1
-      '@smithy/url-parser': 4.2.12
-      '@smithy/util-endpoints': 3.3.3
+      '@aws-sdk/client-dynamodb': 3.1027.0
       tslib: 2.8.1
 
   '@aws-sdk/util-endpoints@3.996.6':
@@ -2737,27 +2560,11 @@ snapshots:
     dependencies:
       tslib: 2.8.1
 
-  '@aws-sdk/util-user-agent-browser@3.972.8':
-    dependencies:
-      '@aws-sdk/types': 3.973.6
-      '@smithy/types': 4.13.1
-      bowser: 2.14.1
-      tslib: 2.8.1
-
   '@aws-sdk/util-user-agent-browser@3.972.9':
     dependencies:
       '@aws-sdk/types': 3.973.7
       '@smithy/types': 4.14.0
       bowser: 2.14.1
-      tslib: 2.8.1
-
-  '@aws-sdk/util-user-agent-node@3.973.14':
-    dependencies:
-      '@aws-sdk/middleware-user-agent': 3.972.28
-      '@aws-sdk/types': 3.973.6
-      '@smithy/node-config-provider': 4.3.12
-      '@smithy/types': 4.13.1
-      '@smithy/util-config-provider': 4.2.2
       tslib: 2.8.1
 
   '@aws-sdk/util-user-agent-node@3.973.15':
@@ -2767,12 +2574,6 @@ snapshots:
       '@smithy/node-config-provider': 4.3.13
       '@smithy/types': 4.14.0
       '@smithy/util-config-provider': 4.2.2
-      tslib: 2.8.1
-
-  '@aws-sdk/xml-builder@3.972.16':
-    dependencies:
-      '@smithy/types': 4.13.1
-      fast-xml-parser: 5.5.8
       tslib: 2.8.1
 
   '@aws-sdk/xml-builder@3.972.17':
@@ -3269,13 +3070,13 @@ snapshots:
       '@sinonjs/commons': 3.0.1
       type-detect: 4.1.0
 
-  '@smithy/config-resolver@4.4.13':
+  '@smithy/chunked-blob-reader-native@4.2.3':
     dependencies:
-      '@smithy/node-config-provider': 4.3.12
-      '@smithy/types': 4.13.1
-      '@smithy/util-config-provider': 4.2.2
-      '@smithy/util-endpoints': 3.3.3
-      '@smithy/util-middleware': 4.2.12
+      '@smithy/util-base64': 4.3.2
+      tslib: 2.8.1
+
+  '@smithy/chunked-blob-reader@5.2.2':
+    dependencies:
       tslib: 2.8.1
 
   '@smithy/config-resolver@4.4.14':
@@ -3285,19 +3086,6 @@ snapshots:
       '@smithy/util-config-provider': 4.2.2
       '@smithy/util-endpoints': 3.3.4
       '@smithy/util-middleware': 4.2.13
-      tslib: 2.8.1
-
-  '@smithy/core@3.23.13':
-    dependencies:
-      '@smithy/protocol-http': 5.3.12
-      '@smithy/types': 4.13.1
-      '@smithy/url-parser': 4.2.12
-      '@smithy/util-base64': 4.3.2
-      '@smithy/util-body-length-browser': 4.2.2
-      '@smithy/util-middleware': 4.2.12
-      '@smithy/util-stream': 4.5.21
-      '@smithy/util-utf8': 4.2.2
-      '@smithy/uuid': 1.1.2
       tslib: 2.8.1
 
   '@smithy/core@3.23.14':
@@ -3313,14 +3101,6 @@ snapshots:
       '@smithy/uuid': 1.1.2
       tslib: 2.8.1
 
-  '@smithy/credential-provider-imds@4.2.12':
-    dependencies:
-      '@smithy/node-config-provider': 4.3.12
-      '@smithy/property-provider': 4.2.12
-      '@smithy/types': 4.13.1
-      '@smithy/url-parser': 4.2.12
-      tslib: 2.8.1
-
   '@smithy/credential-provider-imds@4.2.13':
     dependencies:
       '@smithy/node-config-provider': 4.3.13
@@ -3329,12 +3109,34 @@ snapshots:
       '@smithy/url-parser': 4.2.13
       tslib: 2.8.1
 
-  '@smithy/fetch-http-handler@5.3.15':
+  '@smithy/eventstream-codec@4.2.13':
     dependencies:
-      '@smithy/protocol-http': 5.3.12
-      '@smithy/querystring-builder': 4.2.12
-      '@smithy/types': 4.13.1
-      '@smithy/util-base64': 4.3.2
+      '@aws-crypto/crc32': 5.2.0
+      '@smithy/types': 4.14.0
+      '@smithy/util-hex-encoding': 4.2.2
+      tslib: 2.8.1
+
+  '@smithy/eventstream-serde-browser@4.2.13':
+    dependencies:
+      '@smithy/eventstream-serde-universal': 4.2.13
+      '@smithy/types': 4.14.0
+      tslib: 2.8.1
+
+  '@smithy/eventstream-serde-config-resolver@4.3.13':
+    dependencies:
+      '@smithy/types': 4.14.0
+      tslib: 2.8.1
+
+  '@smithy/eventstream-serde-node@4.2.13':
+    dependencies:
+      '@smithy/eventstream-serde-universal': 4.2.13
+      '@smithy/types': 4.14.0
+      tslib: 2.8.1
+
+  '@smithy/eventstream-serde-universal@4.2.13':
+    dependencies:
+      '@smithy/eventstream-codec': 4.2.13
+      '@smithy/types': 4.14.0
       tslib: 2.8.1
 
   '@smithy/fetch-http-handler@5.3.16':
@@ -3345,11 +3147,11 @@ snapshots:
       '@smithy/util-base64': 4.3.2
       tslib: 2.8.1
 
-  '@smithy/hash-node@4.2.12':
+  '@smithy/hash-blob-browser@4.2.14':
     dependencies:
-      '@smithy/types': 4.13.1
-      '@smithy/util-buffer-from': 4.2.2
-      '@smithy/util-utf8': 4.2.2
+      '@smithy/chunked-blob-reader': 5.2.2
+      '@smithy/chunked-blob-reader-native': 4.2.3
+      '@smithy/types': 4.14.0
       tslib: 2.8.1
 
   '@smithy/hash-node@4.2.13':
@@ -3359,9 +3161,10 @@ snapshots:
       '@smithy/util-utf8': 4.2.2
       tslib: 2.8.1
 
-  '@smithy/invalid-dependency@4.2.12':
+  '@smithy/hash-stream-node@4.2.13':
     dependencies:
-      '@smithy/types': 4.13.1
+      '@smithy/types': 4.14.0
+      '@smithy/util-utf8': 4.2.2
       tslib: 2.8.1
 
   '@smithy/invalid-dependency@4.2.13':
@@ -3377,27 +3180,16 @@ snapshots:
     dependencies:
       tslib: 2.8.1
 
-  '@smithy/middleware-content-length@4.2.12':
+  '@smithy/md5-js@4.2.13':
     dependencies:
-      '@smithy/protocol-http': 5.3.12
-      '@smithy/types': 4.13.1
+      '@smithy/types': 4.14.0
+      '@smithy/util-utf8': 4.2.2
       tslib: 2.8.1
 
   '@smithy/middleware-content-length@4.2.13':
     dependencies:
       '@smithy/protocol-http': 5.3.13
       '@smithy/types': 4.14.0
-      tslib: 2.8.1
-
-  '@smithy/middleware-endpoint@4.4.28':
-    dependencies:
-      '@smithy/core': 3.23.13
-      '@smithy/middleware-serde': 4.2.16
-      '@smithy/node-config-provider': 4.3.12
-      '@smithy/shared-ini-file-loader': 4.4.7
-      '@smithy/types': 4.13.1
-      '@smithy/url-parser': 4.2.12
-      '@smithy/util-middleware': 4.2.12
       tslib: 2.8.1
 
   '@smithy/middleware-endpoint@4.4.29':
@@ -3409,18 +3201,6 @@ snapshots:
       '@smithy/types': 4.14.0
       '@smithy/url-parser': 4.2.13
       '@smithy/util-middleware': 4.2.13
-      tslib: 2.8.1
-
-  '@smithy/middleware-retry@4.4.46':
-    dependencies:
-      '@smithy/node-config-provider': 4.3.12
-      '@smithy/protocol-http': 5.3.12
-      '@smithy/service-error-classification': 4.2.12
-      '@smithy/smithy-client': 4.12.8
-      '@smithy/types': 4.13.1
-      '@smithy/util-middleware': 4.2.12
-      '@smithy/util-retry': 4.2.13
-      '@smithy/uuid': 1.1.2
       tslib: 2.8.1
 
   '@smithy/middleware-retry@4.5.0':
@@ -3436,13 +3216,6 @@ snapshots:
       '@smithy/uuid': 1.1.2
       tslib: 2.8.1
 
-  '@smithy/middleware-serde@4.2.16':
-    dependencies:
-      '@smithy/core': 3.23.13
-      '@smithy/protocol-http': 5.3.12
-      '@smithy/types': 4.13.1
-      tslib: 2.8.1
-
   '@smithy/middleware-serde@4.2.17':
     dependencies:
       '@smithy/core': 3.23.14
@@ -3450,21 +3223,9 @@ snapshots:
       '@smithy/types': 4.14.0
       tslib: 2.8.1
 
-  '@smithy/middleware-stack@4.2.12':
-    dependencies:
-      '@smithy/types': 4.13.1
-      tslib: 2.8.1
-
   '@smithy/middleware-stack@4.2.13':
     dependencies:
       '@smithy/types': 4.14.0
-      tslib: 2.8.1
-
-  '@smithy/node-config-provider@4.3.12':
-    dependencies:
-      '@smithy/property-provider': 4.2.12
-      '@smithy/shared-ini-file-loader': 4.4.7
-      '@smithy/types': 4.13.1
       tslib: 2.8.1
 
   '@smithy/node-config-provider@4.3.13':
@@ -3474,13 +3235,6 @@ snapshots:
       '@smithy/types': 4.14.0
       tslib: 2.8.1
 
-  '@smithy/node-http-handler@4.5.1':
-    dependencies:
-      '@smithy/protocol-http': 5.3.12
-      '@smithy/querystring-builder': 4.2.12
-      '@smithy/types': 4.13.1
-      tslib: 2.8.1
-
   '@smithy/node-http-handler@4.5.2':
     dependencies:
       '@smithy/protocol-http': 5.3.13
@@ -3488,30 +3242,14 @@ snapshots:
       '@smithy/types': 4.14.0
       tslib: 2.8.1
 
-  '@smithy/property-provider@4.2.12':
-    dependencies:
-      '@smithy/types': 4.13.1
-      tslib: 2.8.1
-
   '@smithy/property-provider@4.2.13':
     dependencies:
       '@smithy/types': 4.14.0
       tslib: 2.8.1
 
-  '@smithy/protocol-http@5.3.12':
-    dependencies:
-      '@smithy/types': 4.13.1
-      tslib: 2.8.1
-
   '@smithy/protocol-http@5.3.13':
     dependencies:
       '@smithy/types': 4.14.0
-      tslib: 2.8.1
-
-  '@smithy/querystring-builder@4.2.12':
-    dependencies:
-      '@smithy/types': 4.13.1
-      '@smithy/util-uri-escape': 4.2.2
       tslib: 2.8.1
 
   '@smithy/querystring-builder@4.2.13':
@@ -3520,43 +3258,18 @@ snapshots:
       '@smithy/util-uri-escape': 4.2.2
       tslib: 2.8.1
 
-  '@smithy/querystring-parser@4.2.12':
-    dependencies:
-      '@smithy/types': 4.13.1
-      tslib: 2.8.1
-
   '@smithy/querystring-parser@4.2.13':
     dependencies:
       '@smithy/types': 4.14.0
       tslib: 2.8.1
 
-  '@smithy/service-error-classification@4.2.12':
-    dependencies:
-      '@smithy/types': 4.13.1
-
   '@smithy/service-error-classification@4.2.13':
     dependencies:
       '@smithy/types': 4.14.0
 
-  '@smithy/shared-ini-file-loader@4.4.7':
-    dependencies:
-      '@smithy/types': 4.13.1
-      tslib: 2.8.1
-
   '@smithy/shared-ini-file-loader@4.4.8':
     dependencies:
       '@smithy/types': 4.14.0
-      tslib: 2.8.1
-
-  '@smithy/signature-v4@5.3.12':
-    dependencies:
-      '@smithy/is-array-buffer': 4.2.2
-      '@smithy/protocol-http': 5.3.12
-      '@smithy/types': 4.13.1
-      '@smithy/util-hex-encoding': 4.2.2
-      '@smithy/util-middleware': 4.2.12
-      '@smithy/util-uri-escape': 4.2.2
-      '@smithy/util-utf8': 4.2.2
       tslib: 2.8.1
 
   '@smithy/signature-v4@5.3.13':
@@ -3570,16 +3283,6 @@ snapshots:
       '@smithy/util-utf8': 4.2.2
       tslib: 2.8.1
 
-  '@smithy/smithy-client@4.12.8':
-    dependencies:
-      '@smithy/core': 3.23.13
-      '@smithy/middleware-endpoint': 4.4.28
-      '@smithy/middleware-stack': 4.2.12
-      '@smithy/protocol-http': 5.3.12
-      '@smithy/types': 4.13.1
-      '@smithy/util-stream': 4.5.21
-      tslib: 2.8.1
-
   '@smithy/smithy-client@4.12.9':
     dependencies:
       '@smithy/core': 3.23.14
@@ -3590,18 +3293,8 @@ snapshots:
       '@smithy/util-stream': 4.5.22
       tslib: 2.8.1
 
-  '@smithy/types@4.13.1':
-    dependencies:
-      tslib: 2.8.1
-
   '@smithy/types@4.14.0':
     dependencies:
-      tslib: 2.8.1
-
-  '@smithy/url-parser@4.2.12':
-    dependencies:
-      '@smithy/querystring-parser': 4.2.12
-      '@smithy/types': 4.13.1
       tslib: 2.8.1
 
   '@smithy/url-parser@4.2.13':
@@ -3638,28 +3331,11 @@ snapshots:
     dependencies:
       tslib: 2.8.1
 
-  '@smithy/util-defaults-mode-browser@4.3.44':
-    dependencies:
-      '@smithy/property-provider': 4.2.12
-      '@smithy/smithy-client': 4.12.8
-      '@smithy/types': 4.13.1
-      tslib: 2.8.1
-
   '@smithy/util-defaults-mode-browser@4.3.45':
     dependencies:
       '@smithy/property-provider': 4.2.13
       '@smithy/smithy-client': 4.12.9
       '@smithy/types': 4.14.0
-      tslib: 2.8.1
-
-  '@smithy/util-defaults-mode-node@4.2.48':
-    dependencies:
-      '@smithy/config-resolver': 4.4.13
-      '@smithy/credential-provider-imds': 4.2.12
-      '@smithy/node-config-provider': 4.3.12
-      '@smithy/property-provider': 4.2.12
-      '@smithy/smithy-client': 4.12.8
-      '@smithy/types': 4.13.1
       tslib: 2.8.1
 
   '@smithy/util-defaults-mode-node@4.2.49':
@@ -3672,12 +3348,6 @@ snapshots:
       '@smithy/types': 4.14.0
       tslib: 2.8.1
 
-  '@smithy/util-endpoints@3.3.3':
-    dependencies:
-      '@smithy/node-config-provider': 4.3.12
-      '@smithy/types': 4.13.1
-      tslib: 2.8.1
-
   '@smithy/util-endpoints@3.3.4':
     dependencies:
       '@smithy/node-config-provider': 4.3.13
@@ -3688,37 +3358,15 @@ snapshots:
     dependencies:
       tslib: 2.8.1
 
-  '@smithy/util-middleware@4.2.12':
-    dependencies:
-      '@smithy/types': 4.13.1
-      tslib: 2.8.1
-
   '@smithy/util-middleware@4.2.13':
     dependencies:
       '@smithy/types': 4.14.0
-      tslib: 2.8.1
-
-  '@smithy/util-retry@4.2.13':
-    dependencies:
-      '@smithy/service-error-classification': 4.2.12
-      '@smithy/types': 4.13.1
       tslib: 2.8.1
 
   '@smithy/util-retry@4.3.0':
     dependencies:
       '@smithy/service-error-classification': 4.2.13
       '@smithy/types': 4.14.0
-      tslib: 2.8.1
-
-  '@smithy/util-stream@4.5.21':
-    dependencies:
-      '@smithy/fetch-http-handler': 5.3.15
-      '@smithy/node-http-handler': 4.5.1
-      '@smithy/types': 4.13.1
-      '@smithy/util-base64': 4.3.2
-      '@smithy/util-buffer-from': 4.2.2
-      '@smithy/util-hex-encoding': 4.2.2
-      '@smithy/util-utf8': 4.2.2
       tslib: 2.8.1
 
   '@smithy/util-stream@4.5.22':
@@ -3746,9 +3394,9 @@ snapshots:
       '@smithy/util-buffer-from': 4.2.2
       tslib: 2.8.1
 
-  '@smithy/util-waiter@4.2.14':
+  '@smithy/util-waiter@4.2.15':
     dependencies:
-      '@smithy/types': 4.13.1
+      '@smithy/types': 4.14.0
       tslib: 2.8.1
 
   '@smithy/uuid@1.1.2':

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -45,6 +45,9 @@ importers:
       '@types/node':
         specifier: 22.7.9
         version: 22.7.9
+      '@types/sharp':
+        specifier: ^0.32.0
+        version: 0.32.0
       aws-cdk:
         specifier: 2.1016.1
         version: 2.1016.1
@@ -57,6 +60,9 @@ importers:
       jest:
         specifier: ^29.7.0
         version: 29.7.0(@types/node@22.7.9)(ts-node@10.9.2(@types/node@22.7.9)(typescript@5.6.3))
+      sharp:
+        specifier: ^0.34.5
+        version: 0.34.5
       ts-jest:
         specifier: ^29.2.5
         version: 29.3.4(@babel/core@7.27.4)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.27.4))(esbuild@0.28.0)(jest@29.7.0(@types/node@22.7.9)(ts-node@10.9.2(@types/node@22.7.9)(typescript@5.6.3)))(typescript@5.6.3)
@@ -454,6 +460,9 @@ packages:
     resolution: {integrity: sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==}
     engines: {node: '>=12'}
 
+  '@emnapi/runtime@1.9.2':
+    resolution: {integrity: sha512-3U4+MIWHImeyu1wnmVygh5WlgfYDtyf0k8AbLhMFxOipihf6nrWC4syIm/SwEeec0mNSafiiNnMJwbza/Is6Lw==}
+
   '@esbuild/aix-ppc64@0.28.0':
     resolution: {integrity: sha512-lhRUCeuOyJQURhTxl4WkpFTjIsbDayJHih5kZC1giwE+MhIzAb7mEsQMqMf18rHLsrb5qI1tafG20mLxEWcWlA==}
     engines: {node: '>=18'}
@@ -607,6 +616,143 @@ packages:
   '@esbuild/win32-x64@0.28.0':
     resolution: {integrity: sha512-pEl1bO9mfAmIC+tW5btTmrKaujg3zGtUmWNdCw/xs70FBjwAL3o9OEKNHvNmnyylD6ubxUERiEhdsL0xBQ9efw==}
     engines: {node: '>=18'}
+    cpu: [x64]
+    os: [win32]
+
+  '@img/colour@1.1.0':
+    resolution: {integrity: sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ==}
+    engines: {node: '>=18'}
+
+  '@img/sharp-darwin-arm64@0.34.5':
+    resolution: {integrity: sha512-imtQ3WMJXbMY4fxb/Ndp6HBTNVtWCUI0WdobyheGf5+ad6xX8VIDO8u2xE4qc/fr08CKG/7dDseFtn6M6g/r3w==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@img/sharp-darwin-x64@0.34.5':
+    resolution: {integrity: sha512-YNEFAF/4KQ/PeW0N+r+aVVsoIY0/qxxikF2SWdp+NRkmMB7y9LBZAVqQ4yhGCm/H3H270OSykqmQMKLBhBJDEw==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [x64]
+    os: [darwin]
+
+  '@img/sharp-libvips-darwin-arm64@1.2.4':
+    resolution: {integrity: sha512-zqjjo7RatFfFoP0MkQ51jfuFZBnVE2pRiaydKJ1G/rHZvnsrHAOcQALIi9sA5co5xenQdTugCvtb1cuf78Vf4g==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@img/sharp-libvips-darwin-x64@1.2.4':
+    resolution: {integrity: sha512-1IOd5xfVhlGwX+zXv2N93k0yMONvUlANylbJw1eTah8K/Jtpi15KC+WSiaX/nBmbm2HxRM1gZ0nSdjSsrZbGKg==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@img/sharp-libvips-linux-arm64@1.2.4':
+    resolution: {integrity: sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@img/sharp-libvips-linux-arm@1.2.4':
+    resolution: {integrity: sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==}
+    cpu: [arm]
+    os: [linux]
+
+  '@img/sharp-libvips-linux-ppc64@1.2.4':
+    resolution: {integrity: sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA==}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@img/sharp-libvips-linux-riscv64@1.2.4':
+    resolution: {integrity: sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@img/sharp-libvips-linux-s390x@1.2.4':
+    resolution: {integrity: sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==}
+    cpu: [s390x]
+    os: [linux]
+
+  '@img/sharp-libvips-linux-x64@1.2.4':
+    resolution: {integrity: sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==}
+    cpu: [x64]
+    os: [linux]
+
+  '@img/sharp-libvips-linuxmusl-arm64@1.2.4':
+    resolution: {integrity: sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@img/sharp-libvips-linuxmusl-x64@1.2.4':
+    resolution: {integrity: sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==}
+    cpu: [x64]
+    os: [linux]
+
+  '@img/sharp-linux-arm64@0.34.5':
+    resolution: {integrity: sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [arm64]
+    os: [linux]
+
+  '@img/sharp-linux-arm@0.34.5':
+    resolution: {integrity: sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [arm]
+    os: [linux]
+
+  '@img/sharp-linux-ppc64@0.34.5':
+    resolution: {integrity: sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@img/sharp-linux-riscv64@0.34.5':
+    resolution: {integrity: sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@img/sharp-linux-s390x@0.34.5':
+    resolution: {integrity: sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [s390x]
+    os: [linux]
+
+  '@img/sharp-linux-x64@0.34.5':
+    resolution: {integrity: sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [x64]
+    os: [linux]
+
+  '@img/sharp-linuxmusl-arm64@0.34.5':
+    resolution: {integrity: sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [arm64]
+    os: [linux]
+
+  '@img/sharp-linuxmusl-x64@0.34.5':
+    resolution: {integrity: sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [x64]
+    os: [linux]
+
+  '@img/sharp-wasm32@0.34.5':
+    resolution: {integrity: sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [wasm32]
+
+  '@img/sharp-win32-arm64@0.34.5':
+    resolution: {integrity: sha512-WQ3AgWCWYSb2yt+IG8mnC6Jdk9Whs7O0gxphblsLvdhSpSTtmu69ZG1Gkb6NuvxsNACwiPV6cNSZNzt0KPsw7g==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [arm64]
+    os: [win32]
+
+  '@img/sharp-win32-ia32@0.34.5':
+    resolution: {integrity: sha512-FV9m/7NmeCmSHDD5j4+4pNI8Cp3aW+JvLoXcTUo0IqyjSfAZJ8dIUmijx1qaJsIiU+Hosw6xM5KijAWRJCSgNg==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [ia32]
+    os: [win32]
+
+  '@img/sharp-win32-x64@0.34.5':
+    resolution: {integrity: sha512-+29YMsqY2/9eFEiW93eqWnuLcWcufowXewwSNIT6UwZdUUCrM3oFjMWH/Z6/TMmb4hlFenmfAVbpWeup2jryCw==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [win32]
 
@@ -980,6 +1126,10 @@ packages:
   '@types/node@22.7.9':
     resolution: {integrity: sha512-jrTfRC7FM6nChvU7X2KqcrgquofrWLFDeYC1hKfwNWomVvrn7JIksqf344WN2X/y8xrgqBd2dJATZV4GbatBfg==}
 
+  '@types/sharp@0.32.0':
+    resolution: {integrity: sha512-OOi3kL+FZDnPhVzsfD37J88FNeZh6gQsGcLc95NbeURRGvmSjeXiDcyWzF2o3yh/gQAUn2uhh/e+CPCa5nwAxw==}
+    deprecated: This is a stub types definition. sharp provides its own type definitions, so you do not need this installed.
+
   '@types/sinon@17.0.4':
     resolution: {integrity: sha512-RHnIrhfPO3+tJT0s7cFaXGZvsL4bbR3/k7z3P312qMS4JaS2Tk+KiwiLx1S0rQ56ERj00u1/BtdyVd0FY+Pdew==}
 
@@ -1204,6 +1354,10 @@ packages:
   deepmerge@4.3.1:
     resolution: {integrity: sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==}
     engines: {node: '>=0.10.0'}
+
+  detect-libc@2.1.2:
+    resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
+    engines: {node: '>=8'}
 
   detect-newline@3.1.0:
     resolution: {integrity: sha512-TLz+x/vEXm/Y7P7wn1EJFNLxYpUD4TgMosxY6fAVJUnJMbupHBOncxyWUG9OpTaH9EBD7uFI5LfEgmMOc54DsA==}
@@ -1759,6 +1913,15 @@ packages:
     resolution: {integrity: sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==}
     engines: {node: '>=10'}
     hasBin: true
+
+  semver@7.7.4:
+    resolution: {integrity: sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==}
+    engines: {node: '>=10'}
+    hasBin: true
+
+  sharp@0.34.5:
+    resolution: {integrity: sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
 
   shebang-command@2.0.0:
     resolution: {integrity: sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==}
@@ -2804,6 +2967,11 @@ snapshots:
     dependencies:
       '@jridgewell/trace-mapping': 0.3.9
 
+  '@emnapi/runtime@1.9.2':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
+
   '@esbuild/aix-ppc64@0.28.0':
     optional: true
 
@@ -2880,6 +3048,102 @@ snapshots:
     optional: true
 
   '@esbuild/win32-x64@0.28.0':
+    optional: true
+
+  '@img/colour@1.1.0': {}
+
+  '@img/sharp-darwin-arm64@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-darwin-arm64': 1.2.4
+    optional: true
+
+  '@img/sharp-darwin-x64@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-darwin-x64': 1.2.4
+    optional: true
+
+  '@img/sharp-libvips-darwin-arm64@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-darwin-x64@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-linux-arm64@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-linux-arm@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-linux-ppc64@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-linux-riscv64@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-linux-s390x@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-linux-x64@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-linuxmusl-arm64@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-linuxmusl-x64@1.2.4':
+    optional: true
+
+  '@img/sharp-linux-arm64@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-arm64': 1.2.4
+    optional: true
+
+  '@img/sharp-linux-arm@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-arm': 1.2.4
+    optional: true
+
+  '@img/sharp-linux-ppc64@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-ppc64': 1.2.4
+    optional: true
+
+  '@img/sharp-linux-riscv64@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-riscv64': 1.2.4
+    optional: true
+
+  '@img/sharp-linux-s390x@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-s390x': 1.2.4
+    optional: true
+
+  '@img/sharp-linux-x64@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-x64': 1.2.4
+    optional: true
+
+  '@img/sharp-linuxmusl-arm64@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linuxmusl-arm64': 1.2.4
+    optional: true
+
+  '@img/sharp-linuxmusl-x64@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linuxmusl-x64': 1.2.4
+    optional: true
+
+  '@img/sharp-wasm32@0.34.5':
+    dependencies:
+      '@emnapi/runtime': 1.9.2
+    optional: true
+
+  '@img/sharp-win32-arm64@0.34.5':
+    optional: true
+
+  '@img/sharp-win32-ia32@0.34.5':
+    optional: true
+
+  '@img/sharp-win32-x64@0.34.5':
     optional: true
 
   '@istanbuljs/load-nyc-config@1.1.0':
@@ -3486,6 +3750,10 @@ snapshots:
     dependencies:
       undici-types: 6.19.8
 
+  '@types/sharp@0.32.0':
+    dependencies:
+      sharp: 0.34.5
+
   '@types/sinon@17.0.4':
     dependencies:
       '@types/sinonjs__fake-timers': 15.0.1
@@ -3708,6 +3976,8 @@ snapshots:
   dedent@1.6.0: {}
 
   deepmerge@4.3.1: {}
+
+  detect-libc@2.1.2: {}
 
   detect-newline@3.1.0: {}
 
@@ -4415,6 +4685,39 @@ snapshots:
   semver@6.3.1: {}
 
   semver@7.7.2: {}
+
+  semver@7.7.4: {}
+
+  sharp@0.34.5:
+    dependencies:
+      '@img/colour': 1.1.0
+      detect-libc: 2.1.2
+      semver: 7.7.4
+    optionalDependencies:
+      '@img/sharp-darwin-arm64': 0.34.5
+      '@img/sharp-darwin-x64': 0.34.5
+      '@img/sharp-libvips-darwin-arm64': 1.2.4
+      '@img/sharp-libvips-darwin-x64': 1.2.4
+      '@img/sharp-libvips-linux-arm': 1.2.4
+      '@img/sharp-libvips-linux-arm64': 1.2.4
+      '@img/sharp-libvips-linux-ppc64': 1.2.4
+      '@img/sharp-libvips-linux-riscv64': 1.2.4
+      '@img/sharp-libvips-linux-s390x': 1.2.4
+      '@img/sharp-libvips-linux-x64': 1.2.4
+      '@img/sharp-libvips-linuxmusl-arm64': 1.2.4
+      '@img/sharp-libvips-linuxmusl-x64': 1.2.4
+      '@img/sharp-linux-arm': 0.34.5
+      '@img/sharp-linux-arm64': 0.34.5
+      '@img/sharp-linux-ppc64': 0.34.5
+      '@img/sharp-linux-riscv64': 0.34.5
+      '@img/sharp-linux-s390x': 0.34.5
+      '@img/sharp-linux-x64': 0.34.5
+      '@img/sharp-linuxmusl-arm64': 0.34.5
+      '@img/sharp-linuxmusl-x64': 0.34.5
+      '@img/sharp-wasm32': 0.34.5
+      '@img/sharp-win32-arm64': 0.34.5
+      '@img/sharp-win32-ia32': 0.34.5
+      '@img/sharp-win32-x64': 0.34.5
 
   shebang-command@2.0.0:
     dependencies:

--- a/test/api-stack.test.ts
+++ b/test/api-stack.test.ts
@@ -30,6 +30,7 @@ function createTestStack(): Template {
     apiCertificate,
     pokedexApiUrl: 'https://abc123.execute-api.eu-west-2.amazonaws.com',
     authApiUrl: 'https://xyz789.execute-api.eu-west-2.amazonaws.com',
+    recipeApiUrl: 'https://recipe123.execute-api.eu-west-2.amazonaws.com',
     tags: {
       Project: 'akli-api',
       Environment: 'production',
@@ -162,6 +163,68 @@ describe('ApiStack', () => {
           CacheBehaviors: Match.arrayWith([
             Match.objectLike({
               PathPattern: '/auth/*',
+              OriginRequestPolicyId: Match.anyValue(),
+            }),
+          ]),
+        }),
+      })
+    })
+
+    it('has the recipe API Gateway as an origin', () => {
+      template.hasResourceProperties('AWS::CloudFront::Distribution', {
+        DistributionConfig: Match.objectLike({
+          Origins: Match.arrayWith([
+            Match.objectLike({
+              DomainName: 'recipe123.execute-api.eu-west-2.amazonaws.com',
+              CustomOriginConfig: Match.objectLike({
+                OriginProtocolPolicy: 'https-only',
+              }),
+            }),
+          ]),
+        }),
+      })
+    })
+
+    it('has a /recipes/* cache behaviour with caching disabled', () => {
+      template.hasResourceProperties('AWS::CloudFront::Distribution', {
+        DistributionConfig: Match.objectLike({
+          CacheBehaviors: Match.arrayWith([
+            Match.objectLike({
+              PathPattern: '/recipes/*',
+              CachePolicyId: '4135ea2d-6df8-44a3-9df3-4b5a84be39ad',
+            }),
+          ]),
+        }),
+      })
+    })
+
+    it('has a /recipes/* cache behaviour with AllowedMethods.ALLOW_ALL', () => {
+      template.hasResourceProperties('AWS::CloudFront::Distribution', {
+        DistributionConfig: Match.objectLike({
+          CacheBehaviors: Match.arrayWith([
+            Match.objectLike({
+              PathPattern: '/recipes/*',
+              AllowedMethods: [
+                'GET',
+                'HEAD',
+                'OPTIONS',
+                'PUT',
+                'PATCH',
+                'POST',
+                'DELETE',
+              ],
+            }),
+          ]),
+        }),
+      })
+    })
+
+    it('has a /recipes/* cache behaviour that forwards Authorization header', () => {
+      template.hasResourceProperties('AWS::CloudFront::Distribution', {
+        DistributionConfig: Match.objectLike({
+          CacheBehaviors: Match.arrayWith([
+            Match.objectLike({
+              PathPattern: '/recipes/*',
               OriginRequestPolicyId: Match.anyValue(),
             }),
           ]),

--- a/test/lambda/image-resizer.test.ts
+++ b/test/lambda/image-resizer.test.ts
@@ -1,0 +1,125 @@
+import { S3Client, GetObjectCommand, PutObjectCommand, DeleteObjectCommand } from '@aws-sdk/client-s3'
+import { mockClient } from 'aws-sdk-client-mock'
+import type { S3Event } from 'aws-lambda'
+
+const s3Mock = mockClient(S3Client)
+
+const mockSharp = {
+  resize: jest.fn().mockReturnThis(),
+  webp: jest.fn().mockReturnThis(),
+  toBuffer: jest.fn().mockResolvedValue(Buffer.from('mock-image')),
+}
+jest.mock('sharp', () => jest.fn(() => mockSharp))
+
+process.env.IMAGE_BUCKET_NAME = 'test-image-bucket'
+
+import { handler } from '../../lambda/image-resizer'
+
+function makeS3Event(key: string, bucket = 'test-image-bucket'): S3Event {
+  return {
+    Records: [
+      {
+        eventVersion: '2.1',
+        eventSource: 'aws:s3',
+        awsRegion: 'eu-west-2',
+        eventTime: '2026-04-09T00:00:00.000Z',
+        eventName: 'ObjectCreated:Put',
+        userIdentity: { principalId: 'test' },
+        requestParameters: { sourceIPAddress: '127.0.0.1' },
+        responseElements: {
+          'x-amz-request-id': 'test',
+          'x-amz-id-2': 'test',
+        },
+        s3: {
+          s3SchemaVersion: '1.0',
+          configurationId: 'test',
+          bucket: {
+            name: bucket,
+            ownerIdentity: { principalId: 'test' },
+            arn: `arn:aws:s3:::${bucket}`,
+          },
+          object: {
+            key,
+            size: 1024,
+            eTag: 'test-etag',
+            sequencer: '001',
+          },
+        },
+      },
+    ],
+  }
+}
+
+describe('image-resizer handler', () => {
+  beforeEach(() => {
+    s3Mock.reset()
+    jest.clearAllMocks()
+
+    s3Mock.on(GetObjectCommand).resolves({
+      Body: {
+        transformToByteArray: jest.fn().mockResolvedValue(new Uint8Array([1, 2, 3])),
+      } as never,
+    })
+    s3Mock.on(PutObjectCommand).resolves({})
+    s3Mock.on(DeleteObjectCommand).resolves({})
+  })
+
+  it('generates three WebP variants with correct dimensions and quality', async () => {
+    await handler(makeS3Event('uploads/recipes/abc/cover'))
+
+    // sharp should be called with the downloaded image buffer
+    const sharp = jest.requireMock('sharp') as jest.Mock
+    expect(sharp).toHaveBeenCalledTimes(3)
+
+    // Verify resize dimensions: 400 (thumb), 800 (medium), 1200 (full)
+    expect(mockSharp.resize).toHaveBeenCalledWith(400)
+    expect(mockSharp.resize).toHaveBeenCalledWith(800)
+    expect(mockSharp.resize).toHaveBeenCalledWith(1200)
+
+    // Verify WebP quality: 80 (thumb), 85 (medium), 90 (full)
+    expect(mockSharp.webp).toHaveBeenCalledWith({ quality: 80 })
+    expect(mockSharp.webp).toHaveBeenCalledWith({ quality: 85 })
+    expect(mockSharp.webp).toHaveBeenCalledWith({ quality: 90 })
+  })
+
+  it('uploads variants to processed/ prefix with correct keys', async () => {
+    await handler(makeS3Event('uploads/recipes/abc/cover'))
+
+    const putCalls = s3Mock.commandCalls(PutObjectCommand)
+    expect(putCalls).toHaveLength(3)
+
+    const putKeys = putCalls.map((call) => call.args[0].input.Key).sort()
+    expect(putKeys).toEqual([
+      'processed/recipes/abc/cover-full.webp',
+      'processed/recipes/abc/cover-medium.webp',
+      'processed/recipes/abc/cover-thumb.webp',
+    ])
+
+    // All uploads go to the correct bucket
+    for (const call of putCalls) {
+      expect(call.args[0].input.Bucket).toBe('test-image-bucket')
+    }
+  })
+
+  it('deletes the original after successful resize', async () => {
+    await handler(makeS3Event('uploads/recipes/abc/cover'))
+
+    const deleteCalls = s3Mock.commandCalls(DeleteObjectCommand)
+    expect(deleteCalls).toHaveLength(1)
+    expect(deleteCalls[0].args[0].input).toEqual({
+      Bucket: 'test-image-bucket',
+      Key: 'uploads/recipes/abc/cover',
+    })
+  })
+
+  it('sets WebP content type on uploaded variants', async () => {
+    await handler(makeS3Event('uploads/recipes/abc/cover'))
+
+    const putCalls = s3Mock.commandCalls(PutObjectCommand)
+    expect(putCalls).toHaveLength(3)
+
+    for (const call of putCalls) {
+      expect(call.args[0].input.ContentType).toBe('image/webp')
+    }
+  })
+})

--- a/test/lambda/recipe-handler.test.ts
+++ b/test/lambda/recipe-handler.test.ts
@@ -1,0 +1,748 @@
+import type { APIGatewayProxyEventV2 } from 'aws-lambda'
+import { DynamoDBDocumentClient, QueryCommand, GetCommand, PutCommand, UpdateCommand, DeleteCommand, ScanCommand } from '@aws-sdk/lib-dynamodb'
+import { S3Client, ListObjectsV2Command, DeleteObjectsCommand } from '@aws-sdk/client-s3'
+import { mockClient } from 'aws-sdk-client-mock'
+
+const ddbMock = mockClient(DynamoDBDocumentClient)
+const s3Mock = mockClient(S3Client)
+
+// Set environment variables before importing handler
+process.env.TABLE_NAME = 'test-recipes-table'
+process.env.IMAGE_BUCKET_NAME = 'test-recipe-images-bucket'
+
+// Import handler after mock setup
+import { handler } from '../../lambda/recipe-handler'
+
+// Build a fake JWT with the given payload (header.payload.signature)
+function fakeJwt(payload: Record<string, unknown>): string {
+  const header = Buffer.from(JSON.stringify({ alg: 'RS256', typ: 'JWT' })).toString('base64url')
+  const body = Buffer.from(JSON.stringify(payload)).toString('base64url')
+  const signature = 'fake-signature'
+  return `${header}.${body}.${signature}`
+}
+
+const contributorToken = fakeJwt({ 'cognito:groups': ['contributor'], sub: 'contributor-user-id', email: 'contributor@example.com', name: 'Test Contributor' })
+const adminToken = fakeJwt({ 'cognito:groups': ['admin'], sub: 'admin-user-id', email: 'admin@example.com', name: 'Admin User' })
+const otherContributorToken = fakeJwt({ 'cognito:groups': ['contributor'], sub: 'other-contributor-id', email: 'other@example.com', name: 'Other Contributor' })
+
+function makeEvent(overrides: Partial<APIGatewayProxyEventV2> = {}): APIGatewayProxyEventV2 {
+  return {
+    version: '2.0',
+    routeKey: 'GET /recipes',
+    rawPath: '/recipes',
+    rawQueryString: '',
+    headers: {},
+    requestContext: {
+      accountId: '123456789012',
+      apiId: 'test-api',
+      domainName: 'test.execute-api.eu-west-2.amazonaws.com',
+      domainPrefix: 'test',
+      http: {
+        method: 'GET',
+        path: '/recipes',
+        protocol: 'HTTP/1.1',
+        sourceIp: '127.0.0.1',
+        userAgent: 'test',
+      },
+      requestId: 'test-request-id',
+      routeKey: 'GET /recipes',
+      stage: '$default',
+      time: '01/Jan/2026:00:00:00 +0000',
+      timeEpoch: 0,
+    },
+    isBase64Encoded: false,
+    ...overrides,
+  } as APIGatewayProxyEventV2
+}
+
+// Helper to build a valid recipe body for POST /recipes
+function validRecipeBody(overrides: Record<string, unknown> = {}): string {
+  return JSON.stringify({
+    title: 'Slow-Cooked Lamb Ragu',
+    coverImage: { key: 'recipes/images/test-id/cover', alt: 'A bowl of lamb ragu' },
+    intro: 'A rich, hearty ragu.',
+    ingredients: [{ item: 'lamb shoulder', quantity: '1', unit: 'kg' }],
+    steps: [{ order: 1, text: 'Season the lamb and sear.' }],
+    tags: ['Italian', 'Slow Cook'],
+    prepTime: 20,
+    cookTime: 240,
+    servings: 4,
+    ...overrides,
+  })
+}
+
+// Sample published recipe item as it would appear in DynamoDB
+function publishedRecipeItem(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    id: 'recipe-uuid-1',
+    slug: 'slow-cooked-lamb-ragu',
+    title: 'Slow-Cooked Lamb Ragu',
+    intro: 'A rich, hearty ragu.',
+    coverImage: { key: 'recipes/images/recipe-uuid-1/cover', alt: 'A bowl of lamb ragu' },
+    ingredients: [{ item: 'lamb shoulder', quantity: '1', unit: 'kg' }],
+    steps: [{ order: 1, text: 'Season the lamb and sear.' }],
+    tags: new Set(['Italian', 'Slow Cook']),
+    prepTime: 20,
+    cookTime: 240,
+    servings: 4,
+    status: 'published',
+    authorId: 'contributor-user-id',
+    authorName: 'Test Contributor',
+    createdAt: '2026-04-08T12:00:00Z',
+    updatedAt: '2026-04-08T14:30:00Z',
+    ...overrides,
+  }
+}
+
+function draftRecipeItem(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+  return publishedRecipeItem({ status: 'draft', slug: 'my-draft-recipe', title: 'My Draft Recipe', ...overrides })
+}
+
+describe('Recipe Lambda handler', () => {
+  beforeEach(() => {
+    ddbMock.reset()
+    s3Mock.reset()
+  })
+
+  // ─── GET /recipes — public listing ──────────────────────────────────
+  describe('GET /recipes — list published recipes', () => {
+    it('returns 200 with lightweight fields for published recipes only', async () => {
+      ddbMock.on(QueryCommand).resolves({
+        Items: [publishedRecipeItem()],
+      })
+
+      const event = makeEvent({
+        routeKey: 'GET /recipes',
+        rawPath: '/recipes',
+      })
+
+      const result = await handler(event)
+
+      expect(result.statusCode).toBe(200)
+      const body = JSON.parse(result.body as string)
+      expect(Array.isArray(body)).toBe(true)
+      expect(body).toHaveLength(1)
+      // Lightweight fields only
+      expect(body[0]).toEqual({
+        id: 'recipe-uuid-1',
+        title: 'Slow-Cooked Lamb Ragu',
+        slug: 'slow-cooked-lamb-ragu',
+        coverImage: { key: 'recipes/images/recipe-uuid-1/cover', alt: 'A bowl of lamb ragu' },
+        tags: ['Italian', 'Slow Cook'],
+        prepTime: 20,
+        cookTime: 240,
+        servings: 4,
+        createdAt: '2026-04-08T12:00:00Z',
+      })
+      // Must NOT include full details like intro, ingredients, steps
+      expect(body[0]).not.toHaveProperty('intro')
+      expect(body[0]).not.toHaveProperty('ingredients')
+      expect(body[0]).not.toHaveProperty('steps')
+    })
+
+    it('does not return draft recipes', async () => {
+      ddbMock.on(QueryCommand).resolves({
+        Items: [publishedRecipeItem()],
+      })
+
+      const event = makeEvent({
+        routeKey: 'GET /recipes',
+        rawPath: '/recipes',
+      })
+
+      const result = await handler(event)
+
+      expect(result.statusCode).toBe(200)
+      const body = JSON.parse(result.body as string)
+      // The query should filter by status=published via the GSI
+      for (const recipe of body) {
+        expect(recipe).not.toHaveProperty('status', 'draft')
+      }
+    })
+
+    it('converts DynamoDB StringSet tags to JSON arrays', async () => {
+      ddbMock.on(QueryCommand).resolves({
+        Items: [publishedRecipeItem({ tags: new Set(['Italian', 'Slow Cook', 'Winter']) })],
+      })
+
+      const event = makeEvent({
+        routeKey: 'GET /recipes',
+        rawPath: '/recipes',
+      })
+
+      const result = await handler(event)
+
+      expect(result.statusCode).toBe(200)
+      const body = JSON.parse(result.body as string)
+      expect(Array.isArray(body[0].tags)).toBe(true)
+      expect(body[0].tags).toContain('Italian')
+      expect(body[0].tags).toContain('Slow Cook')
+      expect(body[0].tags).toContain('Winter')
+    })
+  })
+
+  // ─── GET /recipes/{slug} — single published recipe ──────────────────
+  describe('GET /recipes/{slug} — get published recipe by slug', () => {
+    it('returns 200 with full recipe for a published recipe', async () => {
+      ddbMock.on(ScanCommand).resolves({
+        Items: [publishedRecipeItem()],
+      })
+
+      const event = makeEvent({
+        routeKey: 'GET /recipes/{slug}',
+        rawPath: '/recipes/slow-cooked-lamb-ragu',
+        pathParameters: { slug: 'slow-cooked-lamb-ragu' },
+      })
+
+      const result = await handler(event)
+
+      expect(result.statusCode).toBe(200)
+      const body = JSON.parse(result.body as string)
+      expect(body.id).toBe('recipe-uuid-1')
+      expect(body.slug).toBe('slow-cooked-lamb-ragu')
+      expect(body.title).toBe('Slow-Cooked Lamb Ragu')
+      expect(body.intro).toBe('A rich, hearty ragu.')
+      expect(body.ingredients).toBeDefined()
+      expect(body.steps).toBeDefined()
+      expect(Array.isArray(body.tags)).toBe(true)
+    })
+
+    it('returns 404 for a draft recipe', async () => {
+      ddbMock.on(ScanCommand).resolves({
+        Items: [draftRecipeItem({ slug: 'my-draft-recipe' })],
+      })
+
+      const event = makeEvent({
+        routeKey: 'GET /recipes/{slug}',
+        rawPath: '/recipes/my-draft-recipe',
+        pathParameters: { slug: 'my-draft-recipe' },
+      })
+
+      const result = await handler(event)
+
+      expect(result.statusCode).toBe(404)
+      const body = JSON.parse(result.body as string)
+      expect(body).toHaveProperty('error')
+    })
+
+    it('returns 404 for a non-existent slug', async () => {
+      ddbMock.on(ScanCommand).resolves({
+        Items: [],
+      })
+
+      const event = makeEvent({
+        routeKey: 'GET /recipes/{slug}',
+        rawPath: '/recipes/does-not-exist',
+        pathParameters: { slug: 'does-not-exist' },
+      })
+
+      const result = await handler(event)
+
+      expect(result.statusCode).toBe(404)
+      const body = JSON.parse(result.body as string)
+      expect(body).toHaveProperty('error')
+    })
+  })
+
+  // ─── GET /me/recipes — authenticated user's recipes ─────────────────
+  describe('GET /me/recipes — list user recipes', () => {
+    it('returns 200 with all recipes (draft and published) for authenticated user, sorted newest first', async () => {
+      const draft = draftRecipeItem({ createdAt: '2026-04-09T10:00:00Z' })
+      const published = publishedRecipeItem({ createdAt: '2026-04-08T12:00:00Z' })
+
+      ddbMock.on(QueryCommand).resolves({
+        Items: [draft, published],
+      })
+
+      const event = makeEvent({
+        routeKey: 'GET /me/recipes',
+        rawPath: '/me/recipes',
+        headers: { authorization: `Bearer ${contributorToken}` },
+      })
+
+      const result = await handler(event)
+
+      expect(result.statusCode).toBe(200)
+      const body = JSON.parse(result.body as string)
+      expect(Array.isArray(body)).toBe(true)
+      expect(body).toHaveLength(2)
+    })
+
+    it('returns 401 without a valid token', async () => {
+      const event = makeEvent({
+        routeKey: 'GET /me/recipes',
+        rawPath: '/me/recipes',
+        headers: {},
+      })
+
+      const result = await handler(event)
+
+      expect(result.statusCode).toBe(401)
+      const body = JSON.parse(result.body as string)
+      expect(body).toHaveProperty('error')
+    })
+  })
+
+  // ─── POST /recipes — create recipe ──────────────────────────────────
+  describe('POST /recipes — create recipe', () => {
+    it('returns 201 with status draft and authorId from JWT sub', async () => {
+      // Slug uniqueness check returns no collisions
+      ddbMock.on(ScanCommand).resolves({ Items: [] })
+      ddbMock.on(PutCommand).resolves({})
+
+      const event = makeEvent({
+        routeKey: 'POST /recipes',
+        rawPath: '/recipes',
+        headers: { authorization: `Bearer ${contributorToken}` },
+        body: validRecipeBody(),
+      })
+
+      const result = await handler(event)
+
+      expect(result.statusCode).toBe(201)
+      const body = JSON.parse(result.body as string)
+      expect(body.status).toBe('draft')
+      expect(body.authorId).toBe('contributor-user-id')
+      expect(body.id).toBeDefined()
+      expect(body.slug).toBe('slow-cooked-lamb-ragu')
+      expect(body.createdAt).toBeDefined()
+    })
+
+    it('auto-generates a URL-friendly slug from the title', async () => {
+      ddbMock.on(ScanCommand).resolves({ Items: [] })
+      ddbMock.on(PutCommand).resolves({})
+
+      const event = makeEvent({
+        routeKey: 'POST /recipes',
+        rawPath: '/recipes',
+        headers: { authorization: `Bearer ${contributorToken}` },
+        body: validRecipeBody({ title: 'My Amazing Recipe!' }),
+      })
+
+      const result = await handler(event)
+
+      expect(result.statusCode).toBe(201)
+      const body = JSON.parse(result.body as string)
+      expect(body.slug).toBe('my-amazing-recipe')
+    })
+
+    it('appends numeric suffix when slug collides', async () => {
+      // First scan returns existing recipe with same slug
+      ddbMock.on(ScanCommand)
+        .resolvesOnce({ Items: [{ slug: 'slow-cooked-lamb-ragu' }] })  // collision
+        .resolvesOnce({ Items: [] })  // no collision with suffix
+      ddbMock.on(PutCommand).resolves({})
+
+      const event = makeEvent({
+        routeKey: 'POST /recipes',
+        rawPath: '/recipes',
+        headers: { authorization: `Bearer ${contributorToken}` },
+        body: validRecipeBody(),
+      })
+
+      const result = await handler(event)
+
+      expect(result.statusCode).toBe(201)
+      const body = JSON.parse(result.body as string)
+      expect(body.slug).toBe('slow-cooked-lamb-ragu-2')
+    })
+
+    it('returns 401 without a valid token', async () => {
+      const event = makeEvent({
+        routeKey: 'POST /recipes',
+        rawPath: '/recipes',
+        headers: {},
+        body: validRecipeBody(),
+      })
+
+      const result = await handler(event)
+
+      expect(result.statusCode).toBe(401)
+      const body = JSON.parse(result.body as string)
+      expect(body).toHaveProperty('error')
+    })
+
+    it('returns 400 when title is missing', async () => {
+      const event = makeEvent({
+        routeKey: 'POST /recipes',
+        rawPath: '/recipes',
+        headers: { authorization: `Bearer ${contributorToken}` },
+        body: validRecipeBody({ title: undefined }),
+      })
+
+      const result = await handler(event)
+
+      expect(result.statusCode).toBe(400)
+      const body = JSON.parse(result.body as string)
+      expect(body).toHaveProperty('error')
+    })
+
+    it('returns 400 when coverImage is missing', async () => {
+      const event = makeEvent({
+        routeKey: 'POST /recipes',
+        rawPath: '/recipes',
+        headers: { authorization: `Bearer ${contributorToken}` },
+        body: validRecipeBody({ coverImage: undefined }),
+      })
+
+      const result = await handler(event)
+
+      expect(result.statusCode).toBe(400)
+      const body = JSON.parse(result.body as string)
+      expect(body).toHaveProperty('error')
+    })
+
+    it('returns 400 when coverImage key is missing', async () => {
+      const event = makeEvent({
+        routeKey: 'POST /recipes',
+        rawPath: '/recipes',
+        headers: { authorization: `Bearer ${contributorToken}` },
+        body: validRecipeBody({ coverImage: { alt: 'some alt text' } }),
+      })
+
+      const result = await handler(event)
+
+      expect(result.statusCode).toBe(400)
+      const body = JSON.parse(result.body as string)
+      expect(body).toHaveProperty('error')
+    })
+
+    it('returns 400 when coverImage alt is missing', async () => {
+      const event = makeEvent({
+        routeKey: 'POST /recipes',
+        rawPath: '/recipes',
+        headers: { authorization: `Bearer ${contributorToken}` },
+        body: validRecipeBody({ coverImage: { key: 'some/key' } }),
+      })
+
+      const result = await handler(event)
+
+      expect(result.statusCode).toBe(400)
+      const body = JSON.parse(result.body as string)
+      expect(body).toHaveProperty('error')
+    })
+
+    it('returns 400 when ingredients are empty', async () => {
+      const event = makeEvent({
+        routeKey: 'POST /recipes',
+        rawPath: '/recipes',
+        headers: { authorization: `Bearer ${contributorToken}` },
+        body: validRecipeBody({ ingredients: [] }),
+      })
+
+      const result = await handler(event)
+
+      expect(result.statusCode).toBe(400)
+      const body = JSON.parse(result.body as string)
+      expect(body).toHaveProperty('error')
+    })
+
+    it('returns 400 when steps are empty', async () => {
+      const event = makeEvent({
+        routeKey: 'POST /recipes',
+        rawPath: '/recipes',
+        headers: { authorization: `Bearer ${contributorToken}` },
+        body: validRecipeBody({ steps: [] }),
+      })
+
+      const result = await handler(event)
+
+      expect(result.statusCode).toBe(400)
+      const body = JSON.parse(result.body as string)
+      expect(body).toHaveProperty('error')
+    })
+  })
+
+  // ─── PUT /recipes/{id} — update recipe ──────────────────────────────
+  describe('PUT /recipes/{id} — update recipe', () => {
+    it('returns 200 when contributor updates their own recipe', async () => {
+      ddbMock.on(GetCommand).resolves({
+        Item: publishedRecipeItem({ authorId: 'contributor-user-id' }),
+      })
+      ddbMock.on(UpdateCommand).resolves({
+        Attributes: publishedRecipeItem({ authorId: 'contributor-user-id', title: 'Updated Title' }),
+      })
+
+      const event = makeEvent({
+        routeKey: 'PUT /recipes/{id}',
+        rawPath: '/recipes/recipe-uuid-1',
+        pathParameters: { id: 'recipe-uuid-1' },
+        headers: { authorization: `Bearer ${contributorToken}` },
+        body: JSON.stringify({ title: 'Updated Title', intro: 'Updated intro.' }),
+      })
+
+      const result = await handler(event)
+
+      expect(result.statusCode).toBe(200)
+    })
+
+    it('returns 403 when contributor tries to update another user\'s recipe', async () => {
+      ddbMock.on(GetCommand).resolves({
+        Item: publishedRecipeItem({ authorId: 'other-contributor-id' }),
+      })
+
+      const event = makeEvent({
+        routeKey: 'PUT /recipes/{id}',
+        rawPath: '/recipes/recipe-uuid-1',
+        pathParameters: { id: 'recipe-uuid-1' },
+        headers: { authorization: `Bearer ${contributorToken}` },
+        body: JSON.stringify({ title: 'Hijacked Title' }),
+      })
+
+      const result = await handler(event)
+
+      expect(result.statusCode).toBe(403)
+      const body = JSON.parse(result.body as string)
+      expect(body).toHaveProperty('error')
+    })
+
+    it('returns 200 when admin updates any recipe', async () => {
+      ddbMock.on(GetCommand).resolves({
+        Item: publishedRecipeItem({ authorId: 'contributor-user-id' }),
+      })
+      ddbMock.on(UpdateCommand).resolves({
+        Attributes: publishedRecipeItem({ authorId: 'contributor-user-id', title: 'Admin Updated' }),
+      })
+
+      const event = makeEvent({
+        routeKey: 'PUT /recipes/{id}',
+        rawPath: '/recipes/recipe-uuid-1',
+        pathParameters: { id: 'recipe-uuid-1' },
+        headers: { authorization: `Bearer ${adminToken}` },
+        body: JSON.stringify({ title: 'Admin Updated' }),
+      })
+
+      const result = await handler(event)
+
+      expect(result.statusCode).toBe(200)
+    })
+
+    it('does not change slug when title is updated (slug is immutable)', async () => {
+      ddbMock.on(GetCommand).resolves({
+        Item: publishedRecipeItem({ slug: 'slow-cooked-lamb-ragu', authorId: 'contributor-user-id' }),
+      })
+      ddbMock.on(UpdateCommand).resolves({
+        Attributes: publishedRecipeItem({ slug: 'slow-cooked-lamb-ragu', title: 'Completely New Title', authorId: 'contributor-user-id' }),
+      })
+
+      const event = makeEvent({
+        routeKey: 'PUT /recipes/{id}',
+        rawPath: '/recipes/recipe-uuid-1',
+        pathParameters: { id: 'recipe-uuid-1' },
+        headers: { authorization: `Bearer ${contributorToken}` },
+        body: JSON.stringify({ title: 'Completely New Title' }),
+      })
+
+      const result = await handler(event)
+
+      expect(result.statusCode).toBe(200)
+      const body = JSON.parse(result.body as string)
+      expect(body.slug).toBe('slow-cooked-lamb-ragu')
+    })
+
+    it('returns 401 without a valid token', async () => {
+      const event = makeEvent({
+        routeKey: 'PUT /recipes/{id}',
+        rawPath: '/recipes/recipe-uuid-1',
+        pathParameters: { id: 'recipe-uuid-1' },
+        headers: {},
+        body: JSON.stringify({ title: 'No Auth Update' }),
+      })
+
+      const result = await handler(event)
+
+      expect(result.statusCode).toBe(401)
+      const body = JSON.parse(result.body as string)
+      expect(body).toHaveProperty('error')
+    })
+  })
+
+  // ─── PATCH /recipes/{id}/publish ────────────────────────────────────
+  describe('PATCH /recipes/{id}/publish — publish recipe', () => {
+    it('returns 200 and sets status to published', async () => {
+      ddbMock.on(GetCommand).resolves({
+        Item: draftRecipeItem({ authorId: 'contributor-user-id' }),
+      })
+      ddbMock.on(UpdateCommand).resolves({
+        Attributes: publishedRecipeItem({ authorId: 'contributor-user-id' }),
+      })
+
+      const event = makeEvent({
+        routeKey: 'PATCH /recipes/{id}/publish',
+        rawPath: '/recipes/recipe-uuid-1/publish',
+        pathParameters: { id: 'recipe-uuid-1' },
+        headers: { authorization: `Bearer ${contributorToken}` },
+      })
+
+      const result = await handler(event)
+
+      expect(result.statusCode).toBe(200)
+      const body = JSON.parse(result.body as string)
+      expect(body.status).toBe('published')
+    })
+
+    it('returns 403 when contributor publishes another user\'s recipe', async () => {
+      ddbMock.on(GetCommand).resolves({
+        Item: draftRecipeItem({ authorId: 'other-contributor-id' }),
+      })
+
+      const event = makeEvent({
+        routeKey: 'PATCH /recipes/{id}/publish',
+        rawPath: '/recipes/recipe-uuid-1/publish',
+        pathParameters: { id: 'recipe-uuid-1' },
+        headers: { authorization: `Bearer ${contributorToken}` },
+      })
+
+      const result = await handler(event)
+
+      expect(result.statusCode).toBe(403)
+      const body = JSON.parse(result.body as string)
+      expect(body).toHaveProperty('error')
+    })
+  })
+
+  // ─── PATCH /recipes/{id}/unpublish ──────────────────────────────────
+  describe('PATCH /recipes/{id}/unpublish — unpublish recipe', () => {
+    it('returns 200 and sets status to draft', async () => {
+      ddbMock.on(GetCommand).resolves({
+        Item: publishedRecipeItem({ authorId: 'contributor-user-id' }),
+      })
+      ddbMock.on(UpdateCommand).resolves({
+        Attributes: draftRecipeItem({ authorId: 'contributor-user-id' }),
+      })
+
+      const event = makeEvent({
+        routeKey: 'PATCH /recipes/{id}/unpublish',
+        rawPath: '/recipes/recipe-uuid-1/unpublish',
+        pathParameters: { id: 'recipe-uuid-1' },
+        headers: { authorization: `Bearer ${contributorToken}` },
+      })
+
+      const result = await handler(event)
+
+      expect(result.statusCode).toBe(200)
+      const body = JSON.parse(result.body as string)
+      expect(body.status).toBe('draft')
+    })
+
+    it('returns 403 when contributor unpublishes another user\'s recipe', async () => {
+      ddbMock.on(GetCommand).resolves({
+        Item: publishedRecipeItem({ authorId: 'other-contributor-id' }),
+      })
+
+      const event = makeEvent({
+        routeKey: 'PATCH /recipes/{id}/unpublish',
+        rawPath: '/recipes/recipe-uuid-1/unpublish',
+        pathParameters: { id: 'recipe-uuid-1' },
+        headers: { authorization: `Bearer ${contributorToken}` },
+      })
+
+      const result = await handler(event)
+
+      expect(result.statusCode).toBe(403)
+      const body = JSON.parse(result.body as string)
+      expect(body).toHaveProperty('error')
+    })
+  })
+
+  // ─── DELETE /recipes/{id} — delete recipe ───────────────────────────
+  describe('DELETE /recipes/{id} — delete recipe', () => {
+    it('returns 200 and deletes recipe from DynamoDB and S3 images', async () => {
+      ddbMock.on(GetCommand).resolves({
+        Item: publishedRecipeItem({ authorId: 'contributor-user-id' }),
+      })
+      ddbMock.on(DeleteCommand).resolves({})
+      s3Mock.on(ListObjectsV2Command).resolves({
+        Contents: [
+          { Key: 'processed/recipes/recipe-uuid-1/cover-thumb.webp' },
+          { Key: 'processed/recipes/recipe-uuid-1/cover-medium.webp' },
+          { Key: 'processed/recipes/recipe-uuid-1/cover-full.webp' },
+        ],
+      })
+      s3Mock.on(DeleteObjectsCommand).resolves({})
+
+      const event = makeEvent({
+        routeKey: 'DELETE /recipes/{id}',
+        rawPath: '/recipes/recipe-uuid-1',
+        pathParameters: { id: 'recipe-uuid-1' },
+        headers: { authorization: `Bearer ${contributorToken}` },
+      })
+
+      const result = await handler(event)
+
+      expect(result.statusCode).toBe(200)
+      // Verify S3 cleanup was attempted
+      expect(s3Mock.commandCalls(ListObjectsV2Command)).toHaveLength(1)
+      expect(s3Mock.commandCalls(DeleteObjectsCommand)).toHaveLength(1)
+    })
+
+    it('returns 403 when contributor deletes another user\'s recipe', async () => {
+      ddbMock.on(GetCommand).resolves({
+        Item: publishedRecipeItem({ authorId: 'other-contributor-id' }),
+      })
+
+      const event = makeEvent({
+        routeKey: 'DELETE /recipes/{id}',
+        rawPath: '/recipes/recipe-uuid-1',
+        pathParameters: { id: 'recipe-uuid-1' },
+        headers: { authorization: `Bearer ${contributorToken}` },
+      })
+
+      const result = await handler(event)
+
+      expect(result.statusCode).toBe(403)
+      const body = JSON.parse(result.body as string)
+      expect(body).toHaveProperty('error')
+    })
+
+    it('returns 200 when admin deletes any recipe', async () => {
+      ddbMock.on(GetCommand).resolves({
+        Item: publishedRecipeItem({ authorId: 'contributor-user-id' }),
+      })
+      ddbMock.on(DeleteCommand).resolves({})
+      s3Mock.on(ListObjectsV2Command).resolves({ Contents: [] })
+
+      const event = makeEvent({
+        routeKey: 'DELETE /recipes/{id}',
+        rawPath: '/recipes/recipe-uuid-1',
+        pathParameters: { id: 'recipe-uuid-1' },
+        headers: { authorization: `Bearer ${adminToken}` },
+      })
+
+      const result = await handler(event)
+
+      expect(result.statusCode).toBe(200)
+    })
+
+    it('returns 401 without a valid token', async () => {
+      const event = makeEvent({
+        routeKey: 'DELETE /recipes/{id}',
+        rawPath: '/recipes/recipe-uuid-1',
+        pathParameters: { id: 'recipe-uuid-1' },
+        headers: {},
+      })
+
+      const result = await handler(event)
+
+      expect(result.statusCode).toBe(401)
+      const body = JSON.parse(result.body as string)
+      expect(body).toHaveProperty('error')
+    })
+  })
+
+  // ─── Unknown route ──────────────────────────────────────────────────
+  describe('Unknown route', () => {
+    it('returns 404 for unmatched route', async () => {
+      const event = makeEvent({
+        routeKey: 'GET /unknown',
+        rawPath: '/unknown',
+      })
+
+      const result = await handler(event)
+
+      expect(result.statusCode).toBe(404)
+      const body = JSON.parse(result.body as string)
+      expect(body).toHaveProperty('error')
+    })
+  })
+})

--- a/test/lambda/recipe-handler.test.ts
+++ b/test/lambda/recipe-handler.test.ts
@@ -730,6 +730,100 @@ describe('Recipe Lambda handler', () => {
     })
   })
 
+  // ─── GET /recipes/tags — public tag aggregation ─────────────────────
+  describe('GET /recipes/tags — list tags with counts', () => {
+    it('returns 200 with tags sorted alphabetically with counts', async () => {
+      ddbMock.on(ScanCommand).resolves({
+        Items: [
+          { tags: { wrapperName: 'Set', values: ['Italian', 'Slow Cook'], type: 'String' }, status: 'published' },
+          { tags: { wrapperName: 'Set', values: ['Italian', 'Vegetarian'], type: 'String' }, status: 'published' },
+        ],
+      })
+
+      const event = makeEvent({
+        routeKey: 'GET /recipes/tags',
+        rawPath: '/recipes/tags',
+      })
+
+      const result = await handler(event)
+
+      expect(result.statusCode).toBe(200)
+      const body = JSON.parse(result.body as string)
+      expect(Array.isArray(body)).toBe(true)
+      expect(body).toEqual([
+        { tag: 'Italian', count: 2 },
+        { tag: 'Slow Cook', count: 1 },
+        { tag: 'Vegetarian', count: 1 },
+      ])
+    })
+
+    it('aggregates tag counts across multiple published recipes', async () => {
+      ddbMock.on(ScanCommand).resolves({
+        Items: [
+          { tags: { wrapperName: 'Set', values: ['Italian', 'Pasta'], type: 'String' }, status: 'published' },
+          { tags: { wrapperName: 'Set', values: ['Italian', 'Slow Cook'], type: 'String' }, status: 'published' },
+          { tags: { wrapperName: 'Set', values: ['Italian', 'Pasta', 'Vegetarian'], type: 'String' }, status: 'published' },
+        ],
+      })
+
+      const event = makeEvent({
+        routeKey: 'GET /recipes/tags',
+        rawPath: '/recipes/tags',
+      })
+
+      const result = await handler(event)
+
+      expect(result.statusCode).toBe(200)
+      const body = JSON.parse(result.body as string)
+      // Italian appears in all 3 recipes
+      expect(body.find((t: { tag: string }) => t.tag === 'Italian')).toEqual({ tag: 'Italian', count: 3 })
+      // Pasta appears in 2 recipes
+      expect(body.find((t: { tag: string }) => t.tag === 'Pasta')).toEqual({ tag: 'Pasta', count: 2 })
+      // Slow Cook and Vegetarian appear in 1 recipe each
+      expect(body.find((t: { tag: string }) => t.tag === 'Slow Cook')).toEqual({ tag: 'Slow Cook', count: 1 })
+      expect(body.find((t: { tag: string }) => t.tag === 'Vegetarian')).toEqual({ tag: 'Vegetarian', count: 1 })
+    })
+
+    it('excludes tags from draft recipes', async () => {
+      // The ScanCommand should filter on status = 'published', so drafts should not appear
+      ddbMock.on(ScanCommand).resolves({
+        Items: [
+          { tags: { wrapperName: 'Set', values: ['Italian'], type: 'String' }, status: 'published' },
+        ],
+      })
+
+      const event = makeEvent({
+        routeKey: 'GET /recipes/tags',
+        rawPath: '/recipes/tags',
+      })
+
+      const result = await handler(event)
+
+      expect(result.statusCode).toBe(200)
+      const body = JSON.parse(result.body as string)
+      expect(body).toEqual([{ tag: 'Italian', count: 1 }])
+      // Draft tags must not be included — the scan should only return published recipes
+    })
+
+    it('returns empty array when no published recipes exist', async () => {
+      ddbMock.on(ScanCommand).resolves({
+        Items: [],
+      })
+
+      const event = makeEvent({
+        routeKey: 'GET /recipes/tags',
+        rawPath: '/recipes/tags',
+      })
+
+      const result = await handler(event)
+
+      expect(result.statusCode).toBe(200)
+      const body = JSON.parse(result.body as string)
+      expect(Array.isArray(body)).toBe(true)
+      expect(body).toEqual([])
+    })
+  })
+
   // ─── Unknown route ──────────────────────────────────────────────────
   describe('Unknown route', () => {
     it('returns 404 for unmatched route', async () => {

--- a/test/lambda/recipe-image-handler.test.ts
+++ b/test/lambda/recipe-image-handler.test.ts
@@ -1,0 +1,182 @@
+import type { APIGatewayProxyEventV2 } from 'aws-lambda'
+import { S3Client } from '@aws-sdk/client-s3'
+import { mockClient } from 'aws-sdk-client-mock'
+
+// Mock getSignedUrl before importing the handler
+jest.mock('@aws-sdk/s3-request-presigner', () => ({
+  getSignedUrl: jest.fn().mockResolvedValue('https://mock-presigned-url.s3.amazonaws.com/test'),
+}))
+
+const s3Mock = mockClient(S3Client)
+
+// Set environment variables before importing handler
+process.env.IMAGE_BUCKET_NAME = 'test-recipe-images-bucket'
+
+// Import handler after mock setup
+import { handler } from '../../lambda/recipe-image-handler'
+import { getSignedUrl } from '@aws-sdk/s3-request-presigner'
+
+// Build a fake JWT with the given payload (header.payload.signature)
+function fakeJwt(payload: Record<string, unknown>): string {
+  const header = Buffer.from(JSON.stringify({ alg: 'RS256', typ: 'JWT' })).toString('base64url')
+  const body = Buffer.from(JSON.stringify(payload)).toString('base64url')
+  const signature = 'fake-signature'
+  return `${header}.${body}.${signature}`
+}
+
+const contributorToken = fakeJwt({ 'cognito:groups': ['contributor'], sub: 'contributor-user-id', email: 'contributor@example.com', name: 'Test Contributor' })
+
+function makeEvent(overrides: Partial<APIGatewayProxyEventV2> = {}): APIGatewayProxyEventV2 {
+  return {
+    version: '2.0',
+    routeKey: 'POST /recipes/images/upload-url',
+    rawPath: '/recipes/images/upload-url',
+    rawQueryString: '',
+    headers: {},
+    requestContext: {
+      accountId: '123456789012',
+      apiId: 'test-api',
+      domainName: 'test.execute-api.eu-west-2.amazonaws.com',
+      domainPrefix: 'test',
+      http: {
+        method: 'POST',
+        path: '/recipes/images/upload-url',
+        protocol: 'HTTP/1.1',
+        sourceIp: '127.0.0.1',
+        userAgent: 'test',
+      },
+      requestId: 'test-request-id',
+      routeKey: 'POST /recipes/images/upload-url',
+      stage: '$default',
+      time: '01/Jan/2026:00:00:00 +0000',
+      timeEpoch: 0,
+    },
+    isBase64Encoded: false,
+    ...overrides,
+  } as APIGatewayProxyEventV2
+}
+
+describe('Recipe Image handler', () => {
+  beforeEach(() => {
+    s3Mock.reset()
+    ;(getSignedUrl as jest.Mock).mockClear()
+    ;(getSignedUrl as jest.Mock).mockResolvedValue('https://mock-presigned-url.s3.amazonaws.com/test')
+  })
+
+  // ─── POST /recipes/images/upload-url — presigned URL generation ────
+  describe('POST /recipes/images/upload-url — presigned URL generation', () => {
+    it('returns 200 with uploadUrl and key', async () => {
+      const event = makeEvent({
+        headers: { authorization: `Bearer ${contributorToken}` },
+        body: JSON.stringify({ recipeId: 'abc', imageType: 'cover' }),
+      })
+
+      const result = await handler(event)
+
+      expect(result.statusCode).toBe(200)
+      const body = JSON.parse(result.body as string)
+      expect(typeof body.uploadUrl).toBe('string')
+      expect(typeof body.key).toBe('string')
+      expect(body.key).toMatch(/^uploads\/recipes\/[^/]+\//)
+    })
+
+    it('generates correct S3 key for cover image', async () => {
+      const event = makeEvent({
+        headers: { authorization: `Bearer ${contributorToken}` },
+        body: JSON.stringify({ recipeId: 'abc', imageType: 'cover' }),
+      })
+
+      const result = await handler(event)
+
+      expect(result.statusCode).toBe(200)
+      const body = JSON.parse(result.body as string)
+      expect(body.key).toBe('uploads/recipes/abc/cover')
+    })
+
+    it('generates correct S3 key for step image', async () => {
+      const event = makeEvent({
+        headers: { authorization: `Bearer ${contributorToken}` },
+        body: JSON.stringify({ recipeId: 'abc', imageType: 'step', stepOrder: 3 }),
+      })
+
+      const result = await handler(event)
+
+      expect(result.statusCode).toBe(200)
+      const body = JSON.parse(result.body as string)
+      expect(body.key).toBe('uploads/recipes/abc/step-3')
+    })
+
+    it('returns 401 without bearer token', async () => {
+      const event = makeEvent({
+        headers: {},
+        body: JSON.stringify({ recipeId: 'abc', imageType: 'cover' }),
+      })
+
+      const result = await handler(event)
+
+      expect(result.statusCode).toBe(401)
+      const body = JSON.parse(result.body as string)
+      expect(body).toHaveProperty('error')
+    })
+
+    it('returns 400 for missing recipeId', async () => {
+      const event = makeEvent({
+        headers: { authorization: `Bearer ${contributorToken}` },
+        body: JSON.stringify({ imageType: 'cover' }),
+      })
+
+      const result = await handler(event)
+
+      expect(result.statusCode).toBe(400)
+      const body = JSON.parse(result.body as string)
+      expect(body).toHaveProperty('error')
+    })
+
+    it('returns 400 for missing imageType', async () => {
+      const event = makeEvent({
+        headers: { authorization: `Bearer ${contributorToken}` },
+        body: JSON.stringify({ recipeId: 'abc' }),
+      })
+
+      const result = await handler(event)
+
+      expect(result.statusCode).toBe(400)
+      const body = JSON.parse(result.body as string)
+      expect(body).toHaveProperty('error')
+    })
+  })
+
+  // ─── Unknown route ──────────────────────────────────────────────────
+  describe('Unknown route', () => {
+    it('returns 404 for unmatched route', async () => {
+      const event = makeEvent({
+        routeKey: 'GET /unknown',
+        rawPath: '/unknown',
+        requestContext: {
+          accountId: '123456789012',
+          apiId: 'test-api',
+          domainName: 'test.execute-api.eu-west-2.amazonaws.com',
+          domainPrefix: 'test',
+          http: {
+            method: 'GET',
+            path: '/unknown',
+            protocol: 'HTTP/1.1',
+            sourceIp: '127.0.0.1',
+            userAgent: 'test',
+          },
+          requestId: 'test-request-id',
+          routeKey: 'GET /unknown',
+          stage: '$default',
+          time: '01/Jan/2026:00:00:00 +0000',
+          timeEpoch: 0,
+        },
+      })
+
+      const result = await handler(event)
+
+      expect(result.statusCode).toBe(404)
+      const body = JSON.parse(result.body as string)
+      expect(body).toHaveProperty('error')
+    })
+  })
+})

--- a/test/recipe-stack.test.ts
+++ b/test/recipe-stack.test.ts
@@ -1,0 +1,192 @@
+import * as cdk from 'aws-cdk-lib'
+import { Match, Template } from 'aws-cdk-lib/assertions'
+import { RecipeStack } from '../lib/recipe-stack'
+
+function createTestStack(): Template {
+  const app = new cdk.App()
+
+  cdk.Tags.of(app).add('Owner', 'Akli')
+  cdk.Tags.of(app).add('CostCenter', 'Recipes')
+
+  const stack = new RecipeStack(app, 'TestRecipeStack', {
+    env: { account: '123456789012', region: 'eu-west-2' },
+    tags: {
+      Project: 'recipes',
+      Environment: 'production',
+      ManagedBy: 'cdk',
+    },
+  })
+
+  return Template.fromStack(stack)
+}
+
+describe('RecipeStack', () => {
+  let template: Template
+
+  beforeAll(() => {
+    template = createTestStack()
+  })
+
+  describe('DynamoDB table', () => {
+    it('creates a DynamoDB table named recipes', () => {
+      template.hasResourceProperties('AWS::DynamoDB::Table', {
+        TableName: 'recipes',
+      })
+    })
+
+    it('has partition key id of type String', () => {
+      template.hasResourceProperties('AWS::DynamoDB::Table', {
+        KeySchema: [
+          { AttributeName: 'id', KeyType: 'HASH' },
+        ],
+        AttributeDefinitions: Match.arrayWith([
+          { AttributeName: 'id', AttributeType: 'S' },
+        ]),
+      })
+    })
+
+    it('uses on-demand billing (PAY_PER_REQUEST)', () => {
+      template.hasResourceProperties('AWS::DynamoDB::Table', {
+        BillingMode: 'PAY_PER_REQUEST',
+      })
+    })
+
+    it('enables Point-in-Time Recovery', () => {
+      template.hasResourceProperties('AWS::DynamoDB::Table', {
+        PointInTimeRecoverySpecification: {
+          PointInTimeRecoveryEnabled: true,
+        },
+      })
+    })
+  })
+
+  describe('GSI status-createdAt-index', () => {
+    it('creates GSI with name status-createdAt-index', () => {
+      template.hasResourceProperties('AWS::DynamoDB::Table', {
+        GlobalSecondaryIndexes: Match.arrayWith([
+          Match.objectLike({
+            IndexName: 'status-createdAt-index',
+          }),
+        ]),
+      })
+    })
+
+    it('has partition key status (String)', () => {
+      template.hasResourceProperties('AWS::DynamoDB::Table', {
+        GlobalSecondaryIndexes: Match.arrayWith([
+          Match.objectLike({
+            IndexName: 'status-createdAt-index',
+            KeySchema: Match.arrayWith([
+              { AttributeName: 'status', KeyType: 'HASH' },
+            ]),
+          }),
+        ]),
+        AttributeDefinitions: Match.arrayWith([
+          { AttributeName: 'status', AttributeType: 'S' },
+        ]),
+      })
+    })
+
+    it('has sort key createdAt (String)', () => {
+      template.hasResourceProperties('AWS::DynamoDB::Table', {
+        GlobalSecondaryIndexes: Match.arrayWith([
+          Match.objectLike({
+            IndexName: 'status-createdAt-index',
+            KeySchema: Match.arrayWith([
+              { AttributeName: 'createdAt', KeyType: 'RANGE' },
+            ]),
+          }),
+        ]),
+        AttributeDefinitions: Match.arrayWith([
+          { AttributeName: 'createdAt', AttributeType: 'S' },
+        ]),
+      })
+    })
+  })
+
+  describe('GSI authorId-createdAt-index', () => {
+    it('creates GSI with name authorId-createdAt-index', () => {
+      template.hasResourceProperties('AWS::DynamoDB::Table', {
+        GlobalSecondaryIndexes: Match.arrayWith([
+          Match.objectLike({
+            IndexName: 'authorId-createdAt-index',
+          }),
+        ]),
+      })
+    })
+
+    it('has partition key authorId (String)', () => {
+      template.hasResourceProperties('AWS::DynamoDB::Table', {
+        GlobalSecondaryIndexes: Match.arrayWith([
+          Match.objectLike({
+            IndexName: 'authorId-createdAt-index',
+            KeySchema: Match.arrayWith([
+              { AttributeName: 'authorId', KeyType: 'HASH' },
+            ]),
+          }),
+        ]),
+        AttributeDefinitions: Match.arrayWith([
+          { AttributeName: 'authorId', AttributeType: 'S' },
+        ]),
+      })
+    })
+
+    it('has sort key createdAt (String)', () => {
+      template.hasResourceProperties('AWS::DynamoDB::Table', {
+        GlobalSecondaryIndexes: Match.arrayWith([
+          Match.objectLike({
+            IndexName: 'authorId-createdAt-index',
+            KeySchema: Match.arrayWith([
+              { AttributeName: 'createdAt', KeyType: 'RANGE' },
+            ]),
+          }),
+        ]),
+        AttributeDefinitions: Match.arrayWith([
+          { AttributeName: 'createdAt', AttributeType: 'S' },
+        ]),
+      })
+    })
+  })
+
+  describe('Tags', () => {
+    it('tags the table with Owner', () => {
+      template.hasResourceProperties('AWS::DynamoDB::Table', {
+        Tags: Match.arrayWith([
+          Match.objectLike({ Key: 'Owner', Value: 'Akli' }),
+        ]),
+      })
+    })
+
+    it('tags the table with CostCenter', () => {
+      template.hasResourceProperties('AWS::DynamoDB::Table', {
+        Tags: Match.arrayWith([
+          Match.objectLike({ Key: 'CostCenter', Value: 'Recipes' }),
+        ]),
+      })
+    })
+
+    it('tags the table with Project=recipes', () => {
+      template.hasResourceProperties('AWS::DynamoDB::Table', {
+        Tags: Match.arrayWith([
+          Match.objectLike({ Key: 'Project', Value: 'recipes' }),
+        ]),
+      })
+    })
+
+    it('tags the table with Environment=production', () => {
+      template.hasResourceProperties('AWS::DynamoDB::Table', {
+        Tags: Match.arrayWith([
+          Match.objectLike({ Key: 'Environment', Value: 'production' }),
+        ]),
+      })
+    })
+
+    it('tags the table with ManagedBy=cdk', () => {
+      template.hasResourceProperties('AWS::DynamoDB::Table', {
+        Tags: Match.arrayWith([
+          Match.objectLike({ Key: 'ManagedBy', Value: 'cdk' }),
+        ]),
+      })
+    })
+  })
+})

--- a/test/recipe-stack.test.ts
+++ b/test/recipe-stack.test.ts
@@ -10,6 +10,9 @@ function createTestStack(): Template {
 
   const stack = new RecipeStack(app, 'TestRecipeStack', {
     env: { account: '123456789012', region: 'eu-west-2' },
+    userPoolId: 'eu-west-2_TestPool123',
+    userPoolClientId: 'test-client-id-abc',
+    userPoolArn: 'arn:aws:cognito-idp:eu-west-2:123456789012:userpool/eu-west-2_TestPool123',
     tags: {
       Project: 'recipes',
       Environment: 'production',
@@ -191,6 +194,130 @@ describe('RecipeStack', () => {
             }),
           ]),
         },
+      })
+    })
+  })
+
+  describe('HTTP API Gateway', () => {
+    it('creates an HTTP API (ApiGatewayV2)', () => {
+      template.hasResourceProperties('AWS::ApiGatewayV2::Api', {
+        ProtocolType: 'HTTP',
+      })
+    })
+  })
+
+  describe('CORS', () => {
+    it('configures CORS to allow https://akli.dev', () => {
+      template.hasResourceProperties('AWS::ApiGatewayV2::Api', {
+        CorsConfiguration: Match.objectLike({
+          AllowOrigins: Match.arrayWith(['https://akli.dev']),
+        }),
+      })
+    })
+
+    it('allows GET, POST, PUT, PATCH, and DELETE methods', () => {
+      template.hasResourceProperties('AWS::ApiGatewayV2::Api', {
+        CorsConfiguration: Match.objectLike({
+          AllowMethods: Match.arrayWith(['GET', 'POST', 'PUT', 'PATCH', 'DELETE']),
+        }),
+      })
+    })
+
+    it('allows Content-Type and Authorization headers', () => {
+      template.hasResourceProperties('AWS::ApiGatewayV2::Api', {
+        CorsConfiguration: Match.objectLike({
+          AllowHeaders: Match.arrayWith(['Content-Type', 'Authorization']),
+        }),
+      })
+    })
+  })
+
+  describe('Routes', () => {
+    it('has a GET /recipes route (public)', () => {
+      template.hasResourceProperties('AWS::ApiGatewayV2::Route', {
+        RouteKey: 'GET /recipes',
+        AuthorizationType: 'NONE',
+      })
+    })
+
+    it('has a GET /recipes/{slug} route (public)', () => {
+      template.hasResourceProperties('AWS::ApiGatewayV2::Route', {
+        RouteKey: 'GET /recipes/{slug}',
+        AuthorizationType: 'NONE',
+      })
+    })
+
+    it('has a GET /recipes/tags route (public)', () => {
+      template.hasResourceProperties('AWS::ApiGatewayV2::Route', {
+        RouteKey: 'GET /recipes/tags',
+        AuthorizationType: 'NONE',
+      })
+    })
+
+    it('has a GET /me/recipes route (protected)', () => {
+      template.hasResourceProperties('AWS::ApiGatewayV2::Route', {
+        RouteKey: 'GET /me/recipes',
+        AuthorizationType: 'JWT',
+      })
+    })
+
+    it('has a POST /recipes route (protected)', () => {
+      template.hasResourceProperties('AWS::ApiGatewayV2::Route', {
+        RouteKey: 'POST /recipes',
+        AuthorizationType: 'JWT',
+      })
+    })
+
+    it('has a PUT /recipes/{id} route (protected)', () => {
+      template.hasResourceProperties('AWS::ApiGatewayV2::Route', {
+        RouteKey: 'PUT /recipes/{id}',
+        AuthorizationType: 'JWT',
+      })
+    })
+
+    it('has a PATCH /recipes/{id}/publish route (protected)', () => {
+      template.hasResourceProperties('AWS::ApiGatewayV2::Route', {
+        RouteKey: 'PATCH /recipes/{id}/publish',
+        AuthorizationType: 'JWT',
+      })
+    })
+
+    it('has a PATCH /recipes/{id}/unpublish route (protected)', () => {
+      template.hasResourceProperties('AWS::ApiGatewayV2::Route', {
+        RouteKey: 'PATCH /recipes/{id}/unpublish',
+        AuthorizationType: 'JWT',
+      })
+    })
+
+    it('has a DELETE /recipes/{id} route (protected)', () => {
+      template.hasResourceProperties('AWS::ApiGatewayV2::Route', {
+        RouteKey: 'DELETE /recipes/{id}',
+        AuthorizationType: 'JWT',
+      })
+    })
+
+    it('has a POST /recipes/images/upload-url route (protected)', () => {
+      template.hasResourceProperties('AWS::ApiGatewayV2::Route', {
+        RouteKey: 'POST /recipes/images/upload-url',
+        AuthorizationType: 'JWT',
+      })
+    })
+  })
+
+  describe('JWT Authoriser', () => {
+    it('creates a JWT authoriser', () => {
+      template.hasResourceProperties('AWS::ApiGatewayV2::Authorizer', {
+        AuthorizerType: 'JWT',
+        IdentitySource: Match.arrayWith(['$request.header.Authorization']),
+      })
+    })
+
+    it('configures the JWT authoriser with Issuer and Audience', () => {
+      template.hasResourceProperties('AWS::ApiGatewayV2::Authorizer', {
+        JwtConfiguration: Match.objectLike({
+          Issuer: Match.anyValue(),
+          Audience: Match.anyValue(),
+        }),
       })
     })
   })

--- a/test/recipe-stack.test.ts
+++ b/test/recipe-stack.test.ts
@@ -148,6 +148,53 @@ describe('RecipeStack', () => {
     })
   })
 
+  describe('S3 image bucket', () => {
+    it('creates an S3 bucket named akli-recipe-images-{account-id}-eu-west-2', () => {
+      template.hasResourceProperties('AWS::S3::Bucket', {
+        BucketName: 'akli-recipe-images-123456789012-eu-west-2',
+      })
+    })
+
+    it('blocks all public access', () => {
+      template.hasResourceProperties('AWS::S3::Bucket', {
+        PublicAccessBlockConfiguration: {
+          BlockPublicAcls: true,
+          BlockPublicPolicy: true,
+          IgnorePublicAcls: true,
+          RestrictPublicBuckets: true,
+        },
+      })
+    })
+
+    it('has a lifecycle rule to abort incomplete multipart uploads after 1 day', () => {
+      template.hasResourceProperties('AWS::S3::Bucket', {
+        LifecycleConfiguration: {
+          Rules: Match.arrayWith([
+            Match.objectLike({
+              AbortIncompleteMultipartUpload: {
+                DaysAfterInitiation: 1,
+              },
+              Status: 'Enabled',
+            }),
+          ]),
+        },
+      })
+    })
+
+    it('allows PUT from https://akli.dev via CORS', () => {
+      template.hasResourceProperties('AWS::S3::Bucket', {
+        CorsConfiguration: {
+          CorsRules: Match.arrayWith([
+            Match.objectLike({
+              AllowedMethods: Match.arrayWith(['PUT']),
+              AllowedOrigins: Match.arrayWith(['https://akli.dev']),
+            }),
+          ]),
+        },
+      })
+    })
+  })
+
   describe('Tags', () => {
     it('tags the table with Owner', () => {
       template.hasResourceProperties('AWS::DynamoDB::Table', {


### PR DESCRIPTION
## Summary
Complete recipe API backend infrastructure for akli.dev:

- **DynamoDB recipes table** with GSIs for status-based and author-based queries, PITR enabled
- **S3 image bucket** with CORS for presigned uploads, encryption, lifecycle cleanup
- **Recipe CRUD Lambda** — full CRUD with ownership enforcement, slug generation, tag aggregation, S3 image cleanup on delete
- **Presigned upload Lambda** — generates S3 PUT URLs for browser-based image uploads
- **Image resizer Lambda** — S3-triggered, generates 3 WebP variants (thumb/medium/full) via sharp
- **HTTP API Gateway** with JWT authoriser, 10 routes (3 public, 7 protected), CORS
- **CloudFront /recipes/* behaviour** on api.akli.dev with caching disabled and Authorization forwarding

### Issues completed
- #50 Create DynamoDB recipes table with GSIs
- #51 Create S3 image bucket with upload CORS
- #52 Configure API Gateway and CloudFront for recipe routes
- #53 Implement recipe CRUD Lambda handler
- #54 Implement tags endpoint
- #55 Implement presigned image upload handler
- #56 Implement S3-triggered image resizer Lambda
- #57 Write CDK assertion tests for RecipeStack (covered by TDD)
- #58 Write Lambda unit tests for recipe handlers (covered by TDD)

## Test plan
- [ ] `pnpm test` — all 233 tests pass across 14 suites
- [ ] `pnpm cdk diff --all` — review infrastructure changes before deploy
- [ ] Verify sharp native binary bundles correctly for Lambda (linux-arm64)

🤖 Generated with [Claude Code](https://claude.com/claude-code)