### PR TITLE
Handler: initialise imageStatus map on draft creation

### DIFF
--- a/lambda/recipe-handler.ts
+++ b/lambda/recipe-handler.ts
@@ -266,6 +266,7 @@ async function handleCreateDraft(event: APIGatewayProxyEventV2): Promise<APIGate
     intro: '',
     ingredients: [],
     steps: [],
+    imageStatus: {},
     authorId: payload.sub,
     authorName: payload.name ?? payload.email ?? '',
     createdAt: now,

--- a/test/lambda/recipe-handler.test.ts
+++ b/test/lambda/recipe-handler.test.ts
@@ -417,6 +417,28 @@ describe('Recipe Lambda handler', () => {
       }
     })
 
+    it('initialises imageStatus as an empty map on the new item', async () => {
+      ddbMock.on(ScanCommand).resolves({ Items: [] })
+      ddbMock.on(PutCommand).resolves({})
+
+      const event = makeEvent({
+        routeKey: 'POST /recipes/drafts',
+        rawPath: '/recipes/drafts',
+        headers: { authorization: `Bearer ${adminToken}` },
+        body: '{}',
+      })
+
+      const result = await handler(event)
+
+      expect(result.statusCode).toBe(201)
+
+      const putCalls = ddbMock.commandCalls(PutCommand)
+      expect(putCalls).toHaveLength(1)
+      const item = putCalls[0].args[0].input.Item as Record<string, unknown>
+      expect(item).toHaveProperty('imageStatus')
+      expect(item.imageStatus).toEqual({})
+    })
+
     it('defaults slug to draft-<uuid> when no title is provided', async () => {
       ddbMock.on(ScanCommand).resolves({ Items: [] })
       ddbMock.on(PutCommand).resolves({})


### PR DESCRIPTION
Closes #105

## What changed
- `lambda/recipe-handler.ts`: added `imageStatus: {}` to the item literal in `handleCreateDraft`, between `steps: []` and `authorId`.
- `test/lambda/recipe-handler.test.ts`: new Jest test `initialises imageStatus as an empty map on the new item` inside the existing `POST /recipes/drafts` describe block, asserts the outgoing `PutCommand` Item contains `imageStatus: {}`.

## Why
Blocking defect for the resizer write-back pipeline (see `docs/prds/image-processing-readiness.md` — "Draft creation must initialise imageStatus"). `SET imageStatus.#k = :ts` on a missing top-level map throws `ValidationException: The document path provided in the update expression is invalid for update`. Without this init, the first upload on any freshly-created draft would blow up the resizer.

## How to verify
- `pnpm test` — 277 tests green, including the new assertion.
- Checkout `epic/image-processing-readiness` after merge; `POST /recipes/drafts` items in DynamoDB will now carry `imageStatus: {}`.

## Decisions made
- Field placement: inside the item literal's content-ish block (between `steps: []` and `authorId`), matching the existing logical grouping (content fields first, author/timestamp metadata after).
- Went with the eager-init approach over `if_not_exists(imageStatus, :empty)` in the resizer's UpdateExpression — simpler and avoids SDK-version fragility, per the PRD's explicit recommendation.