### PR TITLE
fix(auth-admin): normalise Cognito UserStatus to domain contract

### DIFF
--- a/lambda/auth-admin-handler.ts
+++ b/lambda/auth-admin-handler.ts
@@ -13,11 +13,17 @@ const cognito = new CognitoIdentityProviderClient({})
 const USER_POOL_ID = process.env.USER_POOL_ID ?? ''
 const ADMIN_GROUP = 'admin'
 
+type AdminUserStatus = 'confirmed' | 'pending'
+
 type AdminUser = {
   email: string
   userId: string
   role: 'admin' | 'contributor'
-  status: string
+  status: AdminUserStatus
+}
+
+function normaliseStatus(cognitoStatus: string | undefined): AdminUserStatus {
+  return cognitoStatus === 'CONFIRMED' ? 'confirmed' : 'pending'
 }
 
 function json(statusCode: number, body: Record<string, unknown> | readonly Record<string, unknown>[]): APIGatewayProxyStructuredResultV2 {
@@ -106,7 +112,7 @@ async function handleListUsers(): Promise<APIGatewayProxyStructuredResultV2> {
     email: user.Attributes?.find((attr) => attr.Name === 'email')?.Value ?? '',
     userId: user.Username ?? '',
     role: user.Username && adminUsernames.has(user.Username) ? 'admin' : 'contributor',
-    status: user.UserStatus ?? '',
+    status: normaliseStatus(user.UserStatus),
   }))
 
   return json(200, users)
@@ -135,7 +141,7 @@ async function handleCreateUser(event: APIGatewayProxyEventV2): Promise<APIGatew
   return json(201, {
     userId: response.User?.Username ?? '',
     email,
-    status: response.User?.UserStatus ?? '',
+    status: normaliseStatus(response.User?.UserStatus),
   })
 }
 

--- a/test/lambda/auth-admin-handler.test.ts
+++ b/test/lambda/auth-admin-handler.test.ts
@@ -195,13 +195,13 @@ describe('Auth Admin Lambda handler', () => {
           email: 'alice@example.com',
           userId: 'user-id-1',
           role: 'admin',
-          status: 'CONFIRMED',
+          status: 'confirmed',
         },
         {
           email: 'bob@example.com',
           userId: 'user-id-2',
           role: 'contributor',
-          status: 'FORCE_CHANGE_PASSWORD',
+          status: 'pending',
         },
       ])
     })
@@ -309,7 +309,7 @@ describe('Auth Admin Lambda handler', () => {
           email: 'alice@example.com',
           userId: 'user-id-1',
           role: 'contributor',
-          status: 'CONFIRMED',
+          status: 'confirmed',
         },
       ])
     })
@@ -360,7 +360,7 @@ describe('Auth Admin Lambda handler', () => {
       const body = JSON.parse(result.body as string)
       expect(body).toHaveProperty('userId', 'new-user-id')
       expect(body).toHaveProperty('email', 'new@example.com')
-      expect(body).toHaveProperty('status', 'FORCE_CHANGE_PASSWORD')
+      expect(body).toHaveProperty('status', 'pending')
     })
   })
 


### PR DESCRIPTION
## Summary

Cognito returns \`UserStatus\` in uppercase (\`CONFIRMED\`, \`FORCE_CHANGE_PASSWORD\`, \`UNCONFIRMED\`, …) but the admin UI's domain contract is lowercase \`'confirmed' | 'pending'\`. The previous passthrough meant every user rendered as "Pending" — including admins who had completed their password setup.

## What changed

- Added a \`normaliseStatus\` helper that maps \`CONFIRMED\` → \`'confirmed'\` and everything else → \`'pending'\`
- Applied in both \`handleListUsers\` and \`handleCreateUser\` (for consistency — the frontend refetches after invite anyway, but the create response should honour the same contract)
- Tightened \`AdminUser.status\` from \`string\` to the \`'confirmed' | 'pending'\` union
- Updated existing tests that were locking in the broken uppercase passthrough

## How to verify

- \`pnpm test\` → 237/237
- After deploy: \`/admin/users\` shows confirmed users as "Confirmed" (not "Pending")

## Decisions

- **"everything not CONFIRMED = pending"** — simpler and safer than enumerating every Cognito state. \`FORCE_CHANGE_PASSWORD\` (the invite state) falls under "pending" which is exactly what the UI wants to surface.
- **No new lint-time tests** — `AdminUser.status` is now a union, so type-checking catches future drift.

🤖 Generated with [Claude Code](https://claude.com/claude-code)