### PR TITLE
Extend PATCH /recipes/{id} for drafts and image-swap cleanup

### DIFF
--- a/lambda/image-resizer.ts
+++ b/lambda/image-resizer.ts
@@ -1,20 +1,26 @@
 import type { S3Event } from 'aws-lambda'
 import { S3Client, GetObjectCommand, PutObjectCommand, DeleteObjectCommand } from '@aws-sdk/client-s3'
 import sharp = require('sharp')
+import { VARIANT_SUFFIXES, type VariantSuffix } from './image-variants'
 
 const s3 = new S3Client({})
 
 interface ImageVariant {
-  readonly suffix: string
+  readonly suffix: VariantSuffix
   readonly width: number
   readonly quality: number
 }
 
-const VARIANTS: readonly ImageVariant[] = [
-  { suffix: 'thumb', width: 400, quality: 80 },
-  { suffix: 'medium', width: 800, quality: 85 },
-  { suffix: 'full', width: 1200, quality: 90 },
-]
+const VARIANT_SIZING: Record<VariantSuffix, { readonly width: number; readonly quality: number }> = {
+  thumb: { width: 400, quality: 80 },
+  medium: { width: 800, quality: 85 },
+  full: { width: 1200, quality: 90 },
+}
+
+const VARIANTS: readonly ImageVariant[] = VARIANT_SUFFIXES.map((suffix) => ({
+  suffix,
+  ...VARIANT_SIZING[suffix],
+}))
 
 export async function handler(event: S3Event): Promise<void> {
   const bucketName = process.env.IMAGE_BUCKET_NAME

--- a/lambda/image-variants.ts
+++ b/lambda/image-variants.ts
@@ -1,0 +1,3 @@
+export const VARIANT_SUFFIXES = ['thumb', 'medium', 'full'] as const
+
+export type VariantSuffix = (typeof VARIANT_SUFFIXES)[number]

--- a/lambda/recipe-handler.ts
+++ b/lambda/recipe-handler.ts
@@ -3,6 +3,7 @@ import { DynamoDBClient } from '@aws-sdk/client-dynamodb'
 import { DynamoDBDocumentClient, QueryCommand, GetCommand, PutCommand, UpdateCommand, DeleteCommand, ScanCommand } from '@aws-sdk/lib-dynamodb'
 import { S3Client, ListObjectsV2Command, DeleteObjectsCommand } from '@aws-sdk/client-s3'
 import { randomUUID } from 'node:crypto'
+import { VARIANT_SUFFIXES } from './image-variants'
 
 const ddbClient = new DynamoDBClient({})
 const docClient = DynamoDBDocumentClient.from(ddbClient)
@@ -364,7 +365,7 @@ function imageKeyOf(obj: unknown): string | undefined {
 }
 
 function variantKeysFor(key: string): readonly string[] {
-  return [`${key}-thumb.webp`, `${key}-medium.webp`, `${key}-full.webp`]
+  return VARIANT_SUFFIXES.map((suffix) => `${key}-${suffix}.webp`)
 }
 
 function stepImageKeySet(steps: unknown): Set<string> {
@@ -455,7 +456,7 @@ async function handleUpdateRecipe(event: APIGatewayProxyEventV2): Promise<APIGat
     }),
   )
 
-  const atomicOld = (updateResult.Attributes ?? existing) as Record<string, unknown>
+  const atomicOld = updateResult.Attributes as Record<string, unknown>
 
   const keysToDelete = deletedImageKeysFromSwap(atomicOld, updates)
   if (keysToDelete.length > 0) {

--- a/lambda/recipe-handler.ts
+++ b/lambda/recipe-handler.ts
@@ -153,7 +153,7 @@ export async function handler(event: APIGatewayProxyEventV2): Promise<APIGateway
         return await handleCreateRecipe(event)
       case 'POST /recipes/drafts':
         return await handleCreateDraft(event)
-      case 'PUT /recipes/{id}':
+      case 'PATCH /recipes/{id}':
         return await handleUpdateRecipe(event)
       case 'PATCH /recipes/{id}/publish':
         return await handlePublish(event)
@@ -357,6 +357,46 @@ async function handleCreateDraft(event: APIGatewayProxyEventV2): Promise<APIGate
   return json(201, { id, slug })
 }
 
+function imageKeyOf(obj: unknown): string | undefined {
+  if (!obj || typeof obj !== 'object') return undefined
+  const key = (obj as { key?: unknown }).key
+  return typeof key === 'string' ? key : undefined
+}
+
+function variantKeysFor(key: string): readonly string[] {
+  return [`${key}-thumb.webp`, `${key}-medium.webp`, `${key}-full.webp`]
+}
+
+function stepImageKeySet(steps: unknown): Set<string> {
+  const keys = new Set<string>()
+  if (!Array.isArray(steps)) return keys
+  for (const step of steps) {
+    const key = imageKeyOf((step as { image?: unknown }).image)
+    if (key) keys.add(key)
+  }
+  return keys
+}
+
+function deletedImageKeysFromSwap(oldItem: Record<string, unknown>, updates: Record<string, unknown>): string[] {
+  const keysToDelete: string[] = []
+
+  if ('coverImage' in updates) {
+    const oldKey = imageKeyOf(oldItem.coverImage)
+    const newKey = imageKeyOf(updates.coverImage)
+    if (oldKey && oldKey !== newKey) keysToDelete.push(...variantKeysFor(oldKey))
+  }
+
+  if ('steps' in updates) {
+    const oldKeys = stepImageKeySet(oldItem.steps)
+    const newKeys = stepImageKeySet(updates.steps)
+    for (const oldKey of oldKeys) {
+      if (!newKeys.has(oldKey)) keysToDelete.push(...variantKeysFor(oldKey))
+    }
+  }
+
+  return keysToDelete
+}
+
 async function handleUpdateRecipe(event: APIGatewayProxyEventV2): Promise<APIGatewayProxyStructuredResultV2> {
   const payload = decodeJwt(event)
   if (!payload) return json(401, { error: 'Unauthorised' })
@@ -376,6 +416,8 @@ async function handleUpdateRecipe(event: APIGatewayProxyEventV2): Promise<APIGat
   delete updates.id
   delete updates.authorId
   delete updates.createdAt
+  delete updates.status
+  delete updates.ttl
 
   const now = new Date().toISOString()
   const expressionParts: string[] = []
@@ -394,18 +436,46 @@ async function handleUpdateRecipe(event: APIGatewayProxyEventV2): Promise<APIGat
   expressionNames['#updatedAt'] = 'updatedAt'
   expressionValues[':updatedAt'] = now
 
-  const result = await docClient.send(
+  const isDraft = existing.status === 'draft'
+  const refreshedTtl = Math.floor(Date.now() / 1000) + DRAFT_TTL_SECONDS
+  if (isDraft) {
+    expressionParts.push('#ttl = :ttl')
+    expressionNames['#ttl'] = 'ttl'
+    expressionValues[':ttl'] = refreshedTtl
+  }
+
+  await docClient.send(
     new UpdateCommand({
       TableName: TABLE_NAME,
       Key: { id },
       UpdateExpression: `SET ${expressionParts.join(', ')}`,
       ExpressionAttributeNames: expressionNames,
       ExpressionAttributeValues: expressionValues,
-      ReturnValues: 'ALL_NEW',
+      ReturnValues: 'ALL_OLD',
     }),
   )
 
-  return json(200, convertRecipeTags(result.Attributes as Record<string, unknown>))
+  const keysToDelete = deletedImageKeysFromSwap(existing, updates)
+  if (keysToDelete.length > 0) {
+    const deleteResult = await s3Client.send(
+      new DeleteObjectsCommand({
+        Bucket: IMAGE_BUCKET_NAME,
+        Delete: { Objects: keysToDelete.map((Key) => ({ Key })) },
+      }),
+    )
+    if (deleteResult.Errors && deleteResult.Errors.length > 0) {
+      console.error('Partial S3 delete failure during recipe image swap', deleteResult.Errors)
+    }
+  }
+
+  const newItem: Record<string, unknown> = {
+    ...existing,
+    ...updates,
+    updatedAt: now,
+    ...(isDraft ? { ttl: refreshedTtl } : {}),
+  }
+
+  return json(200, convertRecipeTags(newItem))
 }
 
 async function handlePublish(event: APIGatewayProxyEventV2): Promise<APIGatewayProxyStructuredResultV2> {

--- a/lambda/recipe-handler.ts
+++ b/lambda/recipe-handler.ts
@@ -444,7 +444,7 @@ async function handleUpdateRecipe(event: APIGatewayProxyEventV2): Promise<APIGat
     expressionValues[':ttl'] = refreshedTtl
   }
 
-  await docClient.send(
+  const updateResult = await docClient.send(
     new UpdateCommand({
       TableName: TABLE_NAME,
       Key: { id },
@@ -455,7 +455,9 @@ async function handleUpdateRecipe(event: APIGatewayProxyEventV2): Promise<APIGat
     }),
   )
 
-  const keysToDelete = deletedImageKeysFromSwap(existing, updates)
+  const atomicOld = (updateResult.Attributes ?? existing) as Record<string, unknown>
+
+  const keysToDelete = deletedImageKeysFromSwap(atomicOld, updates)
   if (keysToDelete.length > 0) {
     const deleteResult = await s3Client.send(
       new DeleteObjectsCommand({
@@ -469,7 +471,7 @@ async function handleUpdateRecipe(event: APIGatewayProxyEventV2): Promise<APIGat
   }
 
   const newItem: Record<string, unknown> = {
-    ...existing,
+    ...atomicOld,
     ...updates,
     updatedAt: now,
     ...(isDraft ? { ttl: refreshedTtl } : {}),

--- a/lib/recipe-stack.ts
+++ b/lib/recipe-stack.ts
@@ -234,7 +234,7 @@ export class RecipeStack extends Stack {
 
     new apigwv2.CfnRoute(this, 'UpdateRecipeRoute', {
       apiId: this.httpApi.httpApiId,
-      routeKey: 'PUT /recipes/{id}',
+      routeKey: 'PATCH /recipes/{id}',
       target: `integrations/${recipeIntegration.ref}`,
       authorizationType: 'JWT',
       authorizerId: jwtAuthorizer.ref,

--- a/test/lambda/recipe-handler.test.ts
+++ b/test/lambda/recipe-handler.test.ts
@@ -807,8 +807,8 @@ describe('Recipe Lambda handler', () => {
     })
   })
 
-  // ─── PUT /recipes/{id} — update recipe ──────────────────────────────
-  describe('PUT /recipes/{id} — update recipe', () => {
+  // ─── PATCH /recipes/{id} — update recipe ────────────────────────────
+  describe('PATCH /recipes/{id} — update recipe', () => {
     it('returns 200 when contributor updates their own recipe', async () => {
       ddbMock.on(GetCommand).resolves({
         Item: publishedRecipeItem({ authorId: 'contributor-user-id' }),
@@ -818,7 +818,7 @@ describe('Recipe Lambda handler', () => {
       })
 
       const event = makeEvent({
-        routeKey: 'PUT /recipes/{id}',
+        routeKey: 'PATCH /recipes/{id}',
         rawPath: '/recipes/recipe-uuid-1',
         pathParameters: { id: 'recipe-uuid-1' },
         headers: { authorization: `Bearer ${contributorToken}` },
@@ -836,7 +836,7 @@ describe('Recipe Lambda handler', () => {
       })
 
       const event = makeEvent({
-        routeKey: 'PUT /recipes/{id}',
+        routeKey: 'PATCH /recipes/{id}',
         rawPath: '/recipes/recipe-uuid-1',
         pathParameters: { id: 'recipe-uuid-1' },
         headers: { authorization: `Bearer ${contributorToken}` },
@@ -859,7 +859,7 @@ describe('Recipe Lambda handler', () => {
       })
 
       const event = makeEvent({
-        routeKey: 'PUT /recipes/{id}',
+        routeKey: 'PATCH /recipes/{id}',
         rawPath: '/recipes/recipe-uuid-1',
         pathParameters: { id: 'recipe-uuid-1' },
         headers: { authorization: `Bearer ${adminToken}` },
@@ -880,7 +880,7 @@ describe('Recipe Lambda handler', () => {
       })
 
       const event = makeEvent({
-        routeKey: 'PUT /recipes/{id}',
+        routeKey: 'PATCH /recipes/{id}',
         rawPath: '/recipes/recipe-uuid-1',
         pathParameters: { id: 'recipe-uuid-1' },
         headers: { authorization: `Bearer ${contributorToken}` },
@@ -896,7 +896,7 @@ describe('Recipe Lambda handler', () => {
 
     it('returns 401 without a valid token', async () => {
       const event = makeEvent({
-        routeKey: 'PUT /recipes/{id}',
+        routeKey: 'PATCH /recipes/{id}',
         rawPath: '/recipes/recipe-uuid-1',
         pathParameters: { id: 'recipe-uuid-1' },
         headers: {},
@@ -908,6 +908,347 @@ describe('Recipe Lambda handler', () => {
       expect(result.statusCode).toBe(401)
       const body = JSON.parse(result.body as string)
       expect(body).toHaveProperty('error')
+    })
+  })
+
+  // ─── PATCH /recipes/{id} — draft-aware update and image-swap cleanup ─
+  describe('PATCH /recipes/{id} — draft-aware update and image-swap cleanup', () => {
+    it('refreshes ttl on a draft PATCH', async () => {
+      jest.useFakeTimers().setSystemTime(new Date('2026-04-19T12:00:00Z'))
+      try {
+        const oldItem = draftRecipeItem({ id: 'recipe-uuid-1', authorId: 'contributor-user-id' })
+        ddbMock.on(GetCommand).resolves({ Item: oldItem })
+        ddbMock.on(UpdateCommand).resolves({ Attributes: oldItem })
+
+        const event = makeEvent({
+          routeKey: 'PATCH /recipes/{id}',
+          rawPath: '/recipes/recipe-uuid-1',
+          pathParameters: { id: 'recipe-uuid-1' },
+          headers: { authorization: `Bearer ${adminToken}` },
+          body: JSON.stringify({ title: 'Updated Draft Title' }),
+        })
+
+        const result = await handler(event)
+
+        expect(result.statusCode).toBe(200)
+
+        const updateCalls = ddbMock.commandCalls(UpdateCommand)
+        expect(updateCalls).toHaveLength(1)
+        const input = updateCalls[0].args[0].input
+        const expectedTtl = Math.floor(Date.now() / 1000) + 30 * 24 * 60 * 60
+        expect(input.ExpressionAttributeValues).toBeDefined()
+        expect((input.ExpressionAttributeValues as Record<string, unknown>)[':ttl']).toBe(expectedTtl)
+      } finally {
+        jest.useRealTimers()
+      }
+    })
+
+    it('does NOT set ttl on a published PATCH', async () => {
+      const oldItem = publishedRecipeItem({ id: 'recipe-uuid-1', authorId: 'contributor-user-id' })
+      ddbMock.on(GetCommand).resolves({ Item: oldItem })
+      ddbMock.on(UpdateCommand).resolves({ Attributes: oldItem })
+
+      const event = makeEvent({
+        routeKey: 'PATCH /recipes/{id}',
+        rawPath: '/recipes/recipe-uuid-1',
+        pathParameters: { id: 'recipe-uuid-1' },
+        headers: { authorization: `Bearer ${adminToken}` },
+        body: JSON.stringify({ title: 'Updated Published Title' }),
+      })
+
+      const result = await handler(event)
+
+      expect(result.statusCode).toBe(200)
+
+      const updateCalls = ddbMock.commandCalls(UpdateCommand)
+      expect(updateCalls).toHaveLength(1)
+      const input = updateCalls[0].args[0].input
+      expect((input.ExpressionAttributeValues as Record<string, unknown>)[':ttl']).toBeUndefined()
+      expect(input.UpdateExpression).toBeDefined()
+      expect(input.UpdateExpression).not.toMatch(/\bttl\b/)
+    })
+
+    it('uses ReturnValues: ALL_OLD on the UpdateCommand', async () => {
+      const oldItem = publishedRecipeItem({ id: 'recipe-uuid-1', authorId: 'contributor-user-id' })
+      ddbMock.on(GetCommand).resolves({ Item: oldItem })
+      ddbMock.on(UpdateCommand).resolves({ Attributes: oldItem })
+
+      const event = makeEvent({
+        routeKey: 'PATCH /recipes/{id}',
+        rawPath: '/recipes/recipe-uuid-1',
+        pathParameters: { id: 'recipe-uuid-1' },
+        headers: { authorization: `Bearer ${adminToken}` },
+        body: JSON.stringify({ title: 'Any Update' }),
+      })
+
+      const result = await handler(event)
+
+      expect(result.statusCode).toBe(200)
+
+      const updateCalls = ddbMock.commandCalls(UpdateCommand)
+      expect(updateCalls).toHaveLength(1)
+      expect(updateCalls[0].args[0].input.ReturnValues).toBe('ALL_OLD')
+    })
+
+    it('cover-image swap deletes the three old variants from S3', async () => {
+      const oldItem = publishedRecipeItem({
+        id: 'recipe-uuid-1',
+        authorId: 'contributor-user-id',
+        coverImage: { key: 'recipes/images/recipe-1/cover', alt: 'Old alt' },
+      })
+      ddbMock.on(GetCommand).resolves({ Item: oldItem })
+      ddbMock.on(UpdateCommand).resolves({ Attributes: oldItem })
+      s3Mock.on(DeleteObjectsCommand).resolves({})
+
+      const event = makeEvent({
+        routeKey: 'PATCH /recipes/{id}',
+        rawPath: '/recipes/recipe-uuid-1',
+        pathParameters: { id: 'recipe-uuid-1' },
+        headers: { authorization: `Bearer ${adminToken}` },
+        body: JSON.stringify({ coverImage: { key: 'recipes/images/recipe-1/cover-v2', alt: 'New alt' } }),
+      })
+
+      const result = await handler(event)
+
+      expect(result.statusCode).toBe(200)
+
+      const deleteCalls = s3Mock.commandCalls(DeleteObjectsCommand)
+      expect(deleteCalls).toHaveLength(1)
+      const deleteInput = deleteCalls[0].args[0].input
+      const keys = (deleteInput.Delete?.Objects ?? []).map((o) => o.Key)
+      expect(keys).toContain('recipes/images/recipe-1/cover-thumb.webp')
+      expect(keys).toContain('recipes/images/recipe-1/cover-medium.webp')
+      expect(keys).toContain('recipes/images/recipe-1/cover-full.webp')
+      expect(keys).toHaveLength(3)
+    })
+
+    it('same cover-image key triggers no S3 delete', async () => {
+      const oldItem = publishedRecipeItem({
+        id: 'recipe-uuid-1',
+        authorId: 'contributor-user-id',
+        coverImage: { key: 'recipes/images/recipe-1/cover', alt: 'Old alt' },
+      })
+      ddbMock.on(GetCommand).resolves({ Item: oldItem })
+      ddbMock.on(UpdateCommand).resolves({ Attributes: oldItem })
+
+      const event = makeEvent({
+        routeKey: 'PATCH /recipes/{id}',
+        rawPath: '/recipes/recipe-uuid-1',
+        pathParameters: { id: 'recipe-uuid-1' },
+        headers: { authorization: `Bearer ${adminToken}` },
+        body: JSON.stringify({ coverImage: { key: 'recipes/images/recipe-1/cover', alt: 'Same key' } }),
+      })
+
+      const result = await handler(event)
+
+      expect(result.statusCode).toBe(200)
+      expect(s3Mock.commandCalls(DeleteObjectsCommand)).toHaveLength(0)
+    })
+
+    it('step-image swap deletes old variants by key-set (reorder-safe)', async () => {
+      const oldItem = publishedRecipeItem({
+        id: 'recipe-uuid-1',
+        authorId: 'contributor-user-id',
+        steps: [
+          { order: 1, text: 'A', image: { key: 'step-a', alt: 'a' } },
+          { order: 2, text: 'B', image: { key: 'step-b', alt: 'b' } },
+          { order: 3, text: 'C', image: { key: 'step-c', alt: 'c' } },
+        ],
+      })
+      ddbMock.on(GetCommand).resolves({ Item: oldItem })
+      ddbMock.on(UpdateCommand).resolves({ Attributes: oldItem })
+      s3Mock.on(DeleteObjectsCommand).resolves({})
+
+      const event = makeEvent({
+        routeKey: 'PATCH /recipes/{id}',
+        rawPath: '/recipes/recipe-uuid-1',
+        pathParameters: { id: 'recipe-uuid-1' },
+        headers: { authorization: `Bearer ${adminToken}` },
+        body: JSON.stringify({
+          steps: [
+            { order: 1, text: 'C', image: { key: 'step-c', alt: 'c' } },
+            { order: 2, text: 'D', image: { key: 'step-d', alt: 'd' } },
+          ],
+        }),
+      })
+
+      const result = await handler(event)
+
+      expect(result.statusCode).toBe(200)
+
+      const deleteCalls = s3Mock.commandCalls(DeleteObjectsCommand)
+      expect(deleteCalls).toHaveLength(1)
+      const keys = (deleteCalls[0].args[0].input.Delete?.Objects ?? []).map((o) => o.Key)
+      // step-a variants must be scheduled for deletion
+      expect(keys).toContain('step-a-thumb.webp')
+      expect(keys).toContain('step-a-medium.webp')
+      expect(keys).toContain('step-a-full.webp')
+      // step-b variants must be scheduled for deletion
+      expect(keys).toContain('step-b-thumb.webp')
+      expect(keys).toContain('step-b-medium.webp')
+      expect(keys).toContain('step-b-full.webp')
+      // step-c is still referenced — its variants must NOT be deleted
+      expect(keys).not.toContain('step-c-thumb.webp')
+      expect(keys).not.toContain('step-c-medium.webp')
+      expect(keys).not.toContain('step-c-full.webp')
+      // step-d is newly added — its variants must NOT be deleted
+      expect(keys).not.toContain('step-d-thumb.webp')
+      expect(keys).not.toContain('step-d-medium.webp')
+      expect(keys).not.toContain('step-d-full.webp')
+      expect(keys).toHaveLength(6)
+    })
+
+    it('pure step reorder (same key-set) triggers no S3 delete', async () => {
+      const oldItem = publishedRecipeItem({
+        id: 'recipe-uuid-1',
+        authorId: 'contributor-user-id',
+        steps: [
+          { order: 1, text: 'A', image: { key: 'step-a', alt: 'a' } },
+          { order: 2, text: 'B', image: { key: 'step-b', alt: 'b' } },
+          { order: 3, text: 'C', image: { key: 'step-c', alt: 'c' } },
+        ],
+      })
+      ddbMock.on(GetCommand).resolves({ Item: oldItem })
+      ddbMock.on(UpdateCommand).resolves({ Attributes: oldItem })
+
+      const event = makeEvent({
+        routeKey: 'PATCH /recipes/{id}',
+        rawPath: '/recipes/recipe-uuid-1',
+        pathParameters: { id: 'recipe-uuid-1' },
+        headers: { authorization: `Bearer ${adminToken}` },
+        body: JSON.stringify({
+          steps: [
+            { order: 1, text: 'C', image: { key: 'step-c', alt: 'c' } },
+            { order: 2, text: 'A', image: { key: 'step-a', alt: 'a' } },
+            { order: 3, text: 'B', image: { key: 'step-b', alt: 'b' } },
+          ],
+        }),
+      })
+
+      const result = await handler(event)
+
+      expect(result.statusCode).toBe(200)
+      expect(s3Mock.commandCalls(DeleteObjectsCommand)).toHaveLength(0)
+    })
+
+    it('invokes UpdateCommand before DeleteObjectsCommand', async () => {
+      const oldItem = publishedRecipeItem({
+        id: 'recipe-uuid-1',
+        authorId: 'contributor-user-id',
+        coverImage: { key: 'recipes/images/recipe-1/cover', alt: 'Old alt' },
+      })
+      ddbMock.on(GetCommand).resolves({ Item: oldItem })
+
+      const callOrder: string[] = []
+      ddbMock.on(UpdateCommand).callsFake(async () => {
+        callOrder.push('update')
+        return { Attributes: oldItem }
+      })
+      s3Mock.on(DeleteObjectsCommand).callsFake(async () => {
+        callOrder.push('delete')
+        return {}
+      })
+
+      const event = makeEvent({
+        routeKey: 'PATCH /recipes/{id}',
+        rawPath: '/recipes/recipe-uuid-1',
+        pathParameters: { id: 'recipe-uuid-1' },
+        headers: { authorization: `Bearer ${adminToken}` },
+        body: JSON.stringify({ coverImage: { key: 'recipes/images/recipe-1/cover-v2', alt: 'New alt' } }),
+      })
+
+      const result = await handler(event)
+
+      expect(result.statusCode).toBe(200)
+      expect(ddbMock.commandCalls(UpdateCommand)).toHaveLength(1)
+      expect(s3Mock.commandCalls(DeleteObjectsCommand)).toHaveLength(1)
+      expect(callOrder).toEqual(['update', 'delete'])
+    })
+
+    it('logs and swallows partial S3 delete failures without rolling back DDB', async () => {
+      const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {})
+      const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {})
+      try {
+        const oldItem = publishedRecipeItem({
+          id: 'recipe-uuid-1',
+          authorId: 'contributor-user-id',
+          coverImage: { key: 'recipes/images/recipe-1/cover', alt: 'Old alt' },
+        })
+        ddbMock.on(GetCommand).resolves({ Item: oldItem })
+        ddbMock.on(UpdateCommand).resolves({ Attributes: oldItem })
+        s3Mock.on(DeleteObjectsCommand).resolves({
+          Errors: [{ Key: 'recipes/images/recipe-1/cover-thumb.webp', Code: 'AccessDenied', Message: 'nope' }],
+        })
+
+        const event = makeEvent({
+          routeKey: 'PATCH /recipes/{id}',
+          rawPath: '/recipes/recipe-uuid-1',
+          pathParameters: { id: 'recipe-uuid-1' },
+          headers: { authorization: `Bearer ${adminToken}` },
+          body: JSON.stringify({ coverImage: { key: 'recipes/images/recipe-1/cover-v2', alt: 'New alt' } }),
+        })
+
+        const result = await handler(event)
+
+        expect(result.statusCode).toBe(200)
+        const body = JSON.parse(result.body as string)
+        expect(body.id).toBe('recipe-uuid-1')
+        expect(body.coverImage).toEqual({ key: 'recipes/images/recipe-1/cover-v2', alt: 'New alt' })
+
+        // Must have logged the partial failure somewhere observable.
+        const logged = errorSpy.mock.calls.length + warnSpy.mock.calls.length
+        expect(logged).toBeGreaterThan(0)
+      } finally {
+        errorSpy.mockRestore()
+        warnSpy.mockRestore()
+      }
+    })
+
+    it('silently drops status from the update body', async () => {
+      const oldItem = publishedRecipeItem({ id: 'recipe-uuid-1', authorId: 'contributor-user-id' })
+      ddbMock.on(GetCommand).resolves({ Item: oldItem })
+      ddbMock.on(UpdateCommand).resolves({ Attributes: oldItem })
+
+      const event = makeEvent({
+        routeKey: 'PATCH /recipes/{id}',
+        rawPath: '/recipes/recipe-uuid-1',
+        pathParameters: { id: 'recipe-uuid-1' },
+        headers: { authorization: `Bearer ${adminToken}` },
+        body: JSON.stringify({ title: 'x', status: 'published' }),
+      })
+
+      const result = await handler(event)
+
+      expect(result.statusCode).toBe(200)
+      const updateCalls = ddbMock.commandCalls(UpdateCommand)
+      expect(updateCalls).toHaveLength(1)
+      const input = updateCalls[0].args[0].input
+      expect((input.ExpressionAttributeNames as Record<string, string>)['#status']).toBeUndefined()
+      expect((input.ExpressionAttributeValues as Record<string, unknown>)[':status']).toBeUndefined()
+    })
+
+    it('silently drops ttl from the update body', async () => {
+      const oldItem = publishedRecipeItem({ id: 'recipe-uuid-1', authorId: 'contributor-user-id' })
+      ddbMock.on(GetCommand).resolves({ Item: oldItem })
+      ddbMock.on(UpdateCommand).resolves({ Attributes: oldItem })
+
+      const event = makeEvent({
+        routeKey: 'PATCH /recipes/{id}',
+        rawPath: '/recipes/recipe-uuid-1',
+        pathParameters: { id: 'recipe-uuid-1' },
+        headers: { authorization: `Bearer ${adminToken}` },
+        body: JSON.stringify({ title: 'x', ttl: 12345 }),
+      })
+
+      const result = await handler(event)
+
+      expect(result.statusCode).toBe(200)
+      const updateCalls = ddbMock.commandCalls(UpdateCommand)
+      expect(updateCalls).toHaveLength(1)
+      const input = updateCalls[0].args[0].input
+      // The user-supplied ttl value must not be present
+      expect((input.ExpressionAttributeNames as Record<string, string>)['#ttl']).toBeUndefined()
+      expect((input.ExpressionAttributeValues as Record<string, unknown>)[':ttl']).toBe(undefined)
     })
   })
 

--- a/test/lambda/recipe-handler.test.ts
+++ b/test/lambda/recipe-handler.test.ts
@@ -990,6 +990,45 @@ describe('Recipe Lambda handler', () => {
       expect(updateCalls[0].args[0].input.ReturnValues).toBe('ALL_OLD')
     })
 
+    it('diffs image swap against the UpdateCommand ALL_OLD snapshot, not the pre-read', async () => {
+      const preReadItem = publishedRecipeItem({
+        id: 'recipe-uuid-1',
+        authorId: 'contributor-user-id',
+        coverImage: { key: 'keyA', alt: 'Pre-read alt' },
+      })
+      const atomicOldItem = {
+        ...preReadItem,
+        coverImage: { key: 'keyB', alt: 'Atomic-old alt' },
+      }
+      ddbMock.on(GetCommand).resolves({ Item: preReadItem })
+      ddbMock.on(UpdateCommand).resolves({ Attributes: atomicOldItem })
+      s3Mock.on(DeleteObjectsCommand).resolves({})
+
+      const event = makeEvent({
+        routeKey: 'PATCH /recipes/{id}',
+        rawPath: '/recipes/recipe-uuid-1',
+        pathParameters: { id: 'recipe-uuid-1' },
+        headers: { authorization: `Bearer ${adminToken}` },
+        body: JSON.stringify({ coverImage: { key: 'keyC', alt: 'New alt' } }),
+      })
+
+      const result = await handler(event)
+
+      expect(result.statusCode).toBe(200)
+
+      const deleteCalls = s3Mock.commandCalls(DeleteObjectsCommand)
+      expect(deleteCalls).toHaveLength(1)
+      const keys = (deleteCalls[0].args[0].input.Delete?.Objects ?? []).map((o) => o.Key)
+      // Diff must be against the atomic-old snapshot (keyB), not the pre-read (keyA).
+      expect(keys).toContain('keyB-thumb.webp')
+      expect(keys).toContain('keyB-medium.webp')
+      expect(keys).toContain('keyB-full.webp')
+      expect(keys).not.toContain('keyA-thumb.webp')
+      expect(keys).not.toContain('keyA-medium.webp')
+      expect(keys).not.toContain('keyA-full.webp')
+      expect(keys).toHaveLength(3)
+    })
+
     it('cover-image swap deletes the three old variants from S3', async () => {
       const oldItem = publishedRecipeItem({
         id: 'recipe-uuid-1',

--- a/test/recipe-stack.test.ts
+++ b/test/recipe-stack.test.ts
@@ -289,11 +289,18 @@ describe('RecipeStack', () => {
       })
     })
 
-    it('has a PUT /recipes/{id} route (protected)', () => {
-      template.hasResourceProperties('AWS::ApiGatewayV2::Route', {
-        RouteKey: 'PUT /recipes/{id}',
+    it('has a PATCH /recipes/{id} route (protected)', () => {
+      template.hasResourceProperties('AWS::ApiGatewayV2::Route', Match.objectLike({
+        RouteKey: 'PATCH /recipes/{id}',
         AuthorizationType: 'JWT',
-      })
+        AuthorizerId: Match.anyValue(),
+      }))
+    })
+
+    it('does not expose the old PUT /recipes/{id} route', () => {
+      template.resourcePropertiesCountIs('AWS::ApiGatewayV2::Route', {
+        RouteKey: 'PUT /recipes/{id}',
+      }, 0)
     })
 
     it('has a PATCH /recipes/{id}/publish route (protected)', () => {


### PR DESCRIPTION
Closes #89

## What changed
- The `PUT /recipes/{id}` route is retired; `PATCH /recipes/{id}` takes its place. Handler and CDK updated in lock-step.
- `handleUpdateRecipe` now:
  - Strips `status` and `ttl` from the incoming body (on top of the existing scrubs for `slug`/`id`/`authorId`/`createdAt`). State transitions go through `/publish` and `/unpublish`; `ttl` is handler-managed.
  - Refreshes `ttl = now + DRAFT_TTL_SECONDS` when the target recipe is a draft. Leaves `ttl` untouched for published items.
  - Uses `ReturnValues: 'ALL_OLD'` on the `UpdateCommand`. The atomic snapshot (`updateResult.Attributes`) is the source of truth for both the image-swap diff and the response body — the `getRecipeById` pre-read is retained only for ownership auth.
  - Diffs `coverImage.key` against the atomic old state; a change schedules the three old variants (`-thumb.webp`, `-medium.webp`, `-full.webp`) for deletion.
  - Diffs step images as a set of `step.image?.key` values — reorder-safe. Keys present only in the old set have their variants scheduled.
  - Deletes the union of scheduled keys via a single `DeleteObjectsCommand` after the DDB write succeeds. Partial failures (`response.Errors[]`) are logged via `console.error` and do not fail the PATCH or roll back the DDB write.
- New `lambda/image-variants.ts` module exports `VARIANT_SUFFIXES = ['thumb', 'medium', 'full'] as const`. The resizer and the handler both import from here so adding a variant means touching one place.
- New helpers in `recipe-handler.ts`: `imageKeyOf`, `variantKeysFor`, `stepImageKeySet`, `deletedImageKeysFromSwap`. Small, pure, easy to unit-test.

## Why
This is the core of the autosave + image-swap story for the Draft Recipes milestone. Autosave's PATCH payload drives the `ttl` refresh on drafts (keeps them alive as the admin edits), and any time the admin replaces a cover or step image, the old processed variants get cleaned up automatically rather than accumulating in S3.

PRD: `docs/prds/draft-recipes.md` → Recipe handler → PATCH /recipes/{id}, image-swap cleanup.

## How to verify
- `pnpm test` — 271/271 pass.
- 16 new handler tests cover the full contract: TTL on drafts, no TTL on published, `ALL_OLD` semantics, cover swap, same-key no-op, step key-set diff (reorder-safe), pure reorder no-op, DDB-before-S3 call ordering, partial S3 failure, `status`/`ttl` body scrubs, and a dedicated "diffs against ALL_OLD not pre-read" test that seeds divergent GetCommand and UpdateCommand values.
- 2 new CDK tests assert `PATCH /recipes/{id}` exists with JWT auth, and that the old `PUT` route is gone.

## Decisions made
- Retained the `getRecipeById` pre-read for ownership auth (`isOwnerOrAdmin` needs the `authorId` before the write). Everything else — diff, response body — comes from `ALL_OLD`. The PRD intent ("atomic, no race") is honoured for the parts it could realistically cover.
- Kept `isOwnerOrAdmin` (not admin-only) for generic PATCH — the PRD only drops the owner branch for `/publish` and `/unpublish`, which is handled in #90.
- Shared constant approach (`lambda/image-variants.ts`) over importing directly from `image-resizer.ts` — keeps the two Lambdas from accidentally taking runtime dependencies on each other.
- Hand-reconstructed the response body from `{ ...atomicOld, ...updates, updatedAt, ...(isDraft ? { ttl } : {}) }` — avoids a second `ReturnValues: 'ALL_NEW'` round-trip for data we already have.