### PR TITLE
Handler: publish validation rejects recipes with unready images

### DIFF
--- a/lambda/recipe-handler.ts
+++ b/lambda/recipe-handler.ts
@@ -86,8 +86,12 @@ async function findUniqueSlug(baseSlug: string): Promise<string> {
   }
 }
 
+function imageStatusOf(item: Record<string, unknown>): Record<string, number> {
+  return (item.imageStatus as Record<string, number> | undefined) ?? {}
+}
+
 function composeImageProcessedAt<T extends Record<string, unknown>>(item: T): Omit<T, 'imageStatus'> {
-  const imageStatus = (item.imageStatus as Record<string, number> | undefined) ?? {}
+  const imageStatus = imageStatusOf(item)
   const coverImage = item.coverImage as { key?: string } | undefined
   const coverProcessedAt = coverImage?.key ? imageStatus[coverImage.key] : undefined
   const steps = Array.isArray(item.steps)
@@ -494,9 +498,9 @@ function validatePublishInput(item: Record<string, unknown>): PublishErrors {
     coverErrors.alt = 'coverImage.alt is required'
   }
 
-  const imageStatus = (item.imageStatus as Record<string, number> | undefined) ?? {}
+  const imageStatus = imageStatusOf(item)
 
-  if (typeof coverKey === 'string' && coverKey.trim().length > 0 && imageStatus[coverKey] === undefined) {
+  if (!coverErrors.key && imageStatus[coverKey as string] === undefined) {
     coverErrors.processedAt = 'Cover image still processing'
   }
 

--- a/lambda/recipe-handler.ts
+++ b/lambda/recipe-handler.ts
@@ -464,9 +464,10 @@ async function handleUpdateRecipe(event: APIGatewayProxyEventV2): Promise<APIGat
 interface PublishErrors {
   title?: string
   intro?: string
-  coverImage?: { key?: string; alt?: string }
+  coverImage?: { key?: string; alt?: string; processedAt?: string }
   ingredients?: string
   steps?: string
+  stepImages?: Array<{ order: number; processedAt: string }>
 }
 
 function validatePublishInput(item: Record<string, unknown>): PublishErrors {
@@ -483,7 +484,7 @@ function validatePublishInput(item: Record<string, unknown>): PublishErrors {
   }
 
   const coverImage = item.coverImage as { key?: unknown; alt?: unknown } | undefined
-  const coverErrors: { key?: string; alt?: string } = {}
+  const coverErrors: { key?: string; alt?: string; processedAt?: string } = {}
   const coverKey = coverImage?.key
   if (typeof coverKey !== 'string' || coverKey.trim().length === 0) {
     coverErrors.key = 'coverImage.key is required'
@@ -492,7 +493,14 @@ function validatePublishInput(item: Record<string, unknown>): PublishErrors {
   if (typeof coverAlt !== 'string' || coverAlt.trim().length === 0) {
     coverErrors.alt = 'coverImage.alt is required'
   }
-  if (coverErrors.key || coverErrors.alt) {
+
+  const imageStatus = (item.imageStatus as Record<string, number> | undefined) ?? {}
+
+  if (typeof coverKey === 'string' && coverKey.trim().length > 0 && imageStatus[coverKey] === undefined) {
+    coverErrors.processedAt = 'Cover image still processing'
+  }
+
+  if (coverErrors.key || coverErrors.alt || coverErrors.processedAt) {
     errors.coverImage = coverErrors
   }
 
@@ -511,6 +519,19 @@ function validatePublishInput(item: Record<string, unknown>): PublishErrors {
     })
     if (hasEmptyStep) {
       errors.steps = 'Every step must have non-empty text'
+    }
+
+    const stepImageErrors: Array<{ order: number; processedAt: string }> = []
+    for (const step of steps) {
+      const typedStep = step as { order?: unknown; image?: { key?: unknown } }
+      const imageKey = typedStep.image?.key
+      if (typeof imageKey !== 'string' || imageKey.trim().length === 0) continue
+      if (imageStatus[imageKey] !== undefined) continue
+      const order = typeof typedStep.order === 'number' ? typedStep.order : 0
+      stepImageErrors.push({ order, processedAt: 'Step image still processing' })
+    }
+    if (stepImageErrors.length > 0) {
+      errors.stepImages = stepImageErrors
     }
   }
 

--- a/test/lambda/recipe-handler.test.ts
+++ b/test/lambda/recipe-handler.test.ts
@@ -1290,7 +1290,6 @@ describe('Recipe Lambda handler', () => {
       })
     })
 
-    // ─── Publish readiness validation (issue #109) ────────────────────
     describe('readiness validation — rejects recipes with unready images', () => {
       const coverKey = 'processed/recipes/recipe-uuid-1/cover'
       const step1Key = 'processed/recipes/recipe-uuid-1/step-1'
@@ -1308,7 +1307,6 @@ describe('Recipe Lambda handler', () => {
         })
       }
 
-      // AC 1, AC 6 (cover-unready alone)
       it('returns 400 with errors.coverImage.processedAt when cover key has no imageStatus entry (steps either absent or fully ready)', async () => {
         ddbMock.on(GetCommand).resolves({
           Item: draftRecipeItem({
@@ -1317,12 +1315,9 @@ describe('Recipe Lambda handler', () => {
             steps: [
               { order: 1, text: 'Sear.', image: { key: step1Key, alt: 'seared' } },
             ],
-            // cover key missing from imageStatus → unready cover
             imageStatus: { [step1Key]: step1Ts },
           }),
         })
-        // Fallback to ensure a failure-to-reject returns 200 (not 500 from a
-        // missing UpdateCommand mock) so the failure signal is unambiguous.
         ddbMock.on(UpdateCommand).resolves({
           Attributes: publishedRecipeItem({ authorId: 'contributor-user-id' }),
         })
@@ -1337,7 +1332,6 @@ describe('Recipe Lambda handler', () => {
         expect(body.errors).not.toHaveProperty('stepImages')
       })
 
-      // AC 2, AC 6 (step-unready alone)
       it('returns 400 with errors.stepImages for each step whose image key has no imageStatus entry (cover ready)', async () => {
         ddbMock.on(GetCommand).resolves({
           Item: draftRecipeItem({
@@ -1347,7 +1341,6 @@ describe('Recipe Lambda handler', () => {
               { order: 1, text: 'Sear.', image: { key: step1Key, alt: 'seared' } },
               { order: 2, text: 'Simmer.', image: { key: step2Key, alt: 'simmering' } },
             ],
-            // cover + step 1 ready; step 2 unready
             imageStatus: { [coverKey]: coverTs, [step1Key]: step1Ts },
           }),
         })
@@ -1366,7 +1359,6 @@ describe('Recipe Lambda handler', () => {
         ])
       })
 
-      // AC 1, AC 2, AC 6 (both)
       it('returns 400 with both errors.coverImage.processedAt and errors.stepImages when cover and step images are unready', async () => {
         ddbMock.on(GetCommand).resolves({
           Item: draftRecipeItem({
@@ -1394,14 +1386,13 @@ describe('Recipe Lambda handler', () => {
         ])
       })
 
-      // AC 4, AC 6 (readiness + other validation error)
       it('returns 400 with readiness errors coexisting with other validation errors (e.g. missing title)', async () => {
         ddbMock.on(GetCommand).resolves({
           Item: draftRecipeItem({
             authorId: 'contributor-user-id',
-            title: '', // triggers existing `errors.title`
+            title: '',
             coverImage: { key: coverKey, alt: 'A bowl of lamb ragu' },
-            imageStatus: {}, // cover unready
+            imageStatus: {},
           }),
         })
 
@@ -1409,24 +1400,18 @@ describe('Recipe Lambda handler', () => {
 
         expect(result.statusCode).toBe(400)
         const body = JSON.parse(result.body as string)
-        // Existing title validation still fires
         expect(body.errors).toHaveProperty('title')
-        // Readiness error coexists on the same response
         expect(body.errors.coverImage).toBeDefined()
         expect(body.errors.coverImage.processedAt).toBe('Cover image still processing')
       })
 
-      // AC 5, AC 6 (republish with unready swapped image)
       it('returns 400 when republishing a currently-published recipe whose cover was swapped to an unready new key', async () => {
         const oldCoverKey = 'processed/recipes/recipe-uuid-1/cover-old'
         const newCoverKey = 'processed/recipes/recipe-uuid-1/cover'
         ddbMock.on(GetCommand).resolves({
           Item: publishedRecipeItem({
             authorId: 'contributor-user-id',
-            // Item is currently published — a cover swap landed via autosave PATCH,
-            // and the resizer hasn't yet written the new key's imageStatus entry.
             coverImage: { key: newCoverKey, alt: 'New cover' },
-            // imageStatus still holds only the OLD key's timestamp
             imageStatus: { [oldCoverKey]: coverTs },
           }),
         })
@@ -1440,7 +1425,6 @@ describe('Recipe Lambda handler', () => {
         expect(body.errors.coverImage.processedAt).toBe('Cover image still processing')
       })
 
-      // AC 3 (preserve existing errors.steps string shape)
       it('preserves the existing errors.steps string shape when steps have empty text (does NOT restructure into stepImages)', async () => {
         ddbMock.on(GetCommand).resolves({
           Item: draftRecipeItem({
@@ -1455,14 +1439,11 @@ describe('Recipe Lambda handler', () => {
 
         expect(result.statusCode).toBe(400)
         const body = JSON.parse(result.body as string)
-        // existing empty-text error is a string under `steps` — shape unchanged
         expect(body.errors).toHaveProperty('steps')
         expect(typeof body.errors.steps).toBe('string')
-        // readiness errors must NOT be smuggled into the `steps` key
         expect(body.errors.steps).not.toEqual(expect.any(Array))
       })
 
-      // Positive control: a recipe with every image ready publishes successfully.
       it('publishes successfully when every image key has a matching imageStatus entry', async () => {
         ddbMock.on(GetCommand).resolves({
           Item: draftRecipeItem({

--- a/test/lambda/recipe-handler.test.ts
+++ b/test/lambda/recipe-handler.test.ts
@@ -1130,7 +1130,10 @@ describe('Recipe Lambda handler', () => {
   describe('PATCH /recipes/{id}/publish — publish recipe (admin-only)', () => {
     it('returns 200 and sets status to published when admin publishes a valid draft', async () => {
       ddbMock.on(GetCommand).resolves({
-        Item: draftRecipeItem({ authorId: 'contributor-user-id' }),
+        Item: draftRecipeItem({
+          authorId: 'contributor-user-id',
+          imageStatus: { 'recipes/images/recipe-uuid-1/cover': 1_745_000_000_000 },
+        }),
       })
       ddbMock.on(UpdateCommand).resolves({
         Attributes: publishedRecipeItem({ authorId: 'contributor-user-id' }),
@@ -1152,7 +1155,10 @@ describe('Recipe Lambda handler', () => {
 
     it('removes ttl via UpdateExpression REMOVE (not SET ttl = null) on publish', async () => {
       ddbMock.on(GetCommand).resolves({
-        Item: draftRecipeItem({ authorId: 'contributor-user-id' }),
+        Item: draftRecipeItem({
+          authorId: 'contributor-user-id',
+          imageStatus: { 'recipes/images/recipe-uuid-1/cover': 1_745_000_000_000 },
+        }),
       })
       ddbMock.on(UpdateCommand).resolves({
         Attributes: publishedRecipeItem({ authorId: 'contributor-user-id' }),
@@ -1481,7 +1487,10 @@ describe('Recipe Lambda handler', () => {
 
     it('returns 200 (no-op) when publishing an already-published recipe that still passes validation', async () => {
       ddbMock.on(GetCommand).resolves({
-        Item: publishedRecipeItem({ authorId: 'contributor-user-id' }),
+        Item: publishedRecipeItem({
+          authorId: 'contributor-user-id',
+          imageStatus: { 'recipes/images/recipe-uuid-1/cover': 1_745_000_000_000 },
+        }),
       })
       ddbMock.on(UpdateCommand).resolves({
         Attributes: publishedRecipeItem({ authorId: 'contributor-user-id' }),

--- a/test/lambda/recipe-handler.test.ts
+++ b/test/lambda/recipe-handler.test.ts
@@ -1284,6 +1284,201 @@ describe('Recipe Lambda handler', () => {
       })
     })
 
+    // ─── Publish readiness validation (issue #109) ────────────────────
+    describe('readiness validation — rejects recipes with unready images', () => {
+      const coverKey = 'processed/recipes/recipe-uuid-1/cover'
+      const step1Key = 'processed/recipes/recipe-uuid-1/step-1'
+      const step2Key = 'processed/recipes/recipe-uuid-1/step-2'
+      const coverTs = 1_745_000_000_001
+      const step1Ts = 1_745_000_000_002
+      const step2Ts = 1_745_000_000_003
+
+      function publishEvent() {
+        return makeEvent({
+          routeKey: 'PATCH /recipes/{id}/publish',
+          rawPath: '/recipes/recipe-uuid-1/publish',
+          pathParameters: { id: 'recipe-uuid-1' },
+          headers: { authorization: `Bearer ${adminToken}` },
+        })
+      }
+
+      // AC 1, AC 6 (cover-unready alone)
+      it('returns 400 with errors.coverImage.processedAt when cover key has no imageStatus entry (steps either absent or fully ready)', async () => {
+        ddbMock.on(GetCommand).resolves({
+          Item: draftRecipeItem({
+            authorId: 'contributor-user-id',
+            coverImage: { key: coverKey, alt: 'A bowl of lamb ragu' },
+            steps: [
+              { order: 1, text: 'Sear.', image: { key: step1Key, alt: 'seared' } },
+            ],
+            // cover key missing from imageStatus → unready cover
+            imageStatus: { [step1Key]: step1Ts },
+          }),
+        })
+        // Fallback to ensure a failure-to-reject returns 200 (not 500 from a
+        // missing UpdateCommand mock) so the failure signal is unambiguous.
+        ddbMock.on(UpdateCommand).resolves({
+          Attributes: publishedRecipeItem({ authorId: 'contributor-user-id' }),
+        })
+
+        const result = await handler(publishEvent())
+
+        expect(result.statusCode).toBe(400)
+        const body = JSON.parse(result.body as string)
+        expect(body.errors).toBeDefined()
+        expect(body.errors.coverImage).toBeDefined()
+        expect(body.errors.coverImage.processedAt).toBe('Cover image still processing')
+        expect(body.errors).not.toHaveProperty('stepImages')
+      })
+
+      // AC 2, AC 6 (step-unready alone)
+      it('returns 400 with errors.stepImages for each step whose image key has no imageStatus entry (cover ready)', async () => {
+        ddbMock.on(GetCommand).resolves({
+          Item: draftRecipeItem({
+            authorId: 'contributor-user-id',
+            coverImage: { key: coverKey, alt: 'A bowl of lamb ragu' },
+            steps: [
+              { order: 1, text: 'Sear.', image: { key: step1Key, alt: 'seared' } },
+              { order: 2, text: 'Simmer.', image: { key: step2Key, alt: 'simmering' } },
+            ],
+            // cover + step 1 ready; step 2 unready
+            imageStatus: { [coverKey]: coverTs, [step1Key]: step1Ts },
+          }),
+        })
+        ddbMock.on(UpdateCommand).resolves({
+          Attributes: publishedRecipeItem({ authorId: 'contributor-user-id' }),
+        })
+
+        const result = await handler(publishEvent())
+
+        expect(result.statusCode).toBe(400)
+        const body = JSON.parse(result.body as string)
+        expect(body.errors).toBeDefined()
+        expect(body.errors).not.toHaveProperty('coverImage')
+        expect(body.errors.stepImages).toEqual([
+          { order: 2, processedAt: 'Step image still processing' },
+        ])
+      })
+
+      // AC 1, AC 2, AC 6 (both)
+      it('returns 400 with both errors.coverImage.processedAt and errors.stepImages when cover and step images are unready', async () => {
+        ddbMock.on(GetCommand).resolves({
+          Item: draftRecipeItem({
+            authorId: 'contributor-user-id',
+            coverImage: { key: coverKey, alt: 'A bowl of lamb ragu' },
+            steps: [
+              { order: 1, text: 'Sear.', image: { key: step1Key, alt: 'seared' } },
+              { order: 2, text: 'Simmer.', image: { key: step2Key, alt: 'simmering' } },
+            ],
+            imageStatus: {},
+          }),
+        })
+        ddbMock.on(UpdateCommand).resolves({
+          Attributes: publishedRecipeItem({ authorId: 'contributor-user-id' }),
+        })
+
+        const result = await handler(publishEvent())
+
+        expect(result.statusCode).toBe(400)
+        const body = JSON.parse(result.body as string)
+        expect(body.errors.coverImage.processedAt).toBe('Cover image still processing')
+        expect(body.errors.stepImages).toEqual([
+          { order: 1, processedAt: 'Step image still processing' },
+          { order: 2, processedAt: 'Step image still processing' },
+        ])
+      })
+
+      // AC 4, AC 6 (readiness + other validation error)
+      it('returns 400 with readiness errors coexisting with other validation errors (e.g. missing title)', async () => {
+        ddbMock.on(GetCommand).resolves({
+          Item: draftRecipeItem({
+            authorId: 'contributor-user-id',
+            title: '', // triggers existing `errors.title`
+            coverImage: { key: coverKey, alt: 'A bowl of lamb ragu' },
+            imageStatus: {}, // cover unready
+          }),
+        })
+
+        const result = await handler(publishEvent())
+
+        expect(result.statusCode).toBe(400)
+        const body = JSON.parse(result.body as string)
+        // Existing title validation still fires
+        expect(body.errors).toHaveProperty('title')
+        // Readiness error coexists on the same response
+        expect(body.errors.coverImage).toBeDefined()
+        expect(body.errors.coverImage.processedAt).toBe('Cover image still processing')
+      })
+
+      // AC 5, AC 6 (republish with unready swapped image)
+      it('returns 400 when republishing a currently-published recipe whose cover was swapped to an unready new key', async () => {
+        const oldCoverKey = 'processed/recipes/recipe-uuid-1/cover-old'
+        const newCoverKey = 'processed/recipes/recipe-uuid-1/cover'
+        ddbMock.on(GetCommand).resolves({
+          Item: publishedRecipeItem({
+            authorId: 'contributor-user-id',
+            // Item is currently published — a cover swap landed via autosave PATCH,
+            // and the resizer hasn't yet written the new key's imageStatus entry.
+            coverImage: { key: newCoverKey, alt: 'New cover' },
+            // imageStatus still holds only the OLD key's timestamp
+            imageStatus: { [oldCoverKey]: coverTs },
+          }),
+        })
+
+        const result = await handler(publishEvent())
+
+        expect(result.statusCode).toBe(400)
+        const body = JSON.parse(result.body as string)
+        expect(body.errors).toBeDefined()
+        expect(body.errors.coverImage).toBeDefined()
+        expect(body.errors.coverImage.processedAt).toBe('Cover image still processing')
+      })
+
+      // AC 3 (preserve existing errors.steps string shape)
+      it('preserves the existing errors.steps string shape when steps have empty text (does NOT restructure into stepImages)', async () => {
+        ddbMock.on(GetCommand).resolves({
+          Item: draftRecipeItem({
+            authorId: 'contributor-user-id',
+            coverImage: { key: coverKey, alt: 'A bowl of lamb ragu' },
+            steps: [{ order: 1, text: '' }, { order: 2, text: '   ' }],
+            imageStatus: { [coverKey]: coverTs },
+          }),
+        })
+
+        const result = await handler(publishEvent())
+
+        expect(result.statusCode).toBe(400)
+        const body = JSON.parse(result.body as string)
+        // existing empty-text error is a string under `steps` — shape unchanged
+        expect(body.errors).toHaveProperty('steps')
+        expect(typeof body.errors.steps).toBe('string')
+        // readiness errors must NOT be smuggled into the `steps` key
+        expect(body.errors.steps).not.toEqual(expect.any(Array))
+      })
+
+      // Positive control: a recipe with every image ready publishes successfully.
+      it('publishes successfully when every image key has a matching imageStatus entry', async () => {
+        ddbMock.on(GetCommand).resolves({
+          Item: draftRecipeItem({
+            authorId: 'contributor-user-id',
+            coverImage: { key: coverKey, alt: 'A bowl of lamb ragu' },
+            steps: [
+              { order: 1, text: 'Sear.', image: { key: step1Key, alt: 'seared' } },
+              { order: 2, text: 'Simmer.', image: { key: step2Key, alt: 'simmering' } },
+            ],
+            imageStatus: { [coverKey]: coverTs, [step1Key]: step1Ts, [step2Key]: step2Ts },
+          }),
+        })
+        ddbMock.on(UpdateCommand).resolves({
+          Attributes: publishedRecipeItem({ authorId: 'contributor-user-id' }),
+        })
+
+        const result = await handler(publishEvent())
+
+        expect(result.statusCode).toBe(200)
+      })
+    })
+
     it('returns 200 (no-op) when publishing an already-published recipe that still passes validation', async () => {
       ddbMock.on(GetCommand).resolves({
         Item: publishedRecipeItem({ authorId: 'contributor-user-id' }),


### PR DESCRIPTION
Closes #109

## What changed
- `validatePublishInput` now rejects when a recipe's `coverImage.key` or any `step.image.key` has no matching `imageStatus` entry.
- `PublishErrors` gains `coverImage.processedAt?: string` and a new top-level `stepImages?: Array<{ order, processedAt }>`. The existing `errors.steps` string (empty-text check) is untouched.
- Extracted `imageStatusOf(item)` so `composeImageProcessedAt` and `validatePublishInput` share one source of truth for the readiness map cast.
- Three pre-existing publish tests had their fixtures updated to include `imageStatus` for their cover keys so they still exercise the happy path under the new gate.

## Why
Per `docs/prds/image-processing-readiness.md`: the server-side publish guard backstops the frontend's client-side mirror. A stale tab or a direct API call cannot flip a recipe live with broken image URLs — readiness is derived from the resizer's write-back, not trusted from the request.

## How to verify
- `pnpm test` → 310 passing (93 in `recipe-handler`; 7 new in the `readiness validation — rejects recipes with unready images` describe block).
- `pnpm lint` clean.
- Read `lambda/recipe-handler.ts` around `validatePublishInput` — readiness checks sit alongside the existing key/alt/text validations, so readiness errors coexist on the same 400 response.

## Decisions made
- Used `imageStatus[key] === undefined` (not a truthy check) so `0` remains a valid "ready" timestamp — preserves the invariant from issue #107's `preserves processedAt: 0` test.
- Readiness errors live under `errors.stepImages` (new key), not under `errors.steps`, to keep the existing empty-text contract binary-compatible for any API consumer already reading `errors.steps` as a string.
- Skipped readiness when an image has no `key` at all — there's nothing to check, and step-text validation covers the "empty step" case separately.
- Per-call-site fixture updates over a default `imageStatus` in the `draftRecipeItem` / `publishedRecipeItem` factories: a default would leak composed `processedAt` into unrelated response-shape tests.