### PR TITLE
CDK: add TABLE_NAME env var and DDB UpdateItem grant for image-resizer

### DIFF
--- a/lib/recipe-stack.ts
+++ b/lib/recipe-stack.ts
@@ -133,6 +133,7 @@ export class RecipeStack extends Stack {
 
     imageBucket.grantReadWrite(imageResizer)
     imageBucket.grantDelete(imageResizer)
+    // Narrow ARN (no GSI wildcards): table.grant() would add /index/* which UpdateItem cannot target.
     imageResizer.addToRolePolicy(new iam.PolicyStatement({
       actions: ['dynamodb:UpdateItem'],
       resources: [table.tableArn],

--- a/lib/recipe-stack.ts
+++ b/lib/recipe-stack.ts
@@ -127,11 +127,16 @@ export class RecipeStack extends Stack {
       functionName: 'akli-image-resizer',
       environment: {
         IMAGE_BUCKET_NAME: imageBucket.bucketName,
+        TABLE_NAME: table.tableName,
       },
     })
 
     imageBucket.grantReadWrite(imageResizer)
     imageBucket.grantDelete(imageResizer)
+    imageResizer.addToRolePolicy(new iam.PolicyStatement({
+      actions: ['dynamodb:UpdateItem'],
+      resources: [table.tableArn],
+    }))
 
     // S3 event notification for image uploads
     imageBucket.addEventNotification(

--- a/test/recipe-stack.test.ts
+++ b/test/recipe-stack.test.ts
@@ -376,66 +376,25 @@ describe('RecipeStack', () => {
     })
 
     it('does not grant dynamodb:PutItem, dynamodb:DeleteItem, or dynamodb:Scan on the image-resizer role', () => {
-      template.hasResourceProperties('AWS::IAM::Policy', {
-        Roles: Match.arrayWith([
-          { Ref: Match.stringLikeRegexp('^ImageResizerServiceRole.*') },
-        ]),
-        PolicyDocument: Match.objectLike({
-          Statement: Match.not(Match.arrayWith([
-            Match.objectLike({ Action: Match.arrayWith(['dynamodb:PutItem']) }),
-          ])),
-        }),
-      })
-      template.hasResourceProperties('AWS::IAM::Policy', {
-        Roles: Match.arrayWith([
-          { Ref: Match.stringLikeRegexp('^ImageResizerServiceRole.*') },
-        ]),
-        PolicyDocument: Match.objectLike({
-          Statement: Match.not(Match.arrayWith([
-            Match.objectLike({ Action: 'dynamodb:PutItem' }),
-          ])),
-        }),
-      })
-      template.hasResourceProperties('AWS::IAM::Policy', {
-        Roles: Match.arrayWith([
-          { Ref: Match.stringLikeRegexp('^ImageResizerServiceRole.*') },
-        ]),
-        PolicyDocument: Match.objectLike({
-          Statement: Match.not(Match.arrayWith([
-            Match.objectLike({ Action: Match.arrayWith(['dynamodb:DeleteItem']) }),
-          ])),
-        }),
-      })
-      template.hasResourceProperties('AWS::IAM::Policy', {
-        Roles: Match.arrayWith([
-          { Ref: Match.stringLikeRegexp('^ImageResizerServiceRole.*') },
-        ]),
-        PolicyDocument: Match.objectLike({
-          Statement: Match.not(Match.arrayWith([
-            Match.objectLike({ Action: 'dynamodb:DeleteItem' }),
-          ])),
-        }),
-      })
-      template.hasResourceProperties('AWS::IAM::Policy', {
-        Roles: Match.arrayWith([
-          { Ref: Match.stringLikeRegexp('^ImageResizerServiceRole.*') },
-        ]),
-        PolicyDocument: Match.objectLike({
-          Statement: Match.not(Match.arrayWith([
-            Match.objectLike({ Action: Match.arrayWith(['dynamodb:Scan']) }),
-          ])),
-        }),
-      })
-      template.hasResourceProperties('AWS::IAM::Policy', {
-        Roles: Match.arrayWith([
-          { Ref: Match.stringLikeRegexp('^ImageResizerServiceRole.*') },
-        ]),
-        PolicyDocument: Match.objectLike({
-          Statement: Match.not(Match.arrayWith([
-            Match.objectLike({ Action: 'dynamodb:Scan' }),
-          ])),
-        }),
-      })
+      const assertResizerLacks = (action: string) => {
+        // CDK consolidates actions into either a string or string[] — assert both forms.
+        for (const actionMatcher of [action, Match.arrayWith([action])]) {
+          template.hasResourceProperties('AWS::IAM::Policy', {
+            Roles: Match.arrayWith([
+              { Ref: Match.stringLikeRegexp('^ImageResizerServiceRole.*') },
+            ]),
+            PolicyDocument: Match.objectLike({
+              Statement: Match.not(Match.arrayWith([
+                Match.objectLike({ Action: actionMatcher }),
+              ])),
+            }),
+          })
+        }
+      }
+
+      for (const action of ['dynamodb:PutItem', 'dynamodb:DeleteItem', 'dynamodb:Scan']) {
+        assertResizerLacks(action)
+      }
     })
   })
 

--- a/test/recipe-stack.test.ts
+++ b/test/recipe-stack.test.ts
@@ -346,6 +346,99 @@ describe('RecipeStack', () => {
     })
   })
 
+  describe('IAM — image-resizer role', () => {
+    it('image-resizer Lambda environment includes TABLE_NAME set to the recipes table name', () => {
+      template.hasResourceProperties('AWS::Lambda::Function', Match.objectLike({
+        FunctionName: 'akli-image-resizer',
+        Environment: {
+          Variables: Match.objectLike({
+            TABLE_NAME: { Ref: Match.stringLikeRegexp('^RecipesTable.*') },
+          }),
+        },
+      }))
+    })
+
+    it('grants dynamodb:UpdateItem on the recipes table ARN', () => {
+      template.hasResourceProperties('AWS::IAM::Policy', {
+        Roles: Match.arrayWith([
+          { Ref: Match.stringLikeRegexp('^ImageResizerServiceRole.*') },
+        ]),
+        PolicyDocument: Match.objectLike({
+          Statement: Match.arrayWith([
+            Match.objectLike({
+              Action: 'dynamodb:UpdateItem',
+              Effect: 'Allow',
+              Resource: { 'Fn::GetAtt': [Match.stringLikeRegexp('^RecipesTable.*'), 'Arn'] },
+            }),
+          ]),
+        }),
+      })
+    })
+
+    it('does not grant dynamodb:PutItem, dynamodb:DeleteItem, or dynamodb:Scan on the image-resizer role', () => {
+      template.hasResourceProperties('AWS::IAM::Policy', {
+        Roles: Match.arrayWith([
+          { Ref: Match.stringLikeRegexp('^ImageResizerServiceRole.*') },
+        ]),
+        PolicyDocument: Match.objectLike({
+          Statement: Match.not(Match.arrayWith([
+            Match.objectLike({ Action: Match.arrayWith(['dynamodb:PutItem']) }),
+          ])),
+        }),
+      })
+      template.hasResourceProperties('AWS::IAM::Policy', {
+        Roles: Match.arrayWith([
+          { Ref: Match.stringLikeRegexp('^ImageResizerServiceRole.*') },
+        ]),
+        PolicyDocument: Match.objectLike({
+          Statement: Match.not(Match.arrayWith([
+            Match.objectLike({ Action: 'dynamodb:PutItem' }),
+          ])),
+        }),
+      })
+      template.hasResourceProperties('AWS::IAM::Policy', {
+        Roles: Match.arrayWith([
+          { Ref: Match.stringLikeRegexp('^ImageResizerServiceRole.*') },
+        ]),
+        PolicyDocument: Match.objectLike({
+          Statement: Match.not(Match.arrayWith([
+            Match.objectLike({ Action: Match.arrayWith(['dynamodb:DeleteItem']) }),
+          ])),
+        }),
+      })
+      template.hasResourceProperties('AWS::IAM::Policy', {
+        Roles: Match.arrayWith([
+          { Ref: Match.stringLikeRegexp('^ImageResizerServiceRole.*') },
+        ]),
+        PolicyDocument: Match.objectLike({
+          Statement: Match.not(Match.arrayWith([
+            Match.objectLike({ Action: 'dynamodb:DeleteItem' }),
+          ])),
+        }),
+      })
+      template.hasResourceProperties('AWS::IAM::Policy', {
+        Roles: Match.arrayWith([
+          { Ref: Match.stringLikeRegexp('^ImageResizerServiceRole.*') },
+        ]),
+        PolicyDocument: Match.objectLike({
+          Statement: Match.not(Match.arrayWith([
+            Match.objectLike({ Action: Match.arrayWith(['dynamodb:Scan']) }),
+          ])),
+        }),
+      })
+      template.hasResourceProperties('AWS::IAM::Policy', {
+        Roles: Match.arrayWith([
+          { Ref: Match.stringLikeRegexp('^ImageResizerServiceRole.*') },
+        ]),
+        PolicyDocument: Match.objectLike({
+          Statement: Match.not(Match.arrayWith([
+            Match.objectLike({ Action: 'dynamodb:Scan' }),
+          ])),
+        }),
+      })
+    })
+  })
+
   describe('JWT Authoriser', () => {
     it('creates a JWT authoriser', () => {
       template.hasResourceProperties('AWS::ApiGatewayV2::Authorizer', {


### PR DESCRIPTION
Closes #104

## What changed
- `lib/recipe-stack.ts`: added `TABLE_NAME: table.tableName` to the `ImageResizer` Lambda environment and attached a narrow `dynamodb:UpdateItem` policy statement on the resizer's role, scoped to the recipes table ARN.
- `test/recipe-stack.test.ts`: three new template assertions covering the env var, the `UpdateItem` grant on the table ARN, and a regression that the resizer's role does not gain `PutItem`/`DeleteItem`/`Scan`.

## Why
Foundation for the resizer write-back pipeline specified in `docs/prds/image-processing-readiness.md`. Without `TABLE_NAME` and the DDB permission, the resizer cannot record `imageStatus` back on the recipe item after writing variants — everything downstream (polling hook, publish-guard, admin single-recipe endpoint) depends on that signal existing.

## How to verify
- `pnpm test` — 276 tests pass, including the three new ones under `IAM — image-resizer role`.
- `cdk diff --all` on this branch should show only two additions to the `ImageResizer` function: one env var and one inline policy statement. No other resource churn.

## Decisions made
- Used `addToRolePolicy(new iam.PolicyStatement(...))` instead of the PRD-suggested `table.grant(imageResizer, 'dynamodb:UpdateItem')`. Reason: the recipes table has two GSIs, and `table.grant()` auto-expands `Resource` to include `<tableArn>/index/*`. `UpdateItem` cannot target a GSI, so that wildcard is both unnecessary and fails AC2 which asserts `Resource` is a single `Fn::GetAtt` on the table Arn. A WHY comment on the policy statement documents this to prevent future "simplification" back to `table.grant()`.
- Regression test collapsed into a loop over `['PutItem','DeleteItem','Scan'] × ['string', 'array']` — CDK emits `Action` as either a string or an array depending on consolidation, and the test asserts neither form appears.