### PR TITLE
Add GET /recipes/admin endpoint

### DIFF
--- a/lambda/recipe-handler.ts
+++ b/lambda/recipe-handler.ts
@@ -135,6 +135,8 @@ export async function handler(event: APIGatewayProxyEventV2): Promise<APIGateway
         return await handleListTags()
       case 'GET /recipes':
         return await handleListPublished()
+      case 'GET /recipes/admin':
+        return await handleListForAdmin(event)
       case 'GET /recipes/{slug}':
         return await handleGetBySlug(event)
       case 'GET /me/recipes':
@@ -199,6 +201,32 @@ async function handleListPublished(): Promise<APIGatewayProxyStructuredResultV2>
 
   const recipes = (result.Items ?? []).map((item) => lightweightRecipe(item as Record<string, unknown>))
   return json(200, recipes)
+}
+
+async function handleListForAdmin(event: APIGatewayProxyEventV2): Promise<APIGatewayProxyStructuredResultV2> {
+  const payload = decodeJwt(event)
+  if (!payload) return json(401, { error: 'Unauthorised' })
+  if (!isAdmin(event)) return json(403, { error: 'Forbidden' })
+
+  const queryByStatus = (status: string) =>
+    docClient.send(
+      new QueryCommand({
+        TableName: TABLE_NAME,
+        IndexName: 'status-createdAt-index',
+        KeyConditionExpression: '#status = :status',
+        ExpressionAttributeNames: { '#status': 'status' },
+        ExpressionAttributeValues: { ':status': status },
+        ScanIndexForward: false,
+      }),
+    )
+
+  const [publishedResult, draftResult] = await Promise.all([queryByStatus('published'), queryByStatus('draft')])
+
+  const nowSeconds = Math.floor(Date.now() / 1000)
+  const merged = [...(publishedResult.Items ?? []), ...(draftResult.Items ?? [])] as Record<string, unknown>[]
+  const live = merged.filter((item) => typeof item.ttl !== 'number' || (item.ttl as number) > nowSeconds)
+
+  return json(200, live.map((item) => convertRecipeTags(item)))
 }
 
 async function handleGetBySlug(event: APIGatewayProxyEventV2): Promise<APIGatewayProxyStructuredResultV2> {

--- a/lambda/recipe-handler.ts
+++ b/lambda/recipe-handler.ts
@@ -195,46 +195,37 @@ async function handleListTags(): Promise<APIGatewayProxyStructuredResultV2> {
   return json(200, sorted)
 }
 
-async function handleListPublished(): Promise<APIGatewayProxyStructuredResultV2> {
-  const result = await docClient.send(
+function queryRecipesByStatus(status: string) {
+  return docClient.send(
     new QueryCommand({
       TableName: TABLE_NAME,
       IndexName: 'status-createdAt-index',
       KeyConditionExpression: '#status = :status',
       ExpressionAttributeNames: { '#status': 'status' },
-      ExpressionAttributeValues: { ':status': 'published' },
+      ExpressionAttributeValues: { ':status': status },
       ScanIndexForward: false,
     }),
   )
+}
+
+async function handleListPublished(): Promise<APIGatewayProxyStructuredResultV2> {
+  const result = await queryRecipesByStatus('published')
 
   const recipes = (result.Items ?? []).map((item) => lightweightRecipe(item as Record<string, unknown>))
   return json(200, recipes)
 }
 
 async function handleListForAdmin(event: APIGatewayProxyEventV2): Promise<APIGatewayProxyStructuredResultV2> {
-  const payload = decodeJwt(event)
-  if (!payload) return json(401, { error: 'Unauthorised' })
+  if (!decodeJwt(event)) return json(401, { error: 'Unauthorised' })
   if (!isAdmin(event)) return json(403, { error: 'Forbidden' })
 
-  const queryByStatus = (status: string) =>
-    docClient.send(
-      new QueryCommand({
-        TableName: TABLE_NAME,
-        IndexName: 'status-createdAt-index',
-        KeyConditionExpression: '#status = :status',
-        ExpressionAttributeNames: { '#status': 'status' },
-        ExpressionAttributeValues: { ':status': status },
-        ScanIndexForward: false,
-      }),
-    )
-
-  const [publishedResult, draftResult] = await Promise.all([queryByStatus('published'), queryByStatus('draft')])
+  const [publishedResult, draftResult] = await Promise.all([queryRecipesByStatus('published'), queryRecipesByStatus('draft')])
 
   const nowSeconds = Math.floor(Date.now() / 1000)
   const merged = [...(publishedResult.Items ?? []), ...(draftResult.Items ?? [])] as Record<string, unknown>[]
-  const live = merged.filter((item) => typeof item.ttl !== 'number' || (item.ttl as number) > nowSeconds)
+  const live = merged.filter((item) => typeof item.ttl !== 'number' || item.ttl > nowSeconds)
 
-  return json(200, live.map((item) => lightweightAdminRecipe(item)))
+  return json(200, live.map(lightweightAdminRecipe))
 }
 
 async function handleGetBySlug(event: APIGatewayProxyEventV2): Promise<APIGatewayProxyStructuredResultV2> {

--- a/lambda/recipe-handler.ts
+++ b/lambda/recipe-handler.ts
@@ -128,6 +128,14 @@ function lightweightRecipe(recipe: Record<string, unknown>): Record<string, unkn
   }
 }
 
+function lightweightAdminRecipe(recipe: Record<string, unknown>): Record<string, unknown> {
+  return {
+    ...lightweightRecipe(recipe),
+    status: recipe.status,
+    updatedAt: recipe.updatedAt,
+  }
+}
+
 export async function handler(event: APIGatewayProxyEventV2): Promise<APIGatewayProxyStructuredResultV2> {
   try {
     switch (event.routeKey) {
@@ -226,7 +234,7 @@ async function handleListForAdmin(event: APIGatewayProxyEventV2): Promise<APIGat
   const merged = [...(publishedResult.Items ?? []), ...(draftResult.Items ?? [])] as Record<string, unknown>[]
   const live = merged.filter((item) => typeof item.ttl !== 'number' || (item.ttl as number) > nowSeconds)
 
-  return json(200, live.map((item) => convertRecipeTags(item)))
+  return json(200, live.map((item) => lightweightAdminRecipe(item)))
 }
 
 async function handleGetBySlug(event: APIGatewayProxyEventV2): Promise<APIGatewayProxyStructuredResultV2> {

--- a/lib/recipe-stack.ts
+++ b/lib/recipe-stack.ts
@@ -208,6 +208,14 @@ export class RecipeStack extends Stack {
       authorizerId: jwtAuthorizer.ref,
     })
 
+    new apigwv2.CfnRoute(this, 'AdminListRecipesRoute', {
+      apiId: this.httpApi.httpApiId,
+      routeKey: 'GET /recipes/admin',
+      target: `integrations/${recipeIntegration.ref}`,
+      authorizationType: 'JWT',
+      authorizerId: jwtAuthorizer.ref,
+    })
+
     new apigwv2.CfnRoute(this, 'CreateRecipeRoute', {
       apiId: this.httpApi.httpApiId,
       routeKey: 'POST /recipes',

--- a/test/lambda/recipe-handler.test.ts
+++ b/test/lambda/recipe-handler.test.ts
@@ -641,6 +641,126 @@ describe('Recipe Lambda handler', () => {
     })
   })
 
+  // ─── GET /recipes/admin — list all recipes for admins ──────────────
+  describe('GET /recipes/admin — list all recipes for admins', () => {
+    it('returns 401 without a valid token', async () => {
+      const event = makeEvent({
+        routeKey: 'GET /recipes/admin',
+        rawPath: '/recipes/admin',
+        headers: {},
+      })
+
+      const result = await handler(event)
+
+      expect(result.statusCode).toBe(401)
+      const body = JSON.parse(result.body as string)
+      expect(body).toHaveProperty('error')
+    })
+
+    it('returns 403 when the caller is not an admin', async () => {
+      const event = makeEvent({
+        routeKey: 'GET /recipes/admin',
+        rawPath: '/recipes/admin',
+        headers: { authorization: `Bearer ${contributorToken}` },
+      })
+
+      const result = await handler(event)
+
+      expect(result.statusCode).toBe(403)
+      const body = JSON.parse(result.body as string)
+      expect(body).toHaveProperty('error')
+    })
+
+    it('merges drafts and published recipes via two GSI queries with no table scan', async () => {
+      const published = publishedRecipeItem({ id: 'pub-id', slug: 'pub-slug', title: 'Published Recipe' })
+      const draft = draftRecipeItem({ id: 'draft-id', slug: 'draft-slug', title: 'Draft Recipe' })
+
+      ddbMock.on(QueryCommand)
+        .resolvesOnce({ Items: [published] })
+        .resolvesOnce({ Items: [draft] })
+
+      const event = makeEvent({
+        routeKey: 'GET /recipes/admin',
+        rawPath: '/recipes/admin',
+        headers: { authorization: `Bearer ${adminToken}` },
+      })
+
+      const result = await handler(event)
+
+      expect(result.statusCode).toBe(200)
+
+      const queryCalls = ddbMock.commandCalls(QueryCommand)
+      expect(queryCalls).toHaveLength(2)
+      for (const call of queryCalls) {
+        expect(call.args[0].input.IndexName).toBe('status-createdAt-index')
+      }
+
+      const statusValues = queryCalls.map((call) => call.args[0].input.ExpressionAttributeValues?.[':status'])
+      expect(new Set(statusValues)).toEqual(new Set(['published', 'draft']))
+
+      expect(ddbMock.commandCalls(ScanCommand)).toHaveLength(0)
+
+      const body = JSON.parse(result.body as string)
+      expect(Array.isArray(body)).toBe(true)
+      expect(body).toHaveLength(2)
+      const statuses = body.map((r: { status: string }) => r.status)
+      expect(statuses).toContain('published')
+      expect(statuses).toContain('draft')
+    })
+
+    it('filters out draft items whose ttl is in the past', async () => {
+      jest.useFakeTimers().setSystemTime(new Date('2026-04-19T12:00:00Z'))
+      try {
+        const nowSeconds = Math.floor(Date.now() / 1000)
+        const expiredDraft = draftRecipeItem({ id: 'expired-id', slug: 'expired-slug', title: 'Expired Draft', ttl: nowSeconds - 100 })
+        const liveDraft = draftRecipeItem({ id: 'live-id', slug: 'live-slug', title: 'Live Draft', ttl: nowSeconds + 100000 })
+
+        ddbMock.on(QueryCommand)
+          .resolvesOnce({ Items: [] })
+          .resolvesOnce({ Items: [expiredDraft, liveDraft] })
+
+        const event = makeEvent({
+          routeKey: 'GET /recipes/admin',
+          rawPath: '/recipes/admin',
+          headers: { authorization: `Bearer ${adminToken}` },
+        })
+
+        const result = await handler(event)
+
+        expect(result.statusCode).toBe(200)
+        const body = JSON.parse(result.body as string)
+        expect(body).toHaveLength(1)
+        expect(body[0].id).toBe('live-id')
+        expect(body.map((r: { id: string }) => r.id)).not.toContain('expired-id')
+      } finally {
+        jest.useRealTimers()
+      }
+    })
+
+    it('includes published items that have no ttl attribute', async () => {
+      const published = publishedRecipeItem({ id: 'pub-id', slug: 'pub-slug', title: 'Published Recipe' })
+      // Confirm the helper does not attach a ttl by default
+      expect(published).not.toHaveProperty('ttl')
+
+      ddbMock.on(QueryCommand)
+        .resolvesOnce({ Items: [published] })
+        .resolvesOnce({ Items: [] })
+
+      const event = makeEvent({
+        routeKey: 'GET /recipes/admin',
+        rawPath: '/recipes/admin',
+        headers: { authorization: `Bearer ${adminToken}` },
+      })
+
+      const result = await handler(event)
+
+      expect(result.statusCode).toBe(200)
+      const body = JSON.parse(result.body as string)
+      expect(body).toHaveLength(1)
+      expect(body[0].id).toBe('pub-id')
+    })
+  })
+
   // ─── PUT /recipes/{id} — update recipe ──────────────────────────────
   describe('PUT /recipes/{id} — update recipe', () => {
     it('returns 200 when contributor updates their own recipe', async () => {

--- a/test/lambda/recipe-handler.test.ts
+++ b/test/lambda/recipe-handler.test.ts
@@ -737,6 +737,52 @@ describe('Recipe Lambda handler', () => {
       }
     })
 
+    it('returns a lightweight admin projection that includes status and updatedAt but omits heavy fields', async () => {
+      const published = publishedRecipeItem({ id: 'pub-id', slug: 'pub-slug', title: 'Published Recipe' })
+      const draft = draftRecipeItem({ id: 'draft-id', slug: 'draft-slug', title: 'Draft Recipe' })
+
+      ddbMock.on(QueryCommand)
+        .resolvesOnce({ Items: [published] })
+        .resolvesOnce({ Items: [draft] })
+
+      const event = makeEvent({
+        routeKey: 'GET /recipes/admin',
+        rawPath: '/recipes/admin',
+        headers: { authorization: `Bearer ${adminToken}` },
+      })
+
+      const result = await handler(event)
+
+      expect(result.statusCode).toBe(200)
+      const body = JSON.parse(result.body as string) as Array<Record<string, unknown>>
+      expect(body).toHaveLength(2)
+
+      for (const item of body) {
+        expect(item).toHaveProperty('id')
+        expect(item).toHaveProperty('title')
+        expect(item).toHaveProperty('slug')
+        expect(item).toHaveProperty('coverImage')
+        expect(item).toHaveProperty('tags')
+        expect(item).toHaveProperty('prepTime')
+        expect(item).toHaveProperty('cookTime')
+        expect(item).toHaveProperty('servings')
+        expect(item).toHaveProperty('createdAt')
+        expect(item).toHaveProperty('status')
+        expect(item).toHaveProperty('updatedAt')
+        expect(typeof item.status).toBe('string')
+        expect(typeof item.updatedAt).toBe('string')
+        expect(Array.isArray(item.tags)).toBe(true)
+
+        // Heavy/private fields must be stripped from the list response.
+        expect(item).not.toHaveProperty('intro')
+        expect(item).not.toHaveProperty('ingredients')
+        expect(item).not.toHaveProperty('steps')
+        expect(item).not.toHaveProperty('authorId')
+        expect(item).not.toHaveProperty('authorName')
+        expect(item).not.toHaveProperty('ttl')
+      }
+    })
+
     it('includes published items that have no ttl attribute', async () => {
       const published = publishedRecipeItem({ id: 'pub-id', slug: 'pub-slug', title: 'Published Recipe' })
       // Confirm the helper does not attach a ttl by default

--- a/test/recipe-stack.test.ts
+++ b/test/recipe-stack.test.ts
@@ -341,6 +341,22 @@ describe('RecipeStack', () => {
     })
   })
 
+  describe('GET /recipes/admin route', () => {
+    it('has a GET /recipes/admin route', () => {
+      template.hasResourceProperties('AWS::ApiGatewayV2::Route', {
+        RouteKey: 'GET /recipes/admin',
+      })
+    })
+
+    it('is protected by the JWT authoriser', () => {
+      template.hasResourceProperties('AWS::ApiGatewayV2::Route', Match.objectLike({
+        RouteKey: 'GET /recipes/admin',
+        AuthorizationType: 'JWT',
+        AuthorizerId: Match.anyValue(),
+      }))
+    })
+  })
+
   describe('JWT Authoriser', () => {
     it('creates a JWT authoriser', () => {
       template.hasResourceProperties('AWS::ApiGatewayV2::Authorizer', {


### PR DESCRIPTION
Closes #88

## What changed
- New `GET /recipes/admin` endpoint in `lambda/recipe-handler.ts`, dispatched via a new `case` in the route switch.
- `handleListForAdmin(event)` issues two parallel `QueryCommand`s against `status-createdAt-index` — one for `'published'`, one for `'draft'` — merges the results, filters out items where `ttl` is in the past, and returns a lightweight admin projection.
- New `lightweightAdminRecipe` helper that extends the public `lightweightRecipe` projection with `status` and `updatedAt` (the fields the admin list UI needs). Heavy/private fields (`intro`, `ingredients`, `steps`, `ttl`, `authorId`, `authorName`) are stripped from the response.
- Extracted `queryRecipesByStatus(status)` helper used by both `handleListPublished` and `handleListForAdmin` so the GSI Query shape lives in one place.
- New `AdminListRecipesRoute` in `lib/recipe-stack.ts` — standard `CfnRoute` with `AuthorizationType: JWT` and the existing authoriser.

## Why
The admin recipe list page needs a single endpoint that returns both drafts and published items, gated to admins, and lightweight enough not to ship full ingredient/step bodies for every row. Two GSI queries in parallel outperform a table scan and use the index we already paid for.

PRD: `docs/prds/draft-recipes.md` — "Shared API contract" → `GET /recipes/admin`.

## How to verify
- `pnpm test` — 258/258 pass.
- 6 new handler tests cover: 401 (no JWT), 403 (non-admin), parallel GSI queries with `status-createdAt-index` and no `ScanCommand`, `ttl`-in-the-past exclusion, projection shape (required fields present, heavy fields absent), and the "no ttl attribute" case.
- 2 new CDK tests assert the route exists and has `AuthorizationType: JWT`.

## Decisions made
- Returned a lightweight projection (`lightweightAdminRecipe`) rather than the full item — the admin list UI only needs the summary fields plus `status` and `updatedAt`, and it's better to strip `ingredients`/`steps`/etc. server-side than rely on the client to ignore them.
- Extracted the GSI-by-status helper because the same query shape was now used in two places; the third caller (if one appears) starts life with the helper already in place.
- Deferred broader refactors flagged during review: a `RecipeStatus` string-union + constant across the whole file, and a shared `decodeJwt + isAdmin` guard helper. Both are worth doing but are cross-cutting and out of scope for this PR.
- Parallel `Promise.all` for the two queries, not sequential — the two status partitions are independent.