### PR TITLE
Enable DynamoDB TTL on recipes table

### DIFF
--- a/lib/recipe-stack.ts
+++ b/lib/recipe-stack.ts
@@ -30,6 +30,7 @@ export class RecipeStack extends Stack {
       tableName: 'recipes',
       partitionKey: { name: 'id', type: dynamodb.AttributeType.STRING },
       billingMode: dynamodb.BillingMode.PAY_PER_REQUEST,
+      timeToLiveAttribute: 'ttl',
       pointInTimeRecoverySpecification: { pointInTimeRecoveryEnabled: true },
       removalPolicy: RemovalPolicy.RETAIN,
     })

--- a/test/recipe-stack.test.ts
+++ b/test/recipe-stack.test.ts
@@ -63,6 +63,27 @@ describe('RecipeStack', () => {
     })
   })
 
+  describe('DynamoDB TTL', () => {
+    it('enables native TTL on the recipes table using the ttl attribute', () => {
+      template.hasResourceProperties('AWS::DynamoDB::Table', Match.objectLike({
+        TableName: 'recipes',
+        TimeToLiveSpecification: {
+          AttributeName: 'ttl',
+          Enabled: true,
+        },
+      }))
+    })
+
+    it('does not include ttl in the recipes table AttributeDefinitions (TTL is metadata, not a key)', () => {
+      template.hasResourceProperties('AWS::DynamoDB::Table', Match.objectLike({
+        TableName: 'recipes',
+        AttributeDefinitions: Match.not(Match.arrayWith([
+          Match.objectLike({ AttributeName: 'ttl' }),
+        ])),
+      }))
+    })
+  })
+
   describe('GSI status-createdAt-index', () => {
     it('creates GSI with name status-createdAt-index', () => {
       template.hasResourceProperties('AWS::DynamoDB::Table', {


### PR DESCRIPTION
Closes #84

## What changed
- Added `timeToLiveAttribute: 'ttl'` to the `RecipesTable` construct in `lib/recipe-stack.ts`.
- Added two CDK assertion tests in `test/recipe-stack.test.ts`:
  - Positive: `recipes` table has `TimeToLiveSpecification: { AttributeName: 'ttl', Enabled: true }`.
  - Negative: `ttl` does not appear in the table's `AttributeDefinitions` (TTL is metadata, not a key).

## Why
Foundational infrastructure for the Draft Recipes milestone — drafts will carry a `ttl = now + 30d` unix timestamp and be deleted automatically by DynamoDB's native TTL (best-effort within 48h of expiry). No data-path changes in this PR; the endpoint work that writes `ttl` lands in later issues (#85 onward).

PRD: `docs/prds/draft-recipes.md` — "DynamoDB TTL config (CDK)" section.

## How to verify
- `pnpm test test/recipe-stack.test.ts` — 37 pass, including the two new TTL tests.
- `pnpm test` — full suite 239/239 pass.
- `cdk diff` (post-deploy) will show only the `TimeToLiveSpecification` addition on the `recipes` table; no replacement, no data loss.

## Decisions made
- Used the L2 `dynamodb.Table` prop directly rather than an escape hatch — it's a supported first-class property.
- Tests split into positive + negative to give independent regression coverage: the positive guards against someone removing TTL later; the negative guards against a future change that (wrongly) adds `ttl` to the key schema.
- Scoped both matchers by `TableName: 'recipes'` to disambiguate from any future additional tables in this stack.