### PR TITLE
fix(auth-admin): derive user role from group membership

### DIFF
--- a/lambda/auth-admin-handler.ts
+++ b/lambda/auth-admin-handler.ts
@@ -5,10 +5,19 @@ import {
   AdminAddUserToGroupCommand,
   AdminDeleteUserCommand,
   ListUsersCommand,
+  ListUsersInGroupCommand,
 } from '@aws-sdk/client-cognito-identity-provider'
 
 const cognito = new CognitoIdentityProviderClient({})
 const USER_POOL_ID = process.env.USER_POOL_ID ?? ''
+const ADMIN_GROUP = 'admin'
+
+type AdminUser = {
+  email: string
+  userId: string
+  role: 'admin' | 'contributor'
+  status: string
+}
 
 function json(statusCode: number, body: Record<string, unknown> | readonly Record<string, unknown>[]): APIGatewayProxyStructuredResultV2 {
   return { statusCode, headers: { 'Content-Type': 'application/json' }, body: JSON.stringify(body) }
@@ -26,7 +35,7 @@ function isAdmin(event: APIGatewayProxyEventV2): boolean {
     if (parts.length < 2) return false
     const payload = JSON.parse(Buffer.from(parts[1], 'base64url').toString()) as Record<string, unknown>
     const groups = payload['cognito:groups']
-    return Array.isArray(groups) && groups.includes('admin')
+    return Array.isArray(groups) && groups.includes(ADMIN_GROUP)
   } catch {
     return false
   }
@@ -54,12 +63,21 @@ export async function handler(event: APIGatewayProxyEventV2): Promise<APIGateway
 }
 
 async function handleListUsers(): Promise<APIGatewayProxyStructuredResultV2> {
-  const response = await cognito.send(new ListUsersCommand({ UserPoolId: USER_POOL_ID }))
+  const [allUsers, adminGroup] = await Promise.all([
+    cognito.send(new ListUsersCommand({ UserPoolId: USER_POOL_ID })),
+    cognito.send(new ListUsersInGroupCommand({ UserPoolId: USER_POOL_ID, GroupName: ADMIN_GROUP })),
+  ])
 
-  const users = (response.Users ?? []).map((user) => ({
+  const adminUsernames = new Set(
+    (adminGroup.Users ?? [])
+      .map((u) => u.Username)
+      .filter((name): name is string => Boolean(name))
+  )
+
+  const users: AdminUser[] = (allUsers.Users ?? []).map((user) => ({
     email: user.Attributes?.find((attr) => attr.Name === 'email')?.Value ?? '',
     userId: user.Username ?? '',
-    role: user.Attributes?.find((attr) => attr.Name === 'custom:role')?.Value ?? 'unknown',
+    role: user.Username && adminUsernames.has(user.Username) ? 'admin' : 'contributor',
     status: user.UserStatus ?? '',
   }))
 

--- a/test/lambda/auth-admin-handler.test.ts
+++ b/test/lambda/auth-admin-handler.test.ts
@@ -3,6 +3,7 @@ import {
   CognitoIdentityProviderClient,
   AdminCreateUserCommand,
   ListUsersCommand,
+  ListUsersInGroupCommand,
   AdminDeleteUserCommand,
   AdminAddUserToGroupCommand,
 } from '@aws-sdk/client-cognito-identity-provider'
@@ -158,28 +159,25 @@ describe('Auth Admin Lambda handler', () => {
   })
 
   describe('GET /auth/users — list users', () => {
-    it('returns 200 with array of users containing email, userId, role, and status', async () => {
+    it('classifies users as admin when they are in the admin Cognito group, contributor otherwise', async () => {
       cognitoMock.on(ListUsersCommand).resolves({
         Users: [
           {
             Username: 'user-id-1',
-            Attributes: [
-              { Name: 'email', Value: 'alice@example.com' },
-              { Name: 'custom:role', Value: 'admin' },
-            ],
+            Attributes: [{ Name: 'email', Value: 'alice@example.com' }],
             UserStatus: 'CONFIRMED',
             Enabled: true,
           },
           {
             Username: 'user-id-2',
-            Attributes: [
-              { Name: 'email', Value: 'bob@example.com' },
-              { Name: 'custom:role', Value: 'user' },
-            ],
+            Attributes: [{ Name: 'email', Value: 'bob@example.com' }],
             UserStatus: 'FORCE_CHANGE_PASSWORD',
             Enabled: true,
           },
         ],
+      })
+      cognitoMock.on(ListUsersInGroupCommand, { GroupName: 'admin' }).resolves({
+        Users: [{ Username: 'user-id-1' }],
       })
 
       const event = makeEvent({
@@ -192,20 +190,55 @@ describe('Auth Admin Lambda handler', () => {
 
       expect(result.statusCode).toBe(200)
       const body = JSON.parse(result.body as string)
-      expect(Array.isArray(body)).toBe(true)
-      expect(body).toHaveLength(2)
-      expect(body[0]).toEqual({
-        email: 'alice@example.com',
-        userId: 'user-id-1',
-        role: 'admin',
-        status: 'CONFIRMED',
+      expect(body).toEqual([
+        {
+          email: 'alice@example.com',
+          userId: 'user-id-1',
+          role: 'admin',
+          status: 'CONFIRMED',
+        },
+        {
+          email: 'bob@example.com',
+          userId: 'user-id-2',
+          role: 'contributor',
+          status: 'FORCE_CHANGE_PASSWORD',
+        },
+      ])
+    })
+
+    it('returns contributor when no users are in the admin group', async () => {
+      cognitoMock.on(ListUsersCommand).resolves({
+        Users: [
+          {
+            Username: 'user-id-1',
+            Attributes: [{ Name: 'email', Value: 'alice@example.com' }],
+            UserStatus: 'CONFIRMED',
+            Enabled: true,
+          },
+        ],
       })
-      expect(body[1]).toEqual({
-        email: 'bob@example.com',
-        userId: 'user-id-2',
-        role: 'user',
-        status: 'FORCE_CHANGE_PASSWORD',
+      cognitoMock.on(ListUsersInGroupCommand, { GroupName: 'admin' }).resolves({
+        Users: [],
       })
+
+      const event = makeEvent({
+        routeKey: 'GET /auth/users',
+        rawPath: '/auth/users',
+        headers: { authorization: `Bearer ${adminToken}` },
+      })
+
+      const result = await handler(event)
+
+      expect(result.statusCode).toBe(200)
+      const body = JSON.parse(result.body as string)
+      expect(body).toEqual([
+        {
+          email: 'alice@example.com',
+          userId: 'user-id-1',
+          role: 'contributor',
+          status: 'CONFIRMED',
+        },
+      ])
     })
   })
 


### PR DESCRIPTION
Closes #77

## Summary

- \`GET /auth/users\` now derives \`role\` from Cognito group membership (\`admin\` group) rather than the non-existent \`custom:role\` attribute, so the admin UI shows the correct badge
- \`ListUsers\` and \`ListUsersInGroup(admin)\` run in parallel via \`Promise.all\`; admin set lookup is O(1) per user
- Return type tightened to \`role: 'admin' | 'contributor'\` via a local \`AdminUser\` type, matching the frontend's \`AdminRole\` union

## Follow-up

Filed #78 for pagination — neither \`ListUsers\` nor \`ListUsersInGroup\` currently handles \`PaginationToken\` (pre-existing for the former, new failure mode for the latter).

## Test plan

- [x] Existing \`GET /auth/users\` test rewritten to assert group-derived classification
- [x] New test covers the "no users in admin group" path
- [x] Full suite: 234/234 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)