### PR TITLE
fix(recipes): return processed key from upload handler

### DIFF
--- a/lambda/image-resizer.ts
+++ b/lambda/image-resizer.ts
@@ -1,7 +1,7 @@
 import { S3Client, GetObjectCommand, PutObjectCommand, DeleteObjectCommand } from '@aws-sdk/client-s3'
 import type { S3Event } from 'aws-lambda'
 import sharp from 'sharp'
-import { VARIANT_SUFFIXES, type VariantSuffix } from './image-variants'
+import { VARIANT_SUFFIXES, toProcessedKey, type VariantSuffix } from './image-variants'
 
 const s3 = new S3Client({})
 
@@ -37,7 +37,7 @@ export async function handler(event: S3Event): Promise<void> {
     const bodyBytes = await getResponse.Body!.transformToByteArray()
     const imageBuffer = Buffer.from(bodyBytes)
 
-    const processedKey = key.replace('uploads/', 'processed/')
+    const processedKey = toProcessedKey(key)
 
     await Promise.all(
       VARIANTS.map(async (variant) => {

--- a/lambda/image-variants.ts
+++ b/lambda/image-variants.ts
@@ -1,3 +1,16 @@
 export const VARIANT_SUFFIXES = ['thumb', 'medium', 'full'] as const
 
 export type VariantSuffix = (typeof VARIANT_SUFFIXES)[number]
+
+// S3 key prefixes for the image pipeline. Uploads land under UPLOAD_PREFIX
+// (what the resizer S3 trigger listens for); processed variants are written
+// under PROCESSED_PREFIX (where the site serves `<prefix><name>-<variant>.webp`).
+export const UPLOAD_PREFIX = 'uploads/'
+export const PROCESSED_PREFIX = 'processed/'
+
+export const toProcessedKey = (uploadKey: string): string => {
+  if (!uploadKey.startsWith(UPLOAD_PREFIX)) {
+    throw new Error(`Expected key to start with "${UPLOAD_PREFIX}", got "${uploadKey}"`)
+  }
+  return PROCESSED_PREFIX + uploadKey.slice(UPLOAD_PREFIX.length)
+}

--- a/lambda/recipe-image-handler.ts
+++ b/lambda/recipe-image-handler.ts
@@ -52,15 +52,20 @@ async function handleUploadUrl(event: APIGatewayProxyEventV2): Promise<APIGatewa
   if (!recipeId || !imageType) return json(400, { error: 'recipeId and imageType are required' })
   if (imageType !== 'cover' && !stepOrder) return json(400, { error: 'stepOrder is required for step images' })
 
-  const key = imageType === 'cover'
+  const uploadKey = imageType === 'cover'
     ? `uploads/recipes/${recipeId}/cover`
     : `uploads/recipes/${recipeId}/step-${stepOrder}`
 
   const uploadUrl = await getSignedUrl(
     s3,
-    new PutObjectCommand({ Bucket: IMAGE_BUCKET_NAME, Key: key }),
+    new PutObjectCommand({ Bucket: IMAGE_BUCKET_NAME, Key: uploadKey }),
     { expiresIn: 900 },
   )
+
+  // `key` is where the resizer writes variants (the caller stores this and
+  // constructs image URLs like `/images/<key>-<variant>.webp`). The presigned
+  // URL still targets the raw `uploads/` prefix that triggers the resizer.
+  const key = uploadKey.replace('uploads/', 'processed/')
 
   return json(200, { uploadUrl, key })
 }

--- a/lambda/recipe-image-handler.ts
+++ b/lambda/recipe-image-handler.ts
@@ -1,6 +1,7 @@
 import { S3Client, PutObjectCommand } from '@aws-sdk/client-s3'
 import { getSignedUrl } from '@aws-sdk/s3-request-presigner'
 import type { APIGatewayProxyEventV2, APIGatewayProxyStructuredResultV2 } from 'aws-lambda'
+import { UPLOAD_PREFIX, toProcessedKey } from './image-variants'
 
 const s3 = new S3Client({})
 const IMAGE_BUCKET_NAME = process.env.IMAGE_BUCKET_NAME ?? ''
@@ -53,8 +54,8 @@ async function handleUploadUrl(event: APIGatewayProxyEventV2): Promise<APIGatewa
   if (imageType !== 'cover' && !stepOrder) return json(400, { error: 'stepOrder is required for step images' })
 
   const uploadKey = imageType === 'cover'
-    ? `uploads/recipes/${recipeId}/cover`
-    : `uploads/recipes/${recipeId}/step-${stepOrder}`
+    ? `${UPLOAD_PREFIX}recipes/${recipeId}/cover`
+    : `${UPLOAD_PREFIX}recipes/${recipeId}/step-${stepOrder}`
 
   const uploadUrl = await getSignedUrl(
     s3,
@@ -64,8 +65,8 @@ async function handleUploadUrl(event: APIGatewayProxyEventV2): Promise<APIGatewa
 
   // `key` is where the resizer writes variants (the caller stores this and
   // constructs image URLs like `/images/<key>-<variant>.webp`). The presigned
-  // URL still targets the raw `uploads/` prefix that triggers the resizer.
-  const key = uploadKey.replace('uploads/', 'processed/')
+  // URL still targets the raw uploads prefix that triggers the resizer.
+  const key = toProcessedKey(uploadKey)
 
   return json(200, { uploadUrl, key })
 }

--- a/test/lambda/recipe-image-handler.test.ts
+++ b/test/lambda/recipe-image-handler.test.ts
@@ -75,7 +75,7 @@ describe('Recipe Image handler', () => {
       const body = JSON.parse(result.body as string)
       expect(typeof body.uploadUrl).toBe('string')
       expect(typeof body.key).toBe('string')
-      expect(body.key).toMatch(/^uploads\/recipes\/[^/]+\//)
+      expect(body.key).toMatch(/^processed\/recipes\/[^/]+\//)
     })
 
     it('generates correct S3 key for cover image', async () => {
@@ -88,7 +88,7 @@ describe('Recipe Image handler', () => {
 
       expect(result.statusCode).toBe(200)
       const body = JSON.parse(result.body as string)
-      expect(body.key).toBe('uploads/recipes/abc/cover')
+      expect(body.key).toBe('processed/recipes/abc/cover')
     })
 
     it('generates correct S3 key for step image', async () => {
@@ -101,7 +101,7 @@ describe('Recipe Image handler', () => {
 
       expect(result.statusCode).toBe(200)
       const body = JSON.parse(result.body as string)
-      expect(body.key).toBe('uploads/recipes/abc/step-3')
+      expect(body.key).toBe('processed/recipes/abc/step-3')
     })
 
     it('returns 401 without bearer token', async () => {


### PR DESCRIPTION
## Problem
After uploading a cover image on the recipe editor, the rendered `<img>` 404s with:
```
GET https://akli.dev/images/uploads/recipes/<id>/cover-medium.webp 404
```

## Root cause
`recipe-image-handler.ts:handleUploadUrl` returns the same S3 key that the presigned URL targets (`uploads/recipes/<id>/cover`). The frontend stores that key on the recipe and builds variant URLs from it (`\`/images/${key}-medium.webp\``). But the image resizer writes variants under `processed/recipes/<id>/cover-{thumb,medium,full}.webp` and deletes the raw upload — so the `uploads/` path never serves anything, while `processed/` is where the real variants live.

## Fix
The presigned URL still targets `uploads/...` (what the resizer listens for), but the returned `key` now represents the PROCESSED destination — the actual location of the variants:
```ts
const uploadKey = ... // uploads/recipes/<id>/cover
const uploadUrl = await getSignedUrl(..., { Key: uploadKey })
const key = uploadKey.replace('uploads/', 'processed/')
return json(200, { uploadUrl, key })
```

Frontend now constructs `/images/processed/recipes/<id>/cover-medium.webp` which matches the resizer's output path.

## Data compat
Any recipes whose `coverImage.key` is currently stored as `uploads/...` (from before this fix) will still 404 after deploy. The table was brand-new for the draft-recipes milestone, and the user has only created ~1 recipe on production — easiest to re-upload that cover image after the deploy rather than run a one-off migration.

## Tests
- Updated 3 assertions in `recipe-image-handler.test.ts` (`uploads/...` → `processed/...`).
- Image-resizer tests unchanged — it still receives events at `uploads/...`.
- `pnpm test` — 273/273.
- `pnpm lint` — exit 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)