### PR TITLE
Resizer: write imageStatus back to DynamoDB after variant PUTs

### DIFF
--- a/lambda/image-resizer.ts
+++ b/lambda/image-resizer.ts
@@ -1,4 +1,4 @@
-import { DynamoDBClient } from '@aws-sdk/client-dynamodb'
+import { ConditionalCheckFailedException, DynamoDBClient } from '@aws-sdk/client-dynamodb'
 import { S3Client, GetObjectCommand, PutObjectCommand, DeleteObjectCommand } from '@aws-sdk/client-s3'
 import { DynamoDBDocumentClient, UpdateCommand } from '@aws-sdk/lib-dynamodb'
 import type { S3Event } from 'aws-lambda'
@@ -6,7 +6,7 @@ import sharp from 'sharp'
 import { VARIANT_SUFFIXES, toProcessedKey, UPLOAD_PREFIX, type VariantSuffix } from './image-variants'
 
 const s3 = new S3Client({})
-const ddb = DynamoDBDocumentClient.from(new DynamoDBClient({}))
+const docClient = DynamoDBDocumentClient.from(new DynamoDBClient({}))
 
 interface ImageVariant {
   readonly suffix: VariantSuffix
@@ -27,10 +27,11 @@ const VARIANTS: readonly ImageVariant[] = VARIANT_SUFFIXES.map((suffix) => ({
 
 const RECIPES_SEGMENT = 'recipes'
 
+// Accepts exactly `uploads/recipes/<id>/<type>` — extra trailing segments are rejected.
 function parseRecipeId(uploadKey: string): string | undefined {
   if (!uploadKey.startsWith(UPLOAD_PREFIX)) return undefined
   const segments = uploadKey.slice(UPLOAD_PREFIX.length).split('/')
-  if (segments.length < 3) return undefined
+  if (segments.length !== 3) return undefined
   if (segments[0] !== RECIPES_SEGMENT) return undefined
   const id = segments[1]
   if (!id) return undefined
@@ -75,12 +76,15 @@ export async function handler(event: S3Event): Promise<void> {
       }),
     )
 
+    const logSkip = (reason: string) =>
+      console.info({ event: 'resizer.writeback.skipped', reason, key })
+
     const recipeId = parseRecipeId(key)
     if (recipeId === undefined) {
-      console.info({ event: 'resizer.writeback.skipped', reason: 'unrecognised_key_shape', key })
+      logSkip('unrecognised_key_shape')
     } else {
       try {
-        await ddb.send(
+        await docClient.send(
           new UpdateCommand({
             TableName: tableName,
             Key: { id: recipeId },
@@ -91,8 +95,8 @@ export async function handler(event: S3Event): Promise<void> {
           }),
         )
       } catch (error) {
-        if (error instanceof Error && error.name === 'ConditionalCheckFailedException') {
-          console.info({ event: 'resizer.writeback.skipped', reason: 'recipe_deleted', key })
+        if (error instanceof ConditionalCheckFailedException) {
+          logSkip('recipe_deleted')
         } else {
           throw error
         }

--- a/lambda/image-resizer.ts
+++ b/lambda/image-resizer.ts
@@ -1,9 +1,12 @@
+import { DynamoDBClient } from '@aws-sdk/client-dynamodb'
 import { S3Client, GetObjectCommand, PutObjectCommand, DeleteObjectCommand } from '@aws-sdk/client-s3'
+import { DynamoDBDocumentClient, UpdateCommand } from '@aws-sdk/lib-dynamodb'
 import type { S3Event } from 'aws-lambda'
 import sharp from 'sharp'
-import { VARIANT_SUFFIXES, toProcessedKey, type VariantSuffix } from './image-variants'
+import { VARIANT_SUFFIXES, toProcessedKey, UPLOAD_PREFIX, type VariantSuffix } from './image-variants'
 
 const s3 = new S3Client({})
+const ddb = DynamoDBDocumentClient.from(new DynamoDBClient({}))
 
 interface ImageVariant {
   readonly suffix: VariantSuffix
@@ -22,9 +25,24 @@ const VARIANTS: readonly ImageVariant[] = VARIANT_SUFFIXES.map((suffix) => ({
   ...VARIANT_SIZING[suffix],
 }))
 
+const RECIPES_SEGMENT = 'recipes'
+
+function parseRecipeId(uploadKey: string): string | undefined {
+  if (!uploadKey.startsWith(UPLOAD_PREFIX)) return undefined
+  const segments = uploadKey.slice(UPLOAD_PREFIX.length).split('/')
+  if (segments.length < 3) return undefined
+  if (segments[0] !== RECIPES_SEGMENT) return undefined
+  const id = segments[1]
+  if (!id) return undefined
+  return id
+}
+
 export async function handler(event: S3Event): Promise<void> {
   const bucketName = process.env.IMAGE_BUCKET_NAME
   if (!bucketName) throw new Error('IMAGE_BUCKET_NAME not set')
+
+  const tableName = process.env.TABLE_NAME
+  if (!tableName) throw new Error('TABLE_NAME not set')
 
   for (const record of event.Records) {
     const key = record.s3.object.key
@@ -56,6 +74,30 @@ export async function handler(event: S3Event): Promise<void> {
         )
       }),
     )
+
+    const recipeId = parseRecipeId(key)
+    if (recipeId === undefined) {
+      console.info({ event: 'resizer.writeback.skipped', reason: 'unrecognised_key_shape', key })
+    } else {
+      try {
+        await ddb.send(
+          new UpdateCommand({
+            TableName: tableName,
+            Key: { id: recipeId },
+            UpdateExpression: 'SET imageStatus.#k = :ts',
+            ConditionExpression: 'attribute_exists(id)',
+            ExpressionAttributeNames: { '#k': processedKey },
+            ExpressionAttributeValues: { ':ts': Date.now() },
+          }),
+        )
+      } catch (error) {
+        if (error instanceof Error && error.name === 'ConditionalCheckFailedException') {
+          console.info({ event: 'resizer.writeback.skipped', reason: 'recipe_deleted', key })
+        } else {
+          throw error
+        }
+      }
+    }
 
     await s3.send(
       new DeleteObjectCommand({ Bucket: sourceBucket, Key: key }),

--- a/test/lambda/image-resizer.test.ts
+++ b/test/lambda/image-resizer.test.ts
@@ -1,8 +1,10 @@
 import { S3Client, GetObjectCommand, PutObjectCommand, DeleteObjectCommand } from '@aws-sdk/client-s3'
+import { DynamoDBDocumentClient, UpdateCommand } from '@aws-sdk/lib-dynamodb'
 import type { S3Event } from 'aws-lambda'
 import { mockClient } from 'aws-sdk-client-mock'
 
 const s3Mock = mockClient(S3Client)
+const ddbMock = mockClient(DynamoDBDocumentClient)
 
 const mockSharp = {
   resize: jest.fn().mockReturnThis(),
@@ -12,6 +14,7 @@ const mockSharp = {
 jest.mock('sharp', () => jest.fn(() => mockSharp))
 
 process.env.IMAGE_BUCKET_NAME = 'test-image-bucket'
+process.env.TABLE_NAME = 'test-recipes-table'
 
 import { handler } from '../../lambda/image-resizer'
 
@@ -53,6 +56,7 @@ function makeS3Event(key: string, bucket = 'test-image-bucket'): S3Event {
 describe('image-resizer handler', () => {
   beforeEach(() => {
     s3Mock.reset()
+    ddbMock.reset()
     jest.clearAllMocks()
 
     s3Mock.on(GetObjectCommand).resolves({
@@ -62,6 +66,7 @@ describe('image-resizer handler', () => {
     })
     s3Mock.on(PutObjectCommand).resolves({})
     s3Mock.on(DeleteObjectCommand).resolves({})
+    ddbMock.on(UpdateCommand).resolves({})
   })
 
   it('generates three WebP variants with correct dimensions and quality', async () => {
@@ -121,5 +126,110 @@ describe('image-resizer handler', () => {
     for (const call of putCalls) {
       expect(call.args[0].input.ContentType).toBe('image/webp')
     }
+  })
+
+  it('throws a clear error when TABLE_NAME env var is unset', async () => {
+    const saved = process.env.TABLE_NAME
+    delete process.env.TABLE_NAME
+    try {
+      await expect(handler(makeS3Event('uploads/recipes/abc/cover'))).rejects.toThrow(/TABLE_NAME/)
+    } finally {
+      process.env.TABLE_NAME = saved
+    }
+  })
+
+  it('writes back imageStatus to DynamoDB after variant PUTs for a cover image', async () => {
+    const before = Date.now()
+    await handler(makeS3Event('uploads/recipes/abc/cover'))
+    const after = Date.now()
+
+    const updateCalls = ddbMock.commandCalls(UpdateCommand)
+    expect(updateCalls).toHaveLength(1)
+
+    const input = updateCalls[0].args[0].input
+    expect(input.TableName).toBe('test-recipes-table')
+    expect(input.Key).toEqual({ id: 'abc' })
+    expect(input.UpdateExpression).toBe('SET imageStatus.#k = :ts')
+    expect(input.ConditionExpression).toBe('attribute_exists(id)')
+    expect(input.ExpressionAttributeNames).toEqual({ '#k': 'processed/recipes/abc/cover' })
+
+    const ts = input.ExpressionAttributeValues?.[':ts']
+    expect(typeof ts).toBe('number')
+    expect(Number.isFinite(ts)).toBe(true)
+    expect(ts).toBeGreaterThanOrEqual(before)
+    expect(ts).toBeLessThanOrEqual(after)
+  })
+
+  it('writes back imageStatus to DynamoDB for a step image key', async () => {
+    await handler(makeS3Event('uploads/recipes/abc/step-2'))
+
+    const updateCalls = ddbMock.commandCalls(UpdateCommand)
+    expect(updateCalls).toHaveLength(1)
+
+    const input = updateCalls[0].args[0].input
+    expect(input.Key).toEqual({ id: 'abc' })
+    expect(input.ExpressionAttributeNames).toEqual({ '#k': 'processed/recipes/abc/step-2' })
+  })
+
+  it('swallows ConditionalCheckFailedException, still deletes source, and logs skip event', async () => {
+    const infoSpy = jest.spyOn(console, 'info').mockImplementation(() => {})
+
+    const condFailed = Object.assign(new Error('The conditional request failed'), {
+      name: 'ConditionalCheckFailedException',
+    })
+    ddbMock.on(UpdateCommand).rejects(condFailed)
+
+    await expect(handler(makeS3Event('uploads/recipes/abc/cover'))).resolves.toBeUndefined()
+
+    // Source-delete still runs.
+    const deleteCalls = s3Mock.commandCalls(DeleteObjectCommand)
+    expect(deleteCalls).toHaveLength(1)
+    expect(deleteCalls[0].args[0].input).toEqual({
+      Bucket: 'test-image-bucket',
+      Key: 'uploads/recipes/abc/cover',
+    })
+
+    // Structured info log is emitted.
+    expect(infoSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        event: 'resizer.writeback.skipped',
+        reason: 'recipe_deleted',
+      }),
+    )
+
+    infoSpy.mockRestore()
+  })
+
+  it('rethrows non-conditional DDB errors', async () => {
+    ddbMock.on(UpdateCommand).rejects(new Error('boom'))
+
+    await expect(handler(makeS3Event('uploads/recipes/abc/cover'))).rejects.toThrow('boom')
+  })
+
+  it('skips the DDB write for a malformed key that does not match uploads/recipes/<id>/...', async () => {
+    // This key passes the toProcessedKey prefix guard but isn't the recipes shape.
+    await handler(makeS3Event('uploads/not-recipes/x'))
+
+    expect(ddbMock.commandCalls(UpdateCommand)).toHaveLength(0)
+
+    // Variant writes and source-delete still happen.
+    expect(s3Mock.commandCalls(PutObjectCommand)).toHaveLength(3)
+    expect(s3Mock.commandCalls(DeleteObjectCommand)).toHaveLength(1)
+  })
+
+  it('invokes DDB UpdateCommand before the source DeleteObjectCommand', async () => {
+    // Sequencing is enforced via the handler's error-propagation contract: if the
+    // UpdateCommand is issued BEFORE the source DeleteObjectCommand, rejecting the
+    // UpdateCommand with a generic error must prevent the source-delete from firing.
+    // If the delete were issued first, it would run regardless of the DDB outcome.
+    ddbMock.on(UpdateCommand).rejects(new Error('sequencing-probe'))
+
+    await expect(handler(makeS3Event('uploads/recipes/abc/cover'))).rejects.toThrow(
+      'sequencing-probe',
+    )
+
+    expect(ddbMock.commandCalls(UpdateCommand)).toHaveLength(1)
+    // Source-delete never fires because the update threw first.
+    expect(s3Mock.commandCalls(DeleteObjectCommand)).toHaveLength(0)
   })
 })

--- a/test/lambda/image-resizer.test.ts
+++ b/test/lambda/image-resizer.test.ts
@@ -1,3 +1,4 @@
+import { ConditionalCheckFailedException } from '@aws-sdk/client-dynamodb'
 import { S3Client, GetObjectCommand, PutObjectCommand, DeleteObjectCommand } from '@aws-sdk/client-s3'
 import { DynamoDBDocumentClient, UpdateCommand } from '@aws-sdk/lib-dynamodb'
 import type { S3Event } from 'aws-lambda'
@@ -174,8 +175,9 @@ describe('image-resizer handler', () => {
   it('swallows ConditionalCheckFailedException, still deletes source, and logs skip event', async () => {
     const infoSpy = jest.spyOn(console, 'info').mockImplementation(() => {})
 
-    const condFailed = Object.assign(new Error('The conditional request failed'), {
-      name: 'ConditionalCheckFailedException',
+    const condFailed = new ConditionalCheckFailedException({
+      $metadata: {},
+      message: 'The conditional request failed',
     })
     ddbMock.on(UpdateCommand).rejects(condFailed)
 


### PR DESCRIPTION
Closes #106

## What changed
- `lambda/image-resizer.ts`: after the variant PUTs succeed and before the source delete, parse the recipe id out of the upload key and fire a conditional `UpdateItem` against the recipes table (`SET imageStatus.#k = :ts`, `ConditionExpression: attribute_exists(id)`). Swallow `ConditionalCheckFailedException` with a structured info log; rethrow other errors so Lambda async retry kicks in. Skip the DDB write for keys that don't match `uploads/recipes/<id>/<type>`. Module-scope `docClient` reused across warm invocations.
- `test/lambda/image-resizer.test.ts`: 7 new tests cover the full AC surface — `TABLE_NAME` guard, cover + step write-back shapes, conditional-failure swallow + skip log + source-delete persistence, non-conditional error rethrow, malformed-key no-op, update-before-delete call ordering.

## Why
Second half of the readiness write-path. After #104 wired `TABLE_NAME` + the `UpdateItem` grant into CDK and #105 seeded `imageStatus: {}` on every draft, the resizer now actually records which variants exist on which recipe — unblocking the frontend polling hook and the publish-guard downstream.

## How to verify
- `pnpm test` → 284/284 green (7 new in `image-resizer.test.ts`).
- `pnpm lint` → clean.
- After deploy, upload a cover image through the admin editor and watch CloudWatch logs for the `UpdateItem` invocation; check the DynamoDB row for `imageStatus.processed/recipes/<id>/cover` with a recent unix-ms timestamp.
- Delete a recipe mid-processing and confirm a `resizer.writeback.skipped` info log with `reason: 'recipe_deleted'` — no `ValidationException`, no resurrected row.

## Decisions made
- **`parseRecipeId` requires exactly 3 segments** after the `uploads/` prefix (`recipes/<id>/<type>`). Keys with trailing junk are rejected — PRD calls for defensive shape validation against misconfigured S3 notifications.
- **`UpdateItem` runs sequentially before the source `DeleteObjectCommand`**, not in parallel. Ordering is load-bearing: on a non-conditional DDB error we rethrow so Lambda async retry can replay the whole sequence — if the delete had already fired, the retry would have nothing to process. The call-order test encodes this via an error-propagation probe (rejected update → delete must not fire).
- **`ConditionalCheckFailedException` via SDK class `instanceof`** rather than `error.name === '...'` string compare — type-safer and survives SDK error-shape evolution.
- **`docClient` naming** aligns with `recipe-handler.ts:9`.