### PR TITLE
Add POST /recipes/drafts endpoint

### DIFF
--- a/lambda/recipe-handler.ts
+++ b/lambda/recipe-handler.ts
@@ -10,6 +10,7 @@ const s3Client = new S3Client({})
 
 const TABLE_NAME = process.env.TABLE_NAME ?? ''
 const IMAGE_BUCKET_NAME = process.env.IMAGE_BUCKET_NAME ?? ''
+const DRAFT_TTL_SECONDS = 30 * 24 * 60 * 60
 
 interface JwtPayload {
   readonly sub: string
@@ -306,7 +307,7 @@ async function handleCreateDraft(event: APIGatewayProxyEventV2): Promise<APIGate
 
   const id = randomUUID()
   const slug = title.length > 0 ? await findUniqueSlug(generateSlug(title)) : `draft-${id}`
-  const ttl = Math.floor(Date.now() / 1000) + 30 * 24 * 60 * 60
+  const ttl = Math.floor(Date.now() / 1000) + DRAFT_TTL_SECONDS
   const now = new Date().toISOString()
 
   const item: Record<string, unknown> = {

--- a/lambda/recipe-handler.ts
+++ b/lambda/recipe-handler.ts
@@ -140,6 +140,8 @@ export async function handler(event: APIGatewayProxyEventV2): Promise<APIGateway
         return await handleListUserRecipes(event)
       case 'POST /recipes':
         return await handleCreateRecipe(event)
+      case 'POST /recipes/drafts':
+        return await handleCreateDraft(event)
       case 'PUT /recipes/{id}':
         return await handleUpdateRecipe(event)
       case 'PATCH /recipes/{id}/publish':
@@ -292,6 +294,38 @@ function validateCreateInput(input: CreateRecipeInput): string[] {
   if (!input.ingredients || input.ingredients.length === 0) errors.push('At least one ingredient is required')
   if (!input.steps || input.steps.length === 0) errors.push('At least one step is required')
   return errors
+}
+
+async function handleCreateDraft(event: APIGatewayProxyEventV2): Promise<APIGatewayProxyStructuredResultV2> {
+  const payload = decodeJwt(event)
+  if (!payload) return json(401, { error: 'Unauthorised' })
+  if (!isAdmin(event)) return json(403, { error: 'Forbidden' })
+
+  const input = JSON.parse(event.body ?? '{}') as { title?: string }
+  const title = typeof input.title === 'string' ? input.title : ''
+
+  const id = randomUUID()
+  const slug = title.length > 0 ? await findUniqueSlug(generateSlug(title)) : `draft-${randomUUID()}`
+  const ttl = Math.floor(Date.now() / 1000) + 30 * 24 * 60 * 60
+  const now = new Date().toISOString()
+
+  const item: Record<string, unknown> = {
+    id,
+    slug,
+    status: 'draft',
+    ttl,
+    title,
+    intro: '',
+    ingredients: [],
+    steps: [],
+    authorId: payload.sub,
+    createdAt: now,
+    updatedAt: now,
+  }
+
+  await docClient.send(new PutCommand({ TableName: TABLE_NAME, Item: item }))
+
+  return json(201, { id, slug })
 }
 
 async function handleUpdateRecipe(event: APIGatewayProxyEventV2): Promise<APIGatewayProxyStructuredResultV2> {

--- a/lambda/recipe-handler.ts
+++ b/lambda/recipe-handler.ts
@@ -305,7 +305,7 @@ async function handleCreateDraft(event: APIGatewayProxyEventV2): Promise<APIGate
   const title = typeof input.title === 'string' ? input.title : ''
 
   const id = randomUUID()
-  const slug = title.length > 0 ? await findUniqueSlug(generateSlug(title)) : `draft-${randomUUID()}`
+  const slug = title.length > 0 ? await findUniqueSlug(generateSlug(title)) : `draft-${id}`
   const ttl = Math.floor(Date.now() / 1000) + 30 * 24 * 60 * 60
   const now = new Date().toISOString()
 
@@ -319,6 +319,7 @@ async function handleCreateDraft(event: APIGatewayProxyEventV2): Promise<APIGate
     ingredients: [],
     steps: [],
     authorId: payload.sub,
+    authorName: payload.name ?? payload.email ?? '',
     createdAt: now,
     updatedAt: now,
   }

--- a/lib/recipe-stack.ts
+++ b/lib/recipe-stack.ts
@@ -216,6 +216,14 @@ export class RecipeStack extends Stack {
       authorizerId: jwtAuthorizer.ref,
     })
 
+    new apigwv2.CfnRoute(this, 'CreateDraftRoute', {
+      apiId: this.httpApi.httpApiId,
+      routeKey: 'POST /recipes/drafts',
+      target: `integrations/${recipeIntegration.ref}`,
+      authorizationType: 'JWT',
+      authorizerId: jwtAuthorizer.ref,
+    })
+
     new apigwv2.CfnRoute(this, 'UpdateRecipeRoute', {
       apiId: this.httpApi.httpApiId,
       routeKey: 'PUT /recipes/{id}',

--- a/test/lambda/recipe-handler.test.ts
+++ b/test/lambda/recipe-handler.test.ts
@@ -524,14 +524,6 @@ describe('Recipe Lambda handler', () => {
 
   // ─── POST /recipes/drafts — create draft ────────────────────────────
   describe('POST /recipes/drafts — create draft', () => {
-    beforeEach(() => {
-      jest.useFakeTimers().setSystemTime(new Date('2026-04-19T12:00:00Z'))
-    })
-
-    afterEach(() => {
-      jest.useRealTimers()
-    })
-
     it('returns 401 without a valid token', async () => {
       const event = makeEvent({
         routeKey: 'POST /recipes/drafts',
@@ -583,28 +575,33 @@ describe('Recipe Lambda handler', () => {
     })
 
     it('writes status=draft and ttl=now+30d to DynamoDB', async () => {
-      ddbMock.on(ScanCommand).resolves({ Items: [] })
-      ddbMock.on(PutCommand).resolves({})
+      jest.useFakeTimers().setSystemTime(new Date('2026-04-19T12:00:00Z'))
+      try {
+        ddbMock.on(ScanCommand).resolves({ Items: [] })
+        ddbMock.on(PutCommand).resolves({})
 
-      const event = makeEvent({
-        routeKey: 'POST /recipes/drafts',
-        rawPath: '/recipes/drafts',
-        headers: { authorization: `Bearer ${adminToken}` },
-        body: '{}',
-      })
+        const event = makeEvent({
+          routeKey: 'POST /recipes/drafts',
+          rawPath: '/recipes/drafts',
+          headers: { authorization: `Bearer ${adminToken}` },
+          body: '{}',
+        })
 
-      const result = await handler(event)
+        const result = await handler(event)
 
-      expect(result.statusCode).toBe(201)
+        expect(result.statusCode).toBe(201)
 
-      const putCalls = ddbMock.commandCalls(PutCommand)
-      expect(putCalls).toHaveLength(1)
-      const item = putCalls[0].args[0].input.Item as Record<string, unknown>
-      expect(item.status).toBe('draft')
+        const putCalls = ddbMock.commandCalls(PutCommand)
+        expect(putCalls).toHaveLength(1)
+        const item = putCalls[0].args[0].input.Item as Record<string, unknown>
+        expect(item.status).toBe('draft')
 
-      const expectedTtl = Math.floor(Date.now() / 1000) + 30 * 24 * 60 * 60
-      expect(typeof item.ttl).toBe('number')
-      expect(item.ttl).toBe(expectedTtl)
+        const expectedTtl = Math.floor(Date.now() / 1000) + 30 * 24 * 60 * 60
+        expect(typeof item.ttl).toBe('number')
+        expect(item.ttl).toBe(expectedTtl)
+      } finally {
+        jest.useRealTimers()
+      }
     })
 
     it('defaults slug to draft-<uuid> when no title is provided', async () => {

--- a/test/lambda/recipe-handler.test.ts
+++ b/test/lambda/recipe-handler.test.ts
@@ -522,6 +522,128 @@ describe('Recipe Lambda handler', () => {
     })
   })
 
+  // ─── POST /recipes/drafts — create draft ────────────────────────────
+  describe('POST /recipes/drafts — create draft', () => {
+    beforeEach(() => {
+      jest.useFakeTimers().setSystemTime(new Date('2026-04-19T12:00:00Z'))
+    })
+
+    afterEach(() => {
+      jest.useRealTimers()
+    })
+
+    it('returns 401 without a valid token', async () => {
+      const event = makeEvent({
+        routeKey: 'POST /recipes/drafts',
+        rawPath: '/recipes/drafts',
+        headers: {},
+        body: '{}',
+      })
+
+      const result = await handler(event)
+
+      expect(result.statusCode).toBe(401)
+      const body = JSON.parse(result.body as string)
+      expect(body).toHaveProperty('error')
+    })
+
+    it('returns 403 when the caller is not an admin', async () => {
+      const event = makeEvent({
+        routeKey: 'POST /recipes/drafts',
+        rawPath: '/recipes/drafts',
+        headers: { authorization: `Bearer ${contributorToken}` },
+        body: '{}',
+      })
+
+      const result = await handler(event)
+
+      expect(result.statusCode).toBe(403)
+      const body = JSON.parse(result.body as string)
+      expect(body).toHaveProperty('error')
+    })
+
+    it('returns 201 with { id, slug } in the body on success', async () => {
+      ddbMock.on(ScanCommand).resolves({ Items: [] })
+      ddbMock.on(PutCommand).resolves({})
+
+      const event = makeEvent({
+        routeKey: 'POST /recipes/drafts',
+        rawPath: '/recipes/drafts',
+        headers: { authorization: `Bearer ${adminToken}` },
+        body: '{}',
+      })
+
+      const result = await handler(event)
+
+      expect(result.statusCode).toBe(201)
+      const body = JSON.parse(result.body as string)
+      expect(typeof body.id).toBe('string')
+      expect(body.id).toMatch(/^[0-9a-f-]+$/i)
+      expect(typeof body.slug).toBe('string')
+    })
+
+    it('writes status=draft and ttl=now+30d to DynamoDB', async () => {
+      ddbMock.on(ScanCommand).resolves({ Items: [] })
+      ddbMock.on(PutCommand).resolves({})
+
+      const event = makeEvent({
+        routeKey: 'POST /recipes/drafts',
+        rawPath: '/recipes/drafts',
+        headers: { authorization: `Bearer ${adminToken}` },
+        body: '{}',
+      })
+
+      const result = await handler(event)
+
+      expect(result.statusCode).toBe(201)
+
+      const putCalls = ddbMock.commandCalls(PutCommand)
+      expect(putCalls).toHaveLength(1)
+      const item = putCalls[0].args[0].input.Item as Record<string, unknown>
+      expect(item.status).toBe('draft')
+
+      const expectedTtl = Math.floor(Date.now() / 1000) + 30 * 24 * 60 * 60
+      expect(typeof item.ttl).toBe('number')
+      expect(item.ttl).toBe(expectedTtl)
+    })
+
+    it('defaults slug to draft-<uuid> when no title is provided', async () => {
+      ddbMock.on(ScanCommand).resolves({ Items: [] })
+      ddbMock.on(PutCommand).resolves({})
+
+      const event = makeEvent({
+        routeKey: 'POST /recipes/drafts',
+        rawPath: '/recipes/drafts',
+        headers: { authorization: `Bearer ${adminToken}` },
+        body: '{}',
+      })
+
+      const result = await handler(event)
+
+      expect(result.statusCode).toBe(201)
+      const body = JSON.parse(result.body as string)
+      expect(body.slug).toMatch(/^draft-/)
+    })
+
+    it('derives slug from the title when one is provided', async () => {
+      ddbMock.on(ScanCommand).resolves({ Items: [] })
+      ddbMock.on(PutCommand).resolves({})
+
+      const event = makeEvent({
+        routeKey: 'POST /recipes/drafts',
+        rawPath: '/recipes/drafts',
+        headers: { authorization: `Bearer ${adminToken}` },
+        body: JSON.stringify({ title: 'My New Recipe' }),
+      })
+
+      const result = await handler(event)
+
+      expect(result.statusCode).toBe(201)
+      const body = JSON.parse(result.body as string)
+      expect(body.slug).toBe('my-new-recipe')
+    })
+  })
+
   // ─── PUT /recipes/{id} — update recipe ──────────────────────────────
   describe('PUT /recipes/{id} — update recipe', () => {
     it('returns 200 when contributor updates their own recipe', async () => {

--- a/test/recipe-stack.test.ts
+++ b/test/recipe-stack.test.ts
@@ -325,6 +325,22 @@ describe('RecipeStack', () => {
     })
   })
 
+  describe('POST /recipes/drafts route', () => {
+    it('has a POST /recipes/drafts route', () => {
+      template.hasResourceProperties('AWS::ApiGatewayV2::Route', {
+        RouteKey: 'POST /recipes/drafts',
+      })
+    })
+
+    it('is protected by the JWT authoriser', () => {
+      template.hasResourceProperties('AWS::ApiGatewayV2::Route', Match.objectLike({
+        RouteKey: 'POST /recipes/drafts',
+        AuthorizationType: 'JWT',
+        AuthorizerId: Match.anyValue(),
+      }))
+    })
+  })
+
   describe('JWT Authoriser', () => {
     it('creates a JWT authoriser', () => {
       template.hasResourceProperties('AWS::ApiGatewayV2::Authorizer', {


### PR DESCRIPTION
Closes #87

## What changed
- New `POST /recipes/drafts` endpoint, dispatched by a new `case` branch in the route switch.
- New `handleCreateDraft(event)` in `lambda/recipe-handler.ts`: requires admin JWT, accepts an optional `{ title }` body, writes a DDB item with `status: 'draft'`, `ttl = now + 30d`, empty `intro`/`ingredients`/`steps`, and shape-consistent fields (`authorId`, `authorName`, `createdAt`, `updatedAt`) mirroring `handleCreateRecipe`.
- Slug: when a title is provided, falls back to the existing `findUniqueSlug(generateSlug(title))` pipeline. Otherwise the slug is `draft-<id>` (reusing the freshly generated `id` so the row is self-consistent and free of slug collisions across concurrent empty drafts).
- `DRAFT_TTL_SECONDS = 30 * 24 * 60 * 60` module constant (named so the retention policy doesn't read as magic arithmetic).
- New `CreateDraftRoute` in `lib/recipe-stack.ts` — standard `CfnRoute` with `AuthorizationType: JWT` and the existing authoriser.

## Why
Foundation for the drafts-first editor flow. The frontend needs a `recipeId` before it can upload a cover image, so the editor hits this endpoint on mount; everything else (autosave via PATCH, publish via PATCH, etc.) depends on having a drafted record first.

PRD: `docs/prds/draft-recipes.md` — "Shared API contract" → `POST /recipes/drafts`.

## How to verify
- `pnpm test` — 250/250 pass.
- 6 new handler tests cover: 401 (no JWT), 403 (non-admin), 201 happy path, DDB Item shape (`status: 'draft'`, `ttl = now + 30d`), empty-body slug fallback, title-derived slug.
- 2 new CDK tests assert the route exists and is JWT-protected.
- TDD progression visible in git history: failing tests first, then implementation, then review-pass fixes, then /simplify.

## Decisions made
- Reused `id` as the draft slug's UUID suffix instead of generating a second `randomUUID()` — it's unique, opaque, and makes the row self-consistent. The AC `/^draft-/` regex still holds.
- Added `authorName` to the draft Item despite the PRD not explicitly requiring it — shape consistency with `handleCreateRecipe` matters for any downstream consumer iterating the table.
- Kept the existing `decodeJwt` + `isAdmin` pattern (double decode) for consistency with the rest of the handler. A `requireAdmin(payload)` refactor is a valid follow-up but out of scope here.
- Narrowed `jest.useFakeTimers()` to the single test that needs it rather than wrapping the whole describe block, so unrelated tests stay clock-agnostic.