### PR TITLE
fix(auth-admin): paginate ListUsers and ListUsersInGroup

### DIFF
--- a/lambda/auth-admin-handler.ts
+++ b/lambda/auth-admin-handler.ts
@@ -6,6 +6,7 @@ import {
   AdminDeleteUserCommand,
   ListUsersCommand,
   ListUsersInGroupCommand,
+  type UserType,
 } from '@aws-sdk/client-cognito-identity-provider'
 
 const cognito = new CognitoIdentityProviderClient({})
@@ -63,19 +64,45 @@ export async function handler(event: APIGatewayProxyEventV2): Promise<APIGateway
   }
 }
 
+async function listAllUsers(): Promise<UserType[]> {
+  const users: UserType[] = []
+  let paginationToken: string | undefined
+  do {
+    const page = await cognito.send(
+      new ListUsersCommand({ UserPoolId: USER_POOL_ID, PaginationToken: paginationToken }),
+    )
+    if (page.Users) users.push(...page.Users)
+    paginationToken = page.PaginationToken
+  } while (paginationToken)
+  return users
+}
+
+async function listAllUsersInGroup(groupName: string): Promise<UserType[]> {
+  const users: UserType[] = []
+  let nextToken: string | undefined
+  do {
+    const page = await cognito.send(
+      new ListUsersInGroupCommand({ UserPoolId: USER_POOL_ID, GroupName: groupName, NextToken: nextToken }),
+    )
+    if (page.Users) users.push(...page.Users)
+    nextToken = page.NextToken
+  } while (nextToken)
+  return users
+}
+
 async function handleListUsers(): Promise<APIGatewayProxyStructuredResultV2> {
-  const [allUsers, adminGroup] = await Promise.all([
-    cognito.send(new ListUsersCommand({ UserPoolId: USER_POOL_ID })),
-    cognito.send(new ListUsersInGroupCommand({ UserPoolId: USER_POOL_ID, GroupName: ADMIN_GROUP })),
+  const [allUsers, adminGroupUsers] = await Promise.all([
+    listAllUsers(),
+    listAllUsersInGroup(ADMIN_GROUP),
   ])
 
   const adminUsernames = new Set(
-    (adminGroup.Users ?? [])
+    adminGroupUsers
       .map((u) => u.Username)
       .filter((name): name is string => Boolean(name))
   )
 
-  const users: AdminUser[] = (allUsers.Users ?? []).map((user) => ({
+  const users: AdminUser[] = allUsers.map((user) => ({
     email: user.Attributes?.find((attr) => attr.Name === 'email')?.Value ?? '',
     userId: user.Username ?? '',
     role: user.Username && adminUsernames.has(user.Username) ? 'admin' : 'contributor',

--- a/test/lambda/auth-admin-handler.test.ts
+++ b/test/lambda/auth-admin-handler.test.ts
@@ -264,21 +264,17 @@ describe('Auth Admin Lambda handler', () => {
       expect(result.statusCode).toBe(200)
       const body = JSON.parse(result.body as string) as Array<{ userId: string; role: string }>
 
-      // All 63 users across both pages are in the response.
       expect(body).toHaveLength(63)
       expect(body.map((u) => u.userId)).toEqual(
         expect.arrayContaining(['user-1', 'user-60', 'user-61', 'late-admin', 'user-63']),
       )
 
-      // Admin on page 2 of the admin group is still classified as admin.
       const lateAdmin = body.find((u) => u.userId === 'late-admin')
       expect(lateAdmin?.role).toBe('admin')
 
-      // Admin on page 1 of the admin group remains admin.
       const earlyAdmin = body.find((u) => u.userId === 'user-1')
       expect(earlyAdmin?.role).toBe('admin')
 
-      // A user on neither admin page is a contributor.
       const contributor = body.find((u) => u.userId === 'user-61')
       expect(contributor?.role).toBe('contributor')
     })

--- a/test/lambda/auth-admin-handler.test.ts
+++ b/test/lambda/auth-admin-handler.test.ts
@@ -206,6 +206,83 @@ describe('Auth Admin Lambda handler', () => {
       ])
     })
 
+    it('paginates ListUsers and ListUsersInGroup so users and admins beyond page 1 are not lost', async () => {
+      // Cognito's default page size is 60 for both APIs. If the handler only reads
+      // page 1, anyone on page 2 of the admin group is silently mis-classified as
+      // a contributor. Exercise both loops by returning two pages for each command.
+      const page1Users = Array.from({ length: 60 }, (_, i) => ({
+        Username: `user-${i + 1}`,
+        Attributes: [{ Name: 'email', Value: `user${i + 1}@example.com` }],
+        UserStatus: 'CONFIRMED' as const,
+        Enabled: true,
+      }))
+      const page2Users = [
+        {
+          Username: 'user-61',
+          Attributes: [{ Name: 'email', Value: 'user61@example.com' }],
+          UserStatus: 'CONFIRMED' as const,
+          Enabled: true,
+        },
+        {
+          Username: 'late-admin',
+          Attributes: [{ Name: 'email', Value: 'late-admin@example.com' }],
+          UserStatus: 'CONFIRMED' as const,
+          Enabled: true,
+        },
+        {
+          Username: 'user-63',
+          Attributes: [{ Name: 'email', Value: 'user63@example.com' }],
+          UserStatus: 'CONFIRMED' as const,
+          Enabled: true,
+        },
+      ]
+
+      cognitoMock
+        .on(ListUsersCommand)
+        .resolvesOnce({ Users: page1Users, PaginationToken: 'users-next-page' })
+        .resolvesOnce({ Users: page2Users })
+
+      // `user-1` is admin on page 1; `late-admin` is admin on page 2.
+      const adminPage1 = Array.from({ length: 60 }, (_, i) => ({ Username: `admin-page1-${i + 1}` }))
+      adminPage1[0] = { Username: 'user-1' }
+      const adminPage2 = [{ Username: 'late-admin' }, { Username: 'admin-page2-extra' }]
+
+      // Cognito's ListUsersInGroup uses NextToken (not PaginationToken) for pagination.
+      cognitoMock
+        .on(ListUsersInGroupCommand, { GroupName: 'admin' })
+        .resolvesOnce({ Users: adminPage1, NextToken: 'admins-next-page' })
+        .resolvesOnce({ Users: adminPage2 })
+
+      const event = makeEvent({
+        routeKey: 'GET /auth/users',
+        rawPath: '/auth/users',
+        headers: { authorization: `Bearer ${adminToken}` },
+      })
+
+      const result = await handler(event)
+
+      expect(result.statusCode).toBe(200)
+      const body = JSON.parse(result.body as string) as Array<{ userId: string; role: string }>
+
+      // All 63 users across both pages are in the response.
+      expect(body).toHaveLength(63)
+      expect(body.map((u) => u.userId)).toEqual(
+        expect.arrayContaining(['user-1', 'user-60', 'user-61', 'late-admin', 'user-63']),
+      )
+
+      // Admin on page 2 of the admin group is still classified as admin.
+      const lateAdmin = body.find((u) => u.userId === 'late-admin')
+      expect(lateAdmin?.role).toBe('admin')
+
+      // Admin on page 1 of the admin group remains admin.
+      const earlyAdmin = body.find((u) => u.userId === 'user-1')
+      expect(earlyAdmin?.role).toBe('admin')
+
+      // A user on neither admin page is a contributor.
+      const contributor = body.find((u) => u.userId === 'user-61')
+      expect(contributor?.role).toBe('contributor')
+    })
+
     it('returns contributor when no users are in the admin group', async () => {
       cognitoMock.on(ListUsersCommand).resolves({
         Users: [


### PR DESCRIPTION
Closes #78

## What changed

- Extracted `listAllUsers` and `listAllUsersInGroup` helpers in `lambda/auth-admin-handler.ts` that loop the respective Cognito commands until their pagination token is exhausted
- Wired both helpers into the existing `Promise.all` at the top of `handleListUsers` so the two loops still run concurrently
- Added a test in `test/lambda/auth-admin-handler.test.ts` that mocks 60+3 users and 60+2 admin group members across two pages each and asserts the page-2 admin stays classified as `admin`

## Why

Cognito's default page size is 60 for both `ListUsers` and `ListUsersInGroup`. The previous handler only ever read page 1, so with enough users the tail was silently dropped and — worse — admins past index 60 in the admin group were misclassified as contributors. Flagged during /simplify on PR #79.

## How to verify

- `pnpm test` → 237/237 passing (new pagination test included)
- The new test fails against `main` and passes on this branch (TDD red/green visible in commit history)

## Decisions made

- **Two helpers, not one generic.** The two Cognito commands use different token field names (`PaginationToken` vs `NextToken` on input and output). A single generic helper would need a token-field accessor pair; the duplication is ~8 lines and keeps the two SDK quirks explicit at their call sites.
- **Kept parallelism shape unchanged.** The existing `Promise.all` in `handleListUsers` now wraps the two paginated loops; wall time is still `max(listAllUsers, listAllUsersInGroup)`.
- **Did not add `AttributesToGet: ['email']`.** Small payload optimisation — worth a follow-up, but out of scope for this fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)