### PR TITLE
Handler: PATCH image-swap removes imageStatus entries and strips client-supplied processedAt

### DIFF
--- a/lambda/recipe-handler.ts
+++ b/lambda/recipe-handler.ts
@@ -327,26 +327,6 @@ function stepImageKeySet(steps: unknown): Set<string> {
   return keys
 }
 
-function deletedImageKeysFromSwap(oldItem: Record<string, unknown>, updates: Record<string, unknown>): string[] {
-  const keysToDelete: string[] = []
-
-  if ('coverImage' in updates) {
-    const oldKey = imageKeyOf(oldItem.coverImage)
-    const newKey = imageKeyOf(updates.coverImage)
-    if (oldKey && oldKey !== newKey) keysToDelete.push(...variantKeysFor(oldKey))
-  }
-
-  if ('steps' in updates) {
-    const oldKeys = stepImageKeySet(oldItem.steps)
-    const newKeys = stepImageKeySet(updates.steps)
-    for (const oldKey of oldKeys) {
-      if (!newKeys.has(oldKey)) keysToDelete.push(...variantKeysFor(oldKey))
-    }
-  }
-
-  return keysToDelete
-}
-
 function droppedImageBaseKeys(oldItem: Record<string, unknown>, updates: Record<string, unknown>): string[] {
   const droppedKeys: string[] = []
 
@@ -458,7 +438,7 @@ async function handleUpdateRecipe(event: APIGatewayProxyEventV2): Promise<APIGat
 
   const atomicOld = updateResult.Attributes as Record<string, unknown>
 
-  const keysToDelete = deletedImageKeysFromSwap(atomicOld, updates)
+  const keysToDelete = droppedImageBaseKeys(atomicOld, updates).flatMap(variantKeysFor)
   if (keysToDelete.length > 0) {
     const deleteResult = await s3Client.send(
       new DeleteObjectsCommand({

--- a/lambda/recipe-handler.ts
+++ b/lambda/recipe-handler.ts
@@ -347,6 +347,44 @@ function deletedImageKeysFromSwap(oldItem: Record<string, unknown>, updates: Rec
   return keysToDelete
 }
 
+function droppedImageBaseKeys(oldItem: Record<string, unknown>, updates: Record<string, unknown>): string[] {
+  const droppedKeys: string[] = []
+
+  if ('coverImage' in updates) {
+    const oldKey = imageKeyOf(oldItem.coverImage)
+    const newKey = imageKeyOf(updates.coverImage)
+    if (oldKey && oldKey !== newKey) droppedKeys.push(oldKey)
+  }
+
+  if ('steps' in updates) {
+    const oldKeys = stepImageKeySet(oldItem.steps)
+    const newKeys = stepImageKeySet(updates.steps)
+    for (const oldKey of oldKeys) {
+      if (!newKeys.has(oldKey)) droppedKeys.push(oldKey)
+    }
+  }
+
+  return droppedKeys
+}
+
+function stripProcessedAtFromBody(updates: Record<string, unknown>): void {
+  const coverImage = updates.coverImage
+  if (coverImage && typeof coverImage === 'object' && !Array.isArray(coverImage)) {
+    delete (coverImage as Record<string, unknown>).processedAt
+  }
+
+  const steps = updates.steps
+  if (Array.isArray(steps)) {
+    for (const step of steps) {
+      if (!step || typeof step !== 'object') continue
+      const image = (step as { image?: unknown }).image
+      if (image && typeof image === 'object' && !Array.isArray(image)) {
+        delete (image as Record<string, unknown>).processedAt
+      }
+    }
+  }
+}
+
 async function handleUpdateRecipe(event: APIGatewayProxyEventV2): Promise<APIGatewayProxyStructuredResultV2> {
   const payload = decodeJwt(event)
   if (!payload) return json(401, { error: 'Unauthorised' })
@@ -368,37 +406,50 @@ async function handleUpdateRecipe(event: APIGatewayProxyEventV2): Promise<APIGat
   delete updates.createdAt
   delete updates.status
   delete updates.ttl
+  stripProcessedAtFromBody(updates)
 
   const now = new Date().toISOString()
-  const expressionParts: string[] = []
+  const setParts: string[] = []
   const expressionNames: Record<string, string> = {}
   const expressionValues: Record<string, unknown> = {}
 
   for (const [key, value] of Object.entries(updates)) {
     const attrName = `#${key}`
     const attrValue = `:${key}`
-    expressionParts.push(`${attrName} = ${attrValue}`)
+    setParts.push(`${attrName} = ${attrValue}`)
     expressionNames[attrName] = key
     expressionValues[attrValue] = value
   }
 
-  expressionParts.push('#updatedAt = :updatedAt')
+  setParts.push('#updatedAt = :updatedAt')
   expressionNames['#updatedAt'] = 'updatedAt'
   expressionValues[':updatedAt'] = now
 
   const isDraft = existing.status === DRAFT
   const refreshedTtl = Math.floor(Date.now() / 1000) + DRAFT_TTL_SECONDS
   if (isDraft) {
-    expressionParts.push('#ttl = :ttl')
+    setParts.push('#ttl = :ttl')
     expressionNames['#ttl'] = 'ttl'
     expressionValues[':ttl'] = refreshedTtl
   }
+
+  const droppedKeys = droppedImageBaseKeys(existing, updates)
+  const removeParts: string[] = []
+  droppedKeys.forEach((droppedKey, index) => {
+    const placeholder = `#droppedImageKey${index}`
+    removeParts.push(`imageStatus.${placeholder}`)
+    expressionNames[placeholder] = droppedKey
+  })
+
+  const updateExpression = removeParts.length > 0
+    ? `SET ${setParts.join(', ')} REMOVE ${removeParts.join(', ')}`
+    : `SET ${setParts.join(', ')}`
 
   const updateResult = await docClient.send(
     new UpdateCommand({
       TableName: TABLE_NAME,
       Key: { id },
-      UpdateExpression: `SET ${expressionParts.join(', ')}`,
+      UpdateExpression: updateExpression,
       ExpressionAttributeNames: expressionNames,
       ExpressionAttributeValues: expressionValues,
       ReturnValues: 'ALL_OLD',

--- a/test/lambda/recipe-handler.test.ts
+++ b/test/lambda/recipe-handler.test.ts
@@ -1977,4 +1977,183 @@ describe('Recipe Lambda handler', () => {
       expect(body.coverImage).toEqual({ key: coverKey, alt: 'cover alt', processedAt: 0 })
     })
   })
+
+  // ─── PATCH /recipes/{id} — imageStatus REMOVE on swap + processedAt strip ───
+  describe('PATCH /recipes/{id} — imageStatus REMOVE on swap and processedAt body strip', () => {
+    const oldCoverKey = 'processed/recipes/recipe-uuid-1/cover'
+    const newCoverKey = 'processed/recipes/recipe-uuid-1/cover-v2'
+    const stepAKey = 'processed/recipes/recipe-uuid-1/step-1'
+    const stepBKey = 'processed/recipes/recipe-uuid-1/step-2'
+    const stepCKey = 'processed/recipes/recipe-uuid-1/step-3'
+
+    // AC 1 + AC 5: cover-image swap REMOVEs imageStatus.#<oldCoverKey> in the same
+    // UpdateCommand as SET for updated fields, with ExpressionAttributeNames pointing
+    // at the dropped key.
+    it('cover-image swap includes REMOVE imageStatus.#<oldKey> in the same UpdateCommand as SET', async () => {
+      const oldItem = publishedRecipeItem({
+        id: 'recipe-uuid-1',
+        authorId: 'contributor-user-id',
+        coverImage: { key: oldCoverKey, alt: 'Old alt' },
+        imageStatus: { [oldCoverKey]: 1_745_000_000_001 },
+      })
+      ddbMock.on(GetCommand).resolves({ Item: oldItem })
+      ddbMock.on(UpdateCommand).resolves({ Attributes: oldItem })
+      s3Mock.on(DeleteObjectsCommand).resolves({})
+
+      const event = makeEvent({
+        routeKey: 'PATCH /recipes/{id}',
+        rawPath: '/recipes/recipe-uuid-1',
+        pathParameters: { id: 'recipe-uuid-1' },
+        headers: { authorization: `Bearer ${adminToken}` },
+        body: JSON.stringify({ coverImage: { key: newCoverKey, alt: 'New alt' } }),
+      })
+
+      const result = await handler(event)
+
+      expect(result.statusCode).toBe(200)
+
+      const updateCalls = ddbMock.commandCalls(UpdateCommand)
+      expect(updateCalls).toHaveLength(1)
+      const input = updateCalls[0].args[0].input
+      const expr = input.UpdateExpression as string
+
+      // Both SET (for the coverImage field) and REMOVE (for imageStatus entry) live in the same expression.
+      expect(expr).toMatch(/\bSET\b/)
+      expect(expr).toMatch(/\bREMOVE\b/)
+      expect(expr).toMatch(/REMOVE\s+imageStatus\.#/)
+
+      // An ExpressionAttributeName must point at the dropped old cover key.
+      const names = input.ExpressionAttributeNames as Record<string, string>
+      const nameValues = Object.values(names)
+      expect(nameValues).toContain(oldCoverKey)
+
+      // The name placeholder used in REMOVE must resolve to the old cover key.
+      const removeMatch = expr.match(/REMOVE\s+imageStatus\.(#[a-zA-Z0-9_]+)/)
+      expect(removeMatch).not.toBeNull()
+      const removePlaceholder = removeMatch![1]
+      expect(names[removePlaceholder]).toBe(oldCoverKey)
+    })
+
+    // AC 2: step-image swap REMOVEs only dropped step image keys; preserved keys stay.
+    it('step-image swap REMOVEs imageStatus entries for dropped keys only, preserving kept keys', async () => {
+      const oldItem = publishedRecipeItem({
+        id: 'recipe-uuid-1',
+        authorId: 'contributor-user-id',
+        coverImage: { key: oldCoverKey, alt: 'Cover alt' },
+        steps: [
+          { order: 1, text: 'A', image: { key: stepAKey, alt: 'a' } },
+          { order: 2, text: 'B', image: { key: stepBKey, alt: 'b' } },
+          { order: 3, text: 'C', image: { key: stepCKey, alt: 'c' } },
+        ],
+        imageStatus: {
+          [oldCoverKey]: 1_745_000_000_000,
+          [stepAKey]: 1_745_000_000_001,
+          [stepBKey]: 1_745_000_000_002,
+          [stepCKey]: 1_745_000_000_003,
+        },
+      })
+      ddbMock.on(GetCommand).resolves({ Item: oldItem })
+      ddbMock.on(UpdateCommand).resolves({ Attributes: oldItem })
+      s3Mock.on(DeleteObjectsCommand).resolves({})
+
+      const event = makeEvent({
+        routeKey: 'PATCH /recipes/{id}',
+        rawPath: '/recipes/recipe-uuid-1',
+        pathParameters: { id: 'recipe-uuid-1' },
+        headers: { authorization: `Bearer ${adminToken}` },
+        // Keep stepC, drop stepA and stepB. Cover unchanged.
+        body: JSON.stringify({
+          steps: [
+            { order: 1, text: 'C', image: { key: stepCKey, alt: 'c' } },
+          ],
+        }),
+      })
+
+      const result = await handler(event)
+
+      expect(result.statusCode).toBe(200)
+
+      const updateCalls = ddbMock.commandCalls(UpdateCommand)
+      expect(updateCalls).toHaveLength(1)
+      const input = updateCalls[0].args[0].input
+      const expr = input.UpdateExpression as string
+      const names = input.ExpressionAttributeNames as Record<string, string>
+
+      expect(expr).toMatch(/\bREMOVE\b/)
+
+      // Collect every imageStatus.#<placeholder> occurrence in the REMOVE segment.
+      const removeSegmentMatch = expr.match(/REMOVE\s+(.+)$/)
+      expect(removeSegmentMatch).not.toBeNull()
+      const removeSegment = removeSegmentMatch![1]
+      const placeholderMatches = Array.from(removeSegment.matchAll(/imageStatus\.(#[a-zA-Z0-9_]+)/g))
+      const removedKeys = placeholderMatches.map((m) => names[m[1]])
+
+      // Dropped step keys are REMOVEd.
+      expect(removedKeys).toContain(stepAKey)
+      expect(removedKeys).toContain(stepBKey)
+      // Preserved step key is NOT REMOVEd.
+      expect(removedKeys).not.toContain(stepCKey)
+      // Cover is unchanged — its imageStatus entry must be preserved too.
+      expect(removedKeys).not.toContain(oldCoverKey)
+      expect(removedKeys).toHaveLength(2)
+    })
+
+    // AC 3 + AC 4: client-supplied processedAt on nested coverImage and step.image is
+    // stripped before expression building; the outgoing UpdateCommand carries the cleaned
+    // objects and no value contains a processedAt field.
+    it('strips client-supplied processedAt from coverImage and step.image before the UpdateCommand runs', async () => {
+      const oldItem = publishedRecipeItem({
+        id: 'recipe-uuid-1',
+        authorId: 'contributor-user-id',
+        coverImage: { key: oldCoverKey, alt: 'Old cover alt' },
+        steps: [{ order: 1, text: 'A', image: { key: stepAKey, alt: 'a' } }],
+        imageStatus: { [oldCoverKey]: 1_745_000_000_000, [stepAKey]: 1_745_000_000_001 },
+      })
+      ddbMock.on(GetCommand).resolves({ Item: oldItem })
+      ddbMock.on(UpdateCommand).resolves({ Attributes: oldItem })
+
+      // Same keys — no image swap — so any UpdateExpression values that carry the nested
+      // image objects come straight from the (stripped) request body.
+      const event = makeEvent({
+        routeKey: 'PATCH /recipes/{id}',
+        rawPath: '/recipes/recipe-uuid-1',
+        pathParameters: { id: 'recipe-uuid-1' },
+        headers: { authorization: `Bearer ${adminToken}` },
+        body: JSON.stringify({
+          coverImage: { key: oldCoverKey, alt: 'Cover alt', processedAt: 9_999_999_999_999 },
+          steps: [
+            { order: 1, text: 'A', image: { key: stepAKey, alt: 'a', processedAt: 9_999_999_999_998 } },
+          ],
+        }),
+      })
+
+      const result = await handler(event)
+
+      expect(result.statusCode).toBe(200)
+
+      const updateCalls = ddbMock.commandCalls(UpdateCommand)
+      expect(updateCalls).toHaveLength(1)
+      const input = updateCalls[0].args[0].input
+      const values = input.ExpressionAttributeValues as Record<string, unknown>
+
+      // AC 4: no ExpressionAttributeValue key exists for a client-supplied processedAt
+      // (i.e. the strip happened on the parsed body before the handler built the expression).
+      expect(Object.keys(values)).not.toContain(':processedAt')
+
+      // The nested coverImage value carried in the UpdateCommand must not include processedAt.
+      const coverValue = values[':coverImage'] as Record<string, unknown> | undefined
+      expect(coverValue).toBeDefined()
+      expect(coverValue).not.toHaveProperty('processedAt')
+      expect(coverValue).toEqual({ key: oldCoverKey, alt: 'Cover alt' })
+
+      // Each nested step.image carried in the UpdateCommand must not include processedAt.
+      const stepsValue = values[':steps'] as Array<{ image?: Record<string, unknown> }> | undefined
+      expect(stepsValue).toBeDefined()
+      expect(stepsValue).toHaveLength(1)
+      const stepImage = stepsValue![0].image
+      expect(stepImage).toBeDefined()
+      expect(stepImage).not.toHaveProperty('processedAt')
+      expect(stepImage).toEqual({ key: stepAKey, alt: 'a' })
+    })
+  })
 })

--- a/test/lambda/recipe-handler.test.ts
+++ b/test/lambda/recipe-handler.test.ts
@@ -1978,7 +1978,6 @@ describe('Recipe Lambda handler', () => {
     })
   })
 
-  // ─── PATCH /recipes/{id} — imageStatus REMOVE on swap + processedAt strip ───
   describe('PATCH /recipes/{id} — imageStatus REMOVE on swap and processedAt body strip', () => {
     const oldCoverKey = 'processed/recipes/recipe-uuid-1/cover'
     const newCoverKey = 'processed/recipes/recipe-uuid-1/cover-v2'
@@ -1986,9 +1985,6 @@ describe('Recipe Lambda handler', () => {
     const stepBKey = 'processed/recipes/recipe-uuid-1/step-2'
     const stepCKey = 'processed/recipes/recipe-uuid-1/step-3'
 
-    // AC 1 + AC 5: cover-image swap REMOVEs imageStatus.#<oldCoverKey> in the same
-    // UpdateCommand as SET for updated fields, with ExpressionAttributeNames pointing
-    // at the dropped key.
     it('cover-image swap includes REMOVE imageStatus.#<oldKey> in the same UpdateCommand as SET', async () => {
       const oldItem = publishedRecipeItem({
         id: 'recipe-uuid-1',
@@ -2017,24 +2013,20 @@ describe('Recipe Lambda handler', () => {
       const input = updateCalls[0].args[0].input
       const expr = input.UpdateExpression as string
 
-      // Both SET (for the coverImage field) and REMOVE (for imageStatus entry) live in the same expression.
       expect(expr).toMatch(/\bSET\b/)
       expect(expr).toMatch(/\bREMOVE\b/)
       expect(expr).toMatch(/REMOVE\s+imageStatus\.#/)
 
-      // An ExpressionAttributeName must point at the dropped old cover key.
       const names = input.ExpressionAttributeNames as Record<string, string>
       const nameValues = Object.values(names)
       expect(nameValues).toContain(oldCoverKey)
 
-      // The name placeholder used in REMOVE must resolve to the old cover key.
       const removeMatch = expr.match(/REMOVE\s+imageStatus\.(#[a-zA-Z0-9_]+)/)
       expect(removeMatch).not.toBeNull()
       const removePlaceholder = removeMatch![1]
       expect(names[removePlaceholder]).toBe(oldCoverKey)
     })
 
-    // AC 2: step-image swap REMOVEs only dropped step image keys; preserved keys stay.
     it('step-image swap REMOVEs imageStatus entries for dropped keys only, preserving kept keys', async () => {
       const oldItem = publishedRecipeItem({
         id: 'recipe-uuid-1',
@@ -2061,7 +2053,6 @@ describe('Recipe Lambda handler', () => {
         rawPath: '/recipes/recipe-uuid-1',
         pathParameters: { id: 'recipe-uuid-1' },
         headers: { authorization: `Bearer ${adminToken}` },
-        // Keep stepC, drop stepA and stepB. Cover unchanged.
         body: JSON.stringify({
           steps: [
             { order: 1, text: 'C', image: { key: stepCKey, alt: 'c' } },
@@ -2081,26 +2072,19 @@ describe('Recipe Lambda handler', () => {
 
       expect(expr).toMatch(/\bREMOVE\b/)
 
-      // Collect every imageStatus.#<placeholder> occurrence in the REMOVE segment.
       const removeSegmentMatch = expr.match(/REMOVE\s+(.+)$/)
       expect(removeSegmentMatch).not.toBeNull()
       const removeSegment = removeSegmentMatch![1]
       const placeholderMatches = Array.from(removeSegment.matchAll(/imageStatus\.(#[a-zA-Z0-9_]+)/g))
       const removedKeys = placeholderMatches.map((m) => names[m[1]])
 
-      // Dropped step keys are REMOVEd.
       expect(removedKeys).toContain(stepAKey)
       expect(removedKeys).toContain(stepBKey)
-      // Preserved step key is NOT REMOVEd.
       expect(removedKeys).not.toContain(stepCKey)
-      // Cover is unchanged — its imageStatus entry must be preserved too.
       expect(removedKeys).not.toContain(oldCoverKey)
       expect(removedKeys).toHaveLength(2)
     })
 
-    // AC 3 + AC 4: client-supplied processedAt on nested coverImage and step.image is
-    // stripped before expression building; the outgoing UpdateCommand carries the cleaned
-    // objects and no value contains a processedAt field.
     it('strips client-supplied processedAt from coverImage and step.image before the UpdateCommand runs', async () => {
       const oldItem = publishedRecipeItem({
         id: 'recipe-uuid-1',
@@ -2112,8 +2096,6 @@ describe('Recipe Lambda handler', () => {
       ddbMock.on(GetCommand).resolves({ Item: oldItem })
       ddbMock.on(UpdateCommand).resolves({ Attributes: oldItem })
 
-      // Same keys — no image swap — so any UpdateExpression values that carry the nested
-      // image objects come straight from the (stripped) request body.
       const event = makeEvent({
         routeKey: 'PATCH /recipes/{id}',
         rawPath: '/recipes/recipe-uuid-1',
@@ -2136,17 +2118,13 @@ describe('Recipe Lambda handler', () => {
       const input = updateCalls[0].args[0].input
       const values = input.ExpressionAttributeValues as Record<string, unknown>
 
-      // AC 4: no ExpressionAttributeValue key exists for a client-supplied processedAt
-      // (i.e. the strip happened on the parsed body before the handler built the expression).
       expect(Object.keys(values)).not.toContain(':processedAt')
 
-      // The nested coverImage value carried in the UpdateCommand must not include processedAt.
       const coverValue = values[':coverImage'] as Record<string, unknown> | undefined
       expect(coverValue).toBeDefined()
       expect(coverValue).not.toHaveProperty('processedAt')
       expect(coverValue).toEqual({ key: oldCoverKey, alt: 'Cover alt' })
 
-      // Each nested step.image carried in the UpdateCommand must not include processedAt.
       const stepsValue = values[':steps'] as Array<{ image?: Record<string, unknown> }> | undefined
       expect(stepsValue).toBeDefined()
       expect(stepsValue).toHaveLength(1)


### PR DESCRIPTION
Closes #110

## What changed
- New `droppedImageBaseKeys` helper computes base image keys being removed when a cover image is swapped or step images are dropped; replaces the former `deletedImageKeysFromSwap` (S3 deletion path now derives variants via `flatMap(variantKeysFor)`).
- `handleUpdateRecipe` builds `SET` and `REMOVE` segments into one `UpdateExpression`, issuing `REMOVE imageStatus.#droppedImageKey<n>` alongside the existing `SET` so orphan readiness entries are cleaned in the same DDB round-trip.
- New `stripProcessedAtFromBody` removes client-supplied `processedAt` from nested `coverImage` and each `step.image` before expression building, so readiness stays server-computed.
- Jest coverage for all five acceptance criteria in `test/lambda/recipe-handler.test.ts`.

## Why
Per `docs/prds/image-processing-readiness.md` Technical Considerations: the `imageStatus` map must stay bounded by live image keys, and the backend must ignore any client attempt to write `processedAt` — readiness is derived from the resizer Lambda's write-back, not from client input.

## How to verify
- `pnpm test` → 303 passing (86 in `recipe-handler`, three new for this issue).
- `pnpm lint` clean.
- Read the diff in `lambda/recipe-handler.ts` around `handleUpdateRecipe`: the `UpdateCommand` now composes `SET ... REMOVE imageStatus.#...` when keys are dropped, and the body strip runs before expression building.

## Decisions made
- Single `droppedImageBaseKeys` helper drives both the DDB REMOVE list and the S3 variant deletion (via `flatMap(variantKeysFor)`), eliminating the near-duplicate traversal that would otherwise have drifted.
- Drop detection for the DDB REMOVE runs against the pre-fetched `existing` item (so the REMOVE lives in the same `UpdateCommand` as the `SET` — no extra round trip); S3 variant deletion continues to diff against the `ALL_OLD` response so it only fires for actually-committed swaps. Call ordering (DDB → S3) is unchanged.
- Placeholder naming `#droppedImageKey<index>` keeps REMOVE placeholders in a distinct namespace from the `#<fieldName>` placeholders generated by the SET loop, so image keys — which can contain `/` and `-` — never clash with field-name placeholders.