### PR TITLE
Admin-only publish/unpublish with validation and TTL semantics

### DIFF
--- a/lambda/recipe-handler.ts
+++ b/lambda/recipe-handler.ts
@@ -481,17 +481,66 @@ async function handleUpdateRecipe(event: APIGatewayProxyEventV2): Promise<APIGat
   return json(200, convertRecipeTags(newItem))
 }
 
+interface PublishErrors {
+  title?: string
+  intro?: string
+  coverImage?: { key?: string; alt?: string }
+  ingredients?: string
+  steps?: string
+}
+
+function validatePublishInput(item: Record<string, unknown>): PublishErrors {
+  const errors: PublishErrors = {}
+
+  const title = item.title
+  if (typeof title !== 'string' || title.trim().length === 0) {
+    errors.title = 'title is required'
+  }
+
+  const intro = item.intro
+  if (typeof intro !== 'string' || intro.trim().length === 0) {
+    errors.intro = 'intro is required'
+  }
+
+  const coverImage = item.coverImage as { key?: unknown; alt?: unknown } | undefined
+  const coverErrors: { key?: string; alt?: string } = {}
+  const coverKey = coverImage?.key
+  if (typeof coverKey !== 'string' || coverKey.trim().length === 0) {
+    coverErrors.key = 'coverImage.key is required'
+  }
+  const coverAlt = coverImage?.alt
+  if (typeof coverAlt !== 'string' || coverAlt.trim().length === 0) {
+    coverErrors.alt = 'coverImage.alt is required'
+  }
+  if (coverErrors.key || coverErrors.alt) {
+    errors.coverImage = coverErrors
+  }
+
+  const ingredients = item.ingredients
+  if (!Array.isArray(ingredients) || ingredients.length === 0) {
+    errors.ingredients = 'At least one ingredient is required'
+  }
+
+  const steps = item.steps
+  if (!Array.isArray(steps) || steps.length === 0) {
+    errors.steps = 'At least one step is required'
+  } else {
+    const hasEmptyStep = steps.some((step) => {
+      const text = (step as { text?: unknown }).text
+      return typeof text !== 'string' || text.trim().length === 0
+    })
+    if (hasEmptyStep) {
+      errors.steps = 'Every step must have non-empty text'
+    }
+  }
+
+  return errors
+}
+
 async function handlePublish(event: APIGatewayProxyEventV2): Promise<APIGatewayProxyStructuredResultV2> {
-  return await handleStatusChange(event, 'published')
-}
-
-async function handleUnpublish(event: APIGatewayProxyEventV2): Promise<APIGatewayProxyStructuredResultV2> {
-  return await handleStatusChange(event, 'draft')
-}
-
-async function handleStatusChange(event: APIGatewayProxyEventV2, newStatus: string): Promise<APIGatewayProxyStructuredResultV2> {
   const payload = decodeJwt(event)
   if (!payload) return json(401, { error: 'Unauthorised' })
+  if (!isAdmin(event)) return json(403, { error: 'Forbidden' })
 
   const id = event.pathParameters?.id
   if (!id) return json(400, { error: 'id is required' })
@@ -499,18 +548,48 @@ async function handleStatusChange(event: APIGatewayProxyEventV2, newStatus: stri
   const existing = await getRecipeById(id)
   if (!existing) return json(404, { error: 'Recipe not found' })
 
-  if (!isOwnerOrAdmin(existing.authorId as string, payload.sub, event)) {
-    return json(403, { error: 'Forbidden' })
-  }
+  const errors = validatePublishInput(existing)
+  if (Object.keys(errors).length > 0) return json(400, { errors: errors as Record<string, unknown> })
 
   const now = new Date().toISOString()
   const result = await docClient.send(
     new UpdateCommand({
       TableName: TABLE_NAME,
       Key: { id },
-      UpdateExpression: 'SET #status = :status, #updatedAt = :updatedAt',
-      ExpressionAttributeNames: { '#status': 'status', '#updatedAt': 'updatedAt' },
-      ExpressionAttributeValues: { ':status': newStatus, ':updatedAt': now },
+      UpdateExpression: 'SET #status = :status, #updatedAt = :updatedAt REMOVE #ttl',
+      ExpressionAttributeNames: { '#status': 'status', '#updatedAt': 'updatedAt', '#ttl': 'ttl' },
+      ExpressionAttributeValues: { ':status': 'published', ':updatedAt': now },
+      ReturnValues: 'ALL_NEW',
+    }),
+  )
+
+  return json(200, convertRecipeTags(result.Attributes as Record<string, unknown>))
+}
+
+async function handleUnpublish(event: APIGatewayProxyEventV2): Promise<APIGatewayProxyStructuredResultV2> {
+  const payload = decodeJwt(event)
+  if (!payload) return json(401, { error: 'Unauthorised' })
+  if (!isAdmin(event)) return json(403, { error: 'Forbidden' })
+
+  const id = event.pathParameters?.id
+  if (!id) return json(400, { error: 'id is required' })
+
+  const existing = await getRecipeById(id)
+  if (!existing) return json(404, { error: 'Recipe not found' })
+
+  if (existing.status === 'draft') {
+    return json(200, convertRecipeTags(existing))
+  }
+
+  const now = new Date().toISOString()
+  const ttl = Math.floor(Date.now() / 1000) + DRAFT_TTL_SECONDS
+  const result = await docClient.send(
+    new UpdateCommand({
+      TableName: TABLE_NAME,
+      Key: { id },
+      UpdateExpression: 'SET #status = :status, #updatedAt = :updatedAt, #ttl = :ttl',
+      ExpressionAttributeNames: { '#status': 'status', '#updatedAt': 'updatedAt', '#ttl': 'ttl' },
+      ExpressionAttributeValues: { ':status': 'draft', ':updatedAt': now, ':ttl': ttl },
       ReturnValues: 'ALL_NEW',
     }),
   )

--- a/lambda/recipe-handler.ts
+++ b/lambda/recipe-handler.ts
@@ -49,7 +49,7 @@ interface CreateRecipeInput {
   readonly servings?: number
 }
 
-function json(statusCode: number, body: Record<string, unknown> | readonly Record<string, unknown>[]): APIGatewayProxyStructuredResultV2 {
+function json(statusCode: number, body: unknown): APIGatewayProxyStructuredResultV2 {
   return { statusCode, headers: { 'Content-Type': 'application/json' }, body: JSON.stringify(body) }
 }
 
@@ -549,7 +549,7 @@ async function handlePublish(event: APIGatewayProxyEventV2): Promise<APIGatewayP
   if (!existing) return json(404, { error: 'Recipe not found' })
 
   const errors = validatePublishInput(existing)
-  if (Object.keys(errors).length > 0) return json(400, { errors: errors as Record<string, unknown> })
+  if (Object.keys(errors).length > 0) return json(400, { errors })
 
   if (existing.status === 'published') {
     return json(200, convertRecipeTags(existing))

--- a/lambda/recipe-handler.ts
+++ b/lambda/recipe-handler.ts
@@ -551,6 +551,10 @@ async function handlePublish(event: APIGatewayProxyEventV2): Promise<APIGatewayP
   const errors = validatePublishInput(existing)
   if (Object.keys(errors).length > 0) return json(400, { errors: errors as Record<string, unknown> })
 
+  if (existing.status === 'published') {
+    return json(200, convertRecipeTags(existing))
+  }
+
   const now = new Date().toISOString()
   const result = await docClient.send(
     new UpdateCommand({

--- a/test/lambda/recipe-handler.test.ts
+++ b/test/lambda/recipe-handler.test.ts
@@ -1292,8 +1292,8 @@ describe('Recipe Lambda handler', () => {
   })
 
   // ─── PATCH /recipes/{id}/publish ────────────────────────────────────
-  describe('PATCH /recipes/{id}/publish — publish recipe', () => {
-    it('returns 200 and sets status to published', async () => {
+  describe('PATCH /recipes/{id}/publish — publish recipe (admin-only)', () => {
+    it('returns 200 and sets status to published when admin publishes a valid draft', async () => {
       ddbMock.on(GetCommand).resolves({
         Item: draftRecipeItem({ authorId: 'contributor-user-id' }),
       })
@@ -1305,7 +1305,7 @@ describe('Recipe Lambda handler', () => {
         routeKey: 'PATCH /recipes/{id}/publish',
         rawPath: '/recipes/recipe-uuid-1/publish',
         pathParameters: { id: 'recipe-uuid-1' },
-        headers: { authorization: `Bearer ${contributorToken}` },
+        headers: { authorization: `Bearer ${adminToken}` },
       })
 
       const result = await handler(event)
@@ -1315,9 +1315,184 @@ describe('Recipe Lambda handler', () => {
       expect(body.status).toBe('published')
     })
 
-    it('returns 403 when contributor publishes another user\'s recipe', async () => {
+    it('removes ttl via UpdateExpression REMOVE (not SET ttl = null) on publish', async () => {
       ddbMock.on(GetCommand).resolves({
-        Item: draftRecipeItem({ authorId: 'other-contributor-id' }),
+        Item: draftRecipeItem({ authorId: 'contributor-user-id' }),
+      })
+      ddbMock.on(UpdateCommand).resolves({
+        Attributes: publishedRecipeItem({ authorId: 'contributor-user-id' }),
+      })
+
+      const event = makeEvent({
+        routeKey: 'PATCH /recipes/{id}/publish',
+        rawPath: '/recipes/recipe-uuid-1/publish',
+        pathParameters: { id: 'recipe-uuid-1' },
+        headers: { authorization: `Bearer ${adminToken}` },
+      })
+
+      const result = await handler(event)
+
+      expect(result.statusCode).toBe(200)
+      const updateCalls = ddbMock.commandCalls(UpdateCommand)
+      expect(updateCalls).toHaveLength(1)
+      const input = updateCalls[0].args[0].input
+      const updateExpression = input.UpdateExpression as string
+      // The UpdateExpression must REMOVE ttl (either `REMOVE ttl` or `REMOVE #ttl`).
+      expect(updateExpression).toMatch(/REMOVE\s+(#ttl|ttl)/)
+      // It must NOT SET a ttl value (no `:ttl` placeholder, no `ttl = :` pattern).
+      const values = (input.ExpressionAttributeValues ?? {}) as Record<string, unknown>
+      expect(values[':ttl']).toBeUndefined()
+    })
+
+    describe('server-side validation — returns 400 with field-level errors', () => {
+      function publishEvent() {
+        return makeEvent({
+          routeKey: 'PATCH /recipes/{id}/publish',
+          rawPath: '/recipes/recipe-uuid-1/publish',
+          pathParameters: { id: 'recipe-uuid-1' },
+          headers: { authorization: `Bearer ${adminToken}` },
+        })
+      }
+
+      it('returns 400 with a `title` error when title is missing', async () => {
+        ddbMock.on(GetCommand).resolves({
+          Item: draftRecipeItem({ authorId: 'contributor-user-id', title: '' }),
+        })
+
+        const result = await handler(publishEvent())
+
+        expect(result.statusCode).toBe(400)
+        const body = JSON.parse(result.body as string)
+        expect(body.errors).toBeDefined()
+        expect(body.errors).toHaveProperty('title')
+      })
+
+      it('returns 400 with an `intro` error when intro is missing', async () => {
+        ddbMock.on(GetCommand).resolves({
+          Item: draftRecipeItem({ authorId: 'contributor-user-id', intro: '' }),
+        })
+
+        const result = await handler(publishEvent())
+
+        expect(result.statusCode).toBe(400)
+        const body = JSON.parse(result.body as string)
+        expect(body.errors).toHaveProperty('intro')
+      })
+
+      it('returns 400 with a `coverImage.key` error when cover key is missing', async () => {
+        ddbMock.on(GetCommand).resolves({
+          Item: draftRecipeItem({
+            authorId: 'contributor-user-id',
+            coverImage: { key: '', alt: 'alt' },
+          }),
+        })
+
+        const result = await handler(publishEvent())
+
+        expect(result.statusCode).toBe(400)
+        const body = JSON.parse(result.body as string)
+        expect(body.errors).toHaveProperty('coverImage.key')
+      })
+
+      it('returns 400 with a `coverImage.alt` error when cover alt is missing', async () => {
+        ddbMock.on(GetCommand).resolves({
+          Item: draftRecipeItem({
+            authorId: 'contributor-user-id',
+            coverImage: { key: 'recipes/images/recipe-uuid-1/cover', alt: '' },
+          }),
+        })
+
+        const result = await handler(publishEvent())
+
+        expect(result.statusCode).toBe(400)
+        const body = JSON.parse(result.body as string)
+        expect(body.errors).toHaveProperty('coverImage.alt')
+      })
+
+      it('returns 400 with an `ingredients` error when ingredients list is empty', async () => {
+        ddbMock.on(GetCommand).resolves({
+          Item: draftRecipeItem({ authorId: 'contributor-user-id', ingredients: [] }),
+        })
+
+        const result = await handler(publishEvent())
+
+        expect(result.statusCode).toBe(400)
+        const body = JSON.parse(result.body as string)
+        expect(body.errors).toHaveProperty('ingredients')
+      })
+
+      it('returns 400 with a `steps` error when steps is missing', async () => {
+        ddbMock.on(GetCommand).resolves({
+          Item: draftRecipeItem({ authorId: 'contributor-user-id', steps: [] }),
+        })
+
+        const result = await handler(publishEvent())
+
+        expect(result.statusCode).toBe(400)
+        const body = JSON.parse(result.body as string)
+        expect(body.errors).toHaveProperty('steps')
+      })
+
+      it('returns 400 with a `steps` error when all steps have empty text', async () => {
+        ddbMock.on(GetCommand).resolves({
+          Item: draftRecipeItem({
+            authorId: 'contributor-user-id',
+            steps: [{ order: 1, text: '' }, { order: 2, text: '   ' }],
+          }),
+        })
+
+        const result = await handler(publishEvent())
+
+        expect(result.statusCode).toBe(400)
+        const body = JSON.parse(result.body as string)
+        expect(body.errors).toHaveProperty('steps')
+      })
+    })
+
+    it('returns 200 (no-op) when publishing an already-published recipe that still passes validation', async () => {
+      ddbMock.on(GetCommand).resolves({
+        Item: publishedRecipeItem({ authorId: 'contributor-user-id' }),
+      })
+      ddbMock.on(UpdateCommand).resolves({
+        Attributes: publishedRecipeItem({ authorId: 'contributor-user-id' }),
+      })
+
+      const event = makeEvent({
+        routeKey: 'PATCH /recipes/{id}/publish',
+        rawPath: '/recipes/recipe-uuid-1/publish',
+        pathParameters: { id: 'recipe-uuid-1' },
+        headers: { authorization: `Bearer ${adminToken}` },
+      })
+
+      const result = await handler(event)
+
+      expect(result.statusCode).toBe(200)
+      const body = JSON.parse(result.body as string)
+      expect(body.status).toBe('published')
+    })
+
+    it('returns 400 when re-publishing an already-published recipe that now fails validation', async () => {
+      ddbMock.on(GetCommand).resolves({
+        Item: publishedRecipeItem({ authorId: 'contributor-user-id', title: '' }),
+      })
+
+      const event = makeEvent({
+        routeKey: 'PATCH /recipes/{id}/publish',
+        rawPath: '/recipes/recipe-uuid-1/publish',
+        pathParameters: { id: 'recipe-uuid-1' },
+        headers: { authorization: `Bearer ${adminToken}` },
+      })
+
+      const result = await handler(event)
+
+      expect(result.statusCode).toBe(400)
+      const body = JSON.parse(result.body as string)
+      expect(body.errors).toHaveProperty('title')
+    })
+
+    it('returns 403 when a contributor (even the owner) publishes — admin-only', async () => {
+      ddbMock.on(GetCommand).resolves({
+        Item: draftRecipeItem({ authorId: 'contributor-user-id' }),
       })
 
       const event = makeEvent({
@@ -1333,13 +1508,65 @@ describe('Recipe Lambda handler', () => {
       const body = JSON.parse(result.body as string)
       expect(body).toHaveProperty('error')
     })
+
+    it('returns 401 without a valid token', async () => {
+      const event = makeEvent({
+        routeKey: 'PATCH /recipes/{id}/publish',
+        rawPath: '/recipes/recipe-uuid-1/publish',
+        pathParameters: { id: 'recipe-uuid-1' },
+        headers: {},
+      })
+
+      const result = await handler(event)
+
+      expect(result.statusCode).toBe(401)
+    })
   })
 
   // ─── PATCH /recipes/{id}/unpublish ──────────────────────────────────
-  describe('PATCH /recipes/{id}/unpublish — unpublish recipe', () => {
-    it('returns 200 and sets status to draft', async () => {
+  describe('PATCH /recipes/{id}/unpublish — unpublish recipe (admin-only)', () => {
+    it('returns 200 and sets status to draft with ttl = now + 30d', async () => {
       ddbMock.on(GetCommand).resolves({
         Item: publishedRecipeItem({ authorId: 'contributor-user-id' }),
+      })
+      ddbMock.on(UpdateCommand).resolves({
+        Attributes: draftRecipeItem({ authorId: 'contributor-user-id' }),
+      })
+
+      const before = Math.floor(Date.now() / 1000)
+
+      const event = makeEvent({
+        routeKey: 'PATCH /recipes/{id}/unpublish',
+        rawPath: '/recipes/recipe-uuid-1/unpublish',
+        pathParameters: { id: 'recipe-uuid-1' },
+        headers: { authorization: `Bearer ${adminToken}` },
+      })
+
+      const result = await handler(event)
+
+      const after = Math.floor(Date.now() / 1000)
+
+      expect(result.statusCode).toBe(200)
+      const body = JSON.parse(result.body as string)
+      expect(body.status).toBe('draft')
+
+      const updateCalls = ddbMock.commandCalls(UpdateCommand)
+      expect(updateCalls).toHaveLength(1)
+      const input = updateCalls[0].args[0].input
+      const values = (input.ExpressionAttributeValues ?? {}) as Record<string, unknown>
+      const ttl = values[':ttl']
+      expect(typeof ttl).toBe('number')
+
+      const thirtyDays = 30 * 24 * 60 * 60
+      const expectedMin = before + thirtyDays - 60
+      const expectedMax = after + thirtyDays + 60
+      expect(ttl as number).toBeGreaterThanOrEqual(expectedMin)
+      expect(ttl as number).toBeLessThanOrEqual(expectedMax)
+    })
+
+    it('returns 200 (no-op) when unpublishing an already-draft recipe', async () => {
+      ddbMock.on(GetCommand).resolves({
+        Item: draftRecipeItem({ authorId: 'contributor-user-id' }),
       })
       ddbMock.on(UpdateCommand).resolves({
         Attributes: draftRecipeItem({ authorId: 'contributor-user-id' }),
@@ -1349,19 +1576,24 @@ describe('Recipe Lambda handler', () => {
         routeKey: 'PATCH /recipes/{id}/unpublish',
         rawPath: '/recipes/recipe-uuid-1/unpublish',
         pathParameters: { id: 'recipe-uuid-1' },
-        headers: { authorization: `Bearer ${contributorToken}` },
+        headers: { authorization: `Bearer ${adminToken}` },
       })
 
       const result = await handler(event)
 
       expect(result.statusCode).toBe(200)
-      const body = JSON.parse(result.body as string)
-      expect(body.status).toBe('draft')
+      const updateCalls = ddbMock.commandCalls(UpdateCommand)
+      if (updateCalls.length > 0) {
+        const values = (updateCalls[0].args[0].input.ExpressionAttributeValues ?? {}) as Record<string, unknown>
+        if (values[':status'] !== undefined) {
+          expect(values[':status']).toBe('draft')
+        }
+      }
     })
 
-    it('returns 403 when contributor unpublishes another user\'s recipe', async () => {
+    it('returns 403 when a contributor (even the owner) unpublishes — admin-only', async () => {
       ddbMock.on(GetCommand).resolves({
-        Item: publishedRecipeItem({ authorId: 'other-contributor-id' }),
+        Item: publishedRecipeItem({ authorId: 'contributor-user-id' }),
       })
 
       const event = makeEvent({
@@ -1376,6 +1608,19 @@ describe('Recipe Lambda handler', () => {
       expect(result.statusCode).toBe(403)
       const body = JSON.parse(result.body as string)
       expect(body).toHaveProperty('error')
+    })
+
+    it('returns 401 without a valid token', async () => {
+      const event = makeEvent({
+        routeKey: 'PATCH /recipes/{id}/unpublish',
+        rawPath: '/recipes/recipe-uuid-1/unpublish',
+        pathParameters: { id: 'recipe-uuid-1' },
+        headers: {},
+      })
+
+      const result = await handler(event)
+
+      expect(result.statusCode).toBe(401)
     })
   })
 

--- a/test/lambda/recipe-handler.test.ts
+++ b/test/lambda/recipe-handler.test.ts
@@ -1469,6 +1469,7 @@ describe('Recipe Lambda handler', () => {
       expect(result.statusCode).toBe(200)
       const body = JSON.parse(result.body as string)
       expect(body.status).toBe('published')
+      expect(ddbMock.commandCalls(UpdateCommand)).toHaveLength(0)
     })
 
     it('returns 400 when re-publishing an already-published recipe that now fails validation', async () => {
@@ -1582,13 +1583,7 @@ describe('Recipe Lambda handler', () => {
       const result = await handler(event)
 
       expect(result.statusCode).toBe(200)
-      const updateCalls = ddbMock.commandCalls(UpdateCommand)
-      if (updateCalls.length > 0) {
-        const values = (updateCalls[0].args[0].input.ExpressionAttributeValues ?? {}) as Record<string, unknown>
-        if (values[':status'] !== undefined) {
-          expect(values[':status']).toBe('draft')
-        }
-      }
+      expect(ddbMock.commandCalls(UpdateCommand)).toHaveLength(0)
     })
 
     it('returns 403 when a contributor (even the owner) unpublishes — admin-only', async () => {


### PR DESCRIPTION
Closes #90

## What changed
- `PATCH /recipes/{id}/publish` now runs server-side validation (`title`, `intro`, `coverImage.key`, `coverImage.alt`, ≥1 ingredient, ≥1 step with non-empty text) and returns `400 { errors }` with field-level messages on failure. On success it flips `status` to `'published'` and removes `ttl` via `UpdateExpression ... REMOVE #ttl`.
- `PATCH /recipes/{id}/unpublish` sets `status: 'draft'` and `ttl = now + 30d`.
- Both routes drop the `isOwnerOrAdmin` branch — a non-admin owner is now rejected with 403.
- Already-published publish and already-draft unpublish short-circuit as true no-ops (no `UpdateCommand`, no `updatedAt` bump).
- `json()` body param widened to `unknown` — removes a dishonest cast at the 400 return.

## Why
Per `docs/prds/draft-recipes.md`, publish is an admin action (not an author action), and a published recipe must never carry a `ttl` — DynamoDB TTL ignores `null`, so `SET ttl = null` would leave rows forever uncollected. `REMOVE` guarantees it's gone.

## How to verify
- `pnpm test` — 284/284 pass.
- Recipe-handler suite covers: 6 validation cases, REMOVE-ttl assertion, no-op short-circuits (`UpdateCommand` call count = 0), admin-only 403 for owner contributors, 401 unauthenticated, unpublish `ttl = now + 30d` (±60s window).
- CDK template test at `test/recipe-stack.test.ts:306-318` already asserts both routes have `AuthorizationType: JWT`.

## Decisions made
- `PublishErrors` is a nested shape (`coverImage: { key, alt }`) rather than flat (`'coverImage.key'` keys) so Jest's `toHaveProperty('coverImage.key')` path-dot semantics work cleanly.
- Split `handleStatusChange` into dedicated `handlePublish` / `handleUnpublish` — the post-auth flows diverge enough (validation + REMOVE vs SET ttl + already-draft short-circuit) that a shared helper obscured both.
- Did not consolidate with `validateCreateInput` — different response shape, stricter rules, and the `POST /recipes` path it guards is being retired in #91.

🤖 Generated with [Claude Code](https://claude.com/claude-code)