### PR TITLE
Handler: compose processedAt onto images and strip imageStatus in responses

### DIFF
--- a/lambda/recipe-handler.ts
+++ b/lambda/recipe-handler.ts
@@ -127,7 +127,15 @@ function lightweightRecipe(recipe: Record<string, unknown>): Record<string, unkn
 function lightweightAdminRecipe(recipe: Record<string, unknown>): Record<string, unknown> {
   const composed = composeImageProcessedAt(recipe)
   return {
-    ...lightweightRecipe(composed),
+    id: composed.id,
+    title: composed.title,
+    slug: composed.slug,
+    coverImage: composed.coverImage,
+    tags: tagsToArray(composed.tags),
+    prepTime: composed.prepTime,
+    cookTime: composed.cookTime,
+    servings: composed.servings,
+    createdAt: composed.createdAt,
     status: composed.status,
     updatedAt: composed.updatedAt,
   }

--- a/lambda/recipe-handler.ts
+++ b/lambda/recipe-handler.ts
@@ -86,29 +86,50 @@ async function findUniqueSlug(baseSlug: string): Promise<string> {
   }
 }
 
+function composeImageProcessedAt<T extends Record<string, unknown>>(item: T): Omit<T, 'imageStatus'> {
+  const imageStatus = (item.imageStatus as Record<string, number> | undefined) ?? {}
+  const coverImage = item.coverImage as { key?: string } | undefined
+  const coverProcessedAt = coverImage?.key ? imageStatus[coverImage.key] : undefined
+  const steps = Array.isArray(item.steps)
+    ? item.steps.map((step) => {
+        const img = (step as { image?: { key?: string } }).image
+        if (!img?.key) return step
+        const processedAt = imageStatus[img.key]
+        return processedAt !== undefined ? { ...(step as object), image: { ...img, processedAt } } : step
+      })
+    : item.steps
+  const nextCover = coverImage && coverProcessedAt !== undefined
+    ? { ...coverImage, processedAt: coverProcessedAt }
+    : coverImage
+  const { imageStatus: _stripped, ...rest } = item
+  return { ...rest, coverImage: nextCover, steps } as Omit<T, 'imageStatus'>
+}
+
 function convertRecipeTags(recipe: Record<string, unknown>): Record<string, unknown> {
-  return { ...recipe, tags: tagsToArray(recipe.tags) }
+  return composeImageProcessedAt({ ...recipe, tags: tagsToArray(recipe.tags) })
 }
 
 function lightweightRecipe(recipe: Record<string, unknown>): Record<string, unknown> {
+  const composed = composeImageProcessedAt(recipe)
   return {
-    id: recipe.id,
-    title: recipe.title,
-    slug: recipe.slug,
-    coverImage: recipe.coverImage,
-    tags: tagsToArray(recipe.tags),
-    prepTime: recipe.prepTime,
-    cookTime: recipe.cookTime,
-    servings: recipe.servings,
-    createdAt: recipe.createdAt,
+    id: composed.id,
+    title: composed.title,
+    slug: composed.slug,
+    coverImage: composed.coverImage,
+    tags: tagsToArray(composed.tags),
+    prepTime: composed.prepTime,
+    cookTime: composed.cookTime,
+    servings: composed.servings,
+    createdAt: composed.createdAt,
   }
 }
 
 function lightweightAdminRecipe(recipe: Record<string, unknown>): Record<string, unknown> {
+  const composed = composeImageProcessedAt(recipe)
   return {
-    ...lightweightRecipe(recipe),
-    status: recipe.status,
-    updatedAt: recipe.updatedAt,
+    ...lightweightRecipe(composed),
+    status: composed.status,
+    updatedAt: composed.updatedAt,
   }
 }
 

--- a/test/lambda/recipe-handler.test.ts
+++ b/test/lambda/recipe-handler.test.ts
@@ -1954,5 +1954,27 @@ describe('Recipe Lambda handler', () => {
       expect(body.steps[0].image).not.toHaveProperty('processedAt')
       expect(body.steps[0].image).toEqual({ key: step1Key, alt: 'step alt' })
     })
+
+    it('preserves processedAt: 0 when imageStatus records a falsy-but-valid timestamp', async () => {
+      // Guards against a future `if (processedAt)` truthiness regression — the code
+      // must keep the `!== undefined` check so 0 is treated as "ready", not "missing".
+      const item = publishedRecipeItem({
+        id: 'recipe-uuid-1',
+        coverImage: { key: coverKey, alt: 'cover alt' },
+        steps: [],
+        imageStatus: { [coverKey]: 0 },
+      })
+      ddbMock.on(ScanCommand).resolves({ Items: [item] })
+
+      const result = await handler(makeEvent({
+        routeKey: 'GET /recipes/{slug}',
+        rawPath: '/recipes/slow-cooked-lamb-ragu',
+        pathParameters: { slug: 'slow-cooked-lamb-ragu' },
+      }))
+
+      expect(result.statusCode).toBe(200)
+      const body = JSON.parse(result.body as string)
+      expect(body.coverImage).toEqual({ key: coverKey, alt: 'cover alt', processedAt: 0 })
+    })
   })
 })

--- a/test/lambda/recipe-handler.test.ts
+++ b/test/lambda/recipe-handler.test.ts
@@ -1648,4 +1648,311 @@ describe('Recipe Lambda handler', () => {
       expect(body).toHaveProperty('error')
     })
   })
+
+  // ─── Response composition — processedAt + imageStatus stripping ─────
+  describe('Response composition — processedAt + imageStatus stripping', () => {
+    // A published recipe whose cover image and one step image both have matching
+    // imageStatus entries, plus one step image without a matching entry.
+    const coverKey = 'processed/recipes/recipe-uuid-1/cover'
+    const step1Key = 'processed/recipes/recipe-uuid-1/step-1'
+    const step2Key = 'processed/recipes/recipe-uuid-1/step-2'
+    const coverTs = 1_745_000_000_001
+    const step1Ts = 1_745_000_000_002
+
+    function recipeWithImageStatus(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+      return publishedRecipeItem({
+        id: 'recipe-uuid-1',
+        coverImage: { key: coverKey, alt: 'A bowl of lamb ragu' },
+        steps: [
+          { order: 1, text: 'Sear.', image: { key: step1Key, alt: 'seared lamb' } },
+          { order: 2, text: 'Simmer.', image: { key: step2Key, alt: 'simmering' } },
+        ],
+        imageStatus: { [coverKey]: coverTs, [step1Key]: step1Ts },
+        ...overrides,
+      })
+    }
+
+    // AC 1: GET /recipes composes processedAt onto cover image.
+    it('GET /recipes composes processedAt onto cover image from imageStatus', async () => {
+      ddbMock.on(QueryCommand).resolves({ Items: [recipeWithImageStatus()] })
+
+      const result = await handler(makeEvent({ routeKey: 'GET /recipes', rawPath: '/recipes' }))
+
+      expect(result.statusCode).toBe(200)
+      const body = JSON.parse(result.body as string)
+      expect(body[0].coverImage).toEqual({ key: coverKey, alt: 'A bowl of lamb ragu', processedAt: coverTs })
+    })
+
+    // AC 2: GET /recipes/{slug} composes onto cover AND each step.image.
+    it('GET /recipes/{slug} composes processedAt onto coverImage and each step.image', async () => {
+      ddbMock.on(ScanCommand).resolves({ Items: [recipeWithImageStatus()] })
+
+      const result = await handler(makeEvent({
+        routeKey: 'GET /recipes/{slug}',
+        rawPath: '/recipes/slow-cooked-lamb-ragu',
+        pathParameters: { slug: 'slow-cooked-lamb-ragu' },
+      }))
+
+      expect(result.statusCode).toBe(200)
+      const body = JSON.parse(result.body as string)
+      expect(body.coverImage).toEqual({ key: coverKey, alt: 'A bowl of lamb ragu', processedAt: coverTs })
+      // step 1 has a matching imageStatus entry → processedAt composed
+      expect(body.steps[0].image).toEqual({ key: step1Key, alt: 'seared lamb', processedAt: step1Ts })
+      // step 2 has no matching entry → processedAt absent (not null, not undefined-serialised)
+      expect(body.steps[1].image).toEqual({ key: step2Key, alt: 'simmering' })
+      expect(body.steps[1].image).not.toHaveProperty('processedAt')
+    })
+
+    // AC 3: GET /me/recipes composes processedAt on returned items.
+    it('GET /me/recipes composes processedAt on returned items', async () => {
+      ddbMock.on(QueryCommand).resolves({ Items: [recipeWithImageStatus({ authorId: 'contributor-user-id' })] })
+
+      const result = await handler(makeEvent({
+        routeKey: 'GET /me/recipes',
+        rawPath: '/me/recipes',
+        headers: { authorization: `Bearer ${contributorToken}` },
+      }))
+
+      expect(result.statusCode).toBe(200)
+      const body = JSON.parse(result.body as string)
+      expect(body).toHaveLength(1)
+      expect(body[0].coverImage).toEqual({ key: coverKey, alt: 'A bowl of lamb ragu', processedAt: coverTs })
+    })
+
+    // AC 4: GET /recipes/admin composes processedAt on returned items.
+    it('GET /recipes/admin composes processedAt on returned items', async () => {
+      ddbMock.on(QueryCommand)
+        .resolvesOnce({ Items: [recipeWithImageStatus()] })
+        .resolvesOnce({ Items: [] })
+
+      const result = await handler(makeEvent({
+        routeKey: 'GET /recipes/admin',
+        rawPath: '/recipes/admin',
+        headers: { authorization: `Bearer ${adminToken}` },
+      }))
+
+      expect(result.statusCode).toBe(200)
+      const body = JSON.parse(result.body as string)
+      expect(body).toHaveLength(1)
+      expect(body[0].coverImage).toEqual({ key: coverKey, alt: 'A bowl of lamb ragu', processedAt: coverTs })
+    })
+
+    // AC 5: PATCH /recipes/{id} response composes processedAt.
+    it('PATCH /recipes/{id} response composes processedAt onto the returned recipe', async () => {
+      const oldItem = recipeWithImageStatus({ authorId: 'contributor-user-id' })
+      ddbMock.on(GetCommand).resolves({ Item: oldItem })
+      ddbMock.on(UpdateCommand).resolves({ Attributes: oldItem })
+
+      const result = await handler(makeEvent({
+        routeKey: 'PATCH /recipes/{id}',
+        rawPath: '/recipes/recipe-uuid-1',
+        pathParameters: { id: 'recipe-uuid-1' },
+        headers: { authorization: `Bearer ${adminToken}` },
+        body: JSON.stringify({ title: 'Updated Title' }),
+      }))
+
+      expect(result.statusCode).toBe(200)
+      const body = JSON.parse(result.body as string)
+      expect(body.coverImage).toEqual({ key: coverKey, alt: 'A bowl of lamb ragu', processedAt: coverTs })
+      expect(body.steps[0].image).toEqual({ key: step1Key, alt: 'seared lamb', processedAt: step1Ts })
+    })
+
+    // AC 6: PATCH /recipes/{id}/publish response composes processedAt.
+    it('PATCH /recipes/{id}/publish response composes processedAt onto the returned recipe', async () => {
+      // Draft we read for validation passes all existing checks AND has readiness on every image.
+      const fullyReadyDraft = recipeWithImageStatus({
+        status: 'draft',
+        authorId: 'contributor-user-id',
+        steps: [
+          { order: 1, text: 'Sear.', image: { key: step1Key, alt: 'seared lamb' } },
+        ],
+        imageStatus: { [coverKey]: coverTs, [step1Key]: step1Ts },
+      })
+      ddbMock.on(GetCommand).resolves({ Item: fullyReadyDraft })
+      ddbMock.on(UpdateCommand).resolves({
+        Attributes: { ...fullyReadyDraft, status: 'published' },
+      })
+
+      const result = await handler(makeEvent({
+        routeKey: 'PATCH /recipes/{id}/publish',
+        rawPath: '/recipes/recipe-uuid-1/publish',
+        pathParameters: { id: 'recipe-uuid-1' },
+        headers: { authorization: `Bearer ${adminToken}` },
+      }))
+
+      expect(result.statusCode).toBe(200)
+      const body = JSON.parse(result.body as string)
+      expect(body.coverImage).toEqual({ key: coverKey, alt: 'A bowl of lamb ragu', processedAt: coverTs })
+      expect(body.steps[0].image).toEqual({ key: step1Key, alt: 'seared lamb', processedAt: step1Ts })
+    })
+
+    // AC 7: PATCH /recipes/{id}/unpublish response composes processedAt.
+    it('PATCH /recipes/{id}/unpublish response composes processedAt onto the returned recipe', async () => {
+      const oldItem = recipeWithImageStatus({ authorId: 'contributor-user-id' })
+      ddbMock.on(GetCommand).resolves({ Item: oldItem })
+      ddbMock.on(UpdateCommand).resolves({
+        Attributes: { ...oldItem, status: 'draft' },
+      })
+
+      const result = await handler(makeEvent({
+        routeKey: 'PATCH /recipes/{id}/unpublish',
+        rawPath: '/recipes/recipe-uuid-1/unpublish',
+        pathParameters: { id: 'recipe-uuid-1' },
+        headers: { authorization: `Bearer ${adminToken}` },
+      }))
+
+      expect(result.statusCode).toBe(200)
+      const body = JSON.parse(result.body as string)
+      expect(body.coverImage).toEqual({ key: coverKey, alt: 'A bowl of lamb ragu', processedAt: coverTs })
+    })
+
+    // AC 8: imageStatus is stripped from every response body.
+    describe('imageStatus is stripped from every response body', () => {
+      it('GET /recipes strips imageStatus', async () => {
+        ddbMock.on(QueryCommand).resolves({ Items: [recipeWithImageStatus()] })
+
+        const result = await handler(makeEvent({ routeKey: 'GET /recipes', rawPath: '/recipes' }))
+
+        expect(result.statusCode).toBe(200)
+        expect(result.body).not.toContain('imageStatus')
+        const body = JSON.parse(result.body as string)
+        expect(body[0]).not.toHaveProperty('imageStatus')
+      })
+
+      it('GET /recipes/{slug} strips imageStatus', async () => {
+        ddbMock.on(ScanCommand).resolves({ Items: [recipeWithImageStatus()] })
+
+        const result = await handler(makeEvent({
+          routeKey: 'GET /recipes/{slug}',
+          rawPath: '/recipes/slow-cooked-lamb-ragu',
+          pathParameters: { slug: 'slow-cooked-lamb-ragu' },
+        }))
+
+        expect(result.statusCode).toBe(200)
+        expect(result.body).not.toContain('imageStatus')
+        const body = JSON.parse(result.body as string)
+        expect(body).not.toHaveProperty('imageStatus')
+      })
+
+      it('GET /me/recipes strips imageStatus', async () => {
+        ddbMock.on(QueryCommand).resolves({ Items: [recipeWithImageStatus({ authorId: 'contributor-user-id' })] })
+
+        const result = await handler(makeEvent({
+          routeKey: 'GET /me/recipes',
+          rawPath: '/me/recipes',
+          headers: { authorization: `Bearer ${contributorToken}` },
+        }))
+
+        expect(result.statusCode).toBe(200)
+        expect(result.body).not.toContain('imageStatus')
+        const body = JSON.parse(result.body as string)
+        expect(body[0]).not.toHaveProperty('imageStatus')
+      })
+
+      it('GET /recipes/admin strips imageStatus', async () => {
+        ddbMock.on(QueryCommand)
+          .resolvesOnce({ Items: [recipeWithImageStatus()] })
+          .resolvesOnce({ Items: [] })
+
+        const result = await handler(makeEvent({
+          routeKey: 'GET /recipes/admin',
+          rawPath: '/recipes/admin',
+          headers: { authorization: `Bearer ${adminToken}` },
+        }))
+
+        expect(result.statusCode).toBe(200)
+        expect(result.body).not.toContain('imageStatus')
+        const body = JSON.parse(result.body as string)
+        expect(body[0]).not.toHaveProperty('imageStatus')
+      })
+
+      it('PATCH /recipes/{id} strips imageStatus', async () => {
+        const oldItem = recipeWithImageStatus({ authorId: 'contributor-user-id' })
+        ddbMock.on(GetCommand).resolves({ Item: oldItem })
+        ddbMock.on(UpdateCommand).resolves({ Attributes: oldItem })
+
+        const result = await handler(makeEvent({
+          routeKey: 'PATCH /recipes/{id}',
+          rawPath: '/recipes/recipe-uuid-1',
+          pathParameters: { id: 'recipe-uuid-1' },
+          headers: { authorization: `Bearer ${adminToken}` },
+          body: JSON.stringify({ title: 'Updated Title' }),
+        }))
+
+        expect(result.statusCode).toBe(200)
+        expect(result.body).not.toContain('imageStatus')
+        const body = JSON.parse(result.body as string)
+        expect(body).not.toHaveProperty('imageStatus')
+      })
+
+      it('PATCH /recipes/{id}/publish strips imageStatus', async () => {
+        const fullyReadyDraft = recipeWithImageStatus({
+          status: 'draft',
+          authorId: 'contributor-user-id',
+          steps: [{ order: 1, text: 'Sear.', image: { key: step1Key, alt: 'seared lamb' } }],
+          imageStatus: { [coverKey]: coverTs, [step1Key]: step1Ts },
+        })
+        ddbMock.on(GetCommand).resolves({ Item: fullyReadyDraft })
+        ddbMock.on(UpdateCommand).resolves({ Attributes: { ...fullyReadyDraft, status: 'published' } })
+
+        const result = await handler(makeEvent({
+          routeKey: 'PATCH /recipes/{id}/publish',
+          rawPath: '/recipes/recipe-uuid-1/publish',
+          pathParameters: { id: 'recipe-uuid-1' },
+          headers: { authorization: `Bearer ${adminToken}` },
+        }))
+
+        expect(result.statusCode).toBe(200)
+        expect(result.body).not.toContain('imageStatus')
+        const body = JSON.parse(result.body as string)
+        expect(body).not.toHaveProperty('imageStatus')
+      })
+
+      it('PATCH /recipes/{id}/unpublish strips imageStatus', async () => {
+        const oldItem = recipeWithImageStatus({ authorId: 'contributor-user-id' })
+        ddbMock.on(GetCommand).resolves({ Item: oldItem })
+        ddbMock.on(UpdateCommand).resolves({ Attributes: { ...oldItem, status: 'draft' } })
+
+        const result = await handler(makeEvent({
+          routeKey: 'PATCH /recipes/{id}/unpublish',
+          rawPath: '/recipes/recipe-uuid-1/unpublish',
+          pathParameters: { id: 'recipe-uuid-1' },
+          headers: { authorization: `Bearer ${adminToken}` },
+        }))
+
+        expect(result.statusCode).toBe(200)
+        expect(result.body).not.toContain('imageStatus')
+        const body = JSON.parse(result.body as string)
+        expect(body).not.toHaveProperty('imageStatus')
+      })
+    })
+
+    // AC 9: No processedAt added when imageStatus entry missing.
+    it('GET /recipes/{slug} omits processedAt when imageStatus has no entry for the cover key', async () => {
+      const item = publishedRecipeItem({
+        id: 'recipe-uuid-1',
+        coverImage: { key: coverKey, alt: 'no-entry alt' },
+        steps: [{ order: 1, text: 'step', image: { key: step1Key, alt: 'step alt' } }],
+        // imageStatus is an empty map — no entries for either key.
+        imageStatus: {},
+      })
+      ddbMock.on(ScanCommand).resolves({ Items: [item] })
+
+      const result = await handler(makeEvent({
+        routeKey: 'GET /recipes/{slug}',
+        rawPath: '/recipes/slow-cooked-lamb-ragu',
+        pathParameters: { slug: 'slow-cooked-lamb-ragu' },
+      }))
+
+      expect(result.statusCode).toBe(200)
+      // Literal check: the serialised body must not contain a processedAt key at all
+      // (guards against `processedAt: null` or `processedAt: undefined` slip-through).
+      expect(result.body).not.toContain('processedAt')
+      const body = JSON.parse(result.body as string)
+      expect(body.coverImage).not.toHaveProperty('processedAt')
+      expect(body.coverImage).toEqual({ key: coverKey, alt: 'no-entry alt' })
+      expect(body.steps[0].image).not.toHaveProperty('processedAt')
+      expect(body.steps[0].image).toEqual({ key: step1Key, alt: 'step alt' })
+    })
+  })
 })


### PR DESCRIPTION
Closes #107

## What changed
- `lambda/recipe-handler.ts`: new `composeImageProcessedAt` helper at lines 89-106. Looks up each image's `key` in the item's `imageStatus` map, merges `processedAt` onto `coverImage` and each `step.image` where a timestamp is known, and strips `imageStatus` itself from the returned object. Wired through the three existing response shapers — `convertRecipeTags`, `lightweightRecipe`, `lightweightAdminRecipe` — so every recipe-returning route picks it up without per-route changes.
- `test/lambda/recipe-handler.test.ts`: new `Response composition — processedAt + imageStatus stripping` describe covering all seven routes (`GET /recipes`, `/recipes/{slug}`, `/me/recipes`, `/recipes/admin`, and all three `PATCH`s), the stripping guarantee per-route, the absence case (no `imageStatus` entry → no stray `processedAt: null` or `undefined` slips through), and the falsy-but-valid timestamp case (`processedAt: 0` is preserved).

## Why
Read-side half of the readiness contract. The resizer now writes `imageStatus` back (from #106) and new drafts seed it with `{}` (from #105); the frontend needs `processedAt` surfaced on each image in every response so its polling hook and render branches can react without reaching into a server-internal map. `imageStatus` stays internal by construction — no route can leak it.

## How to verify
- `pnpm test` → 300/300 green (15 new tests in `recipe-handler.test.ts`).
- `pnpm lint` → clean.
- After deploy, fetch any published recipe via `GET /recipes/{slug}` on a recipe whose resizer has completed — response should carry `coverImage.processedAt` and per-step `image.processedAt`, and the top-level response should never include `imageStatus`.

## Decisions made
- **`composeImageProcessedAt` is a generic** — `<T extends Record<string, unknown>>(item: T): Omit<T, 'imageStatus'>`. Uses rest-destructuring to strip `imageStatus` and returns a type that explicitly excludes it. A single `as` cast on the return line is unavoidable given the pervasive `Record<string, unknown>` typing in the handler.
- **Compose-before-project** in `lightweightRecipe` and `lightweightAdminRecipe` — produces a full object with `processedAt` attached to `coverImage`, then the projection picks it up. Survives a future extension that adds `steps` to the lightweight shape.
- **`lightweightAdminRecipe` builds its shape directly** from the composed recipe rather than delegating to `lightweightRecipe` — avoids a second redundant `composeImageProcessedAt` call on the already-stripped input.
- **`processedAt !== undefined` check** (not truthiness) — `0` is a valid timestamp and must be preserved as "ready". Covered by a dedicated regression test.