### PR TITLE
Add GET /recipes/admin/{id} admin single-recipe endpoint

### DIFF
--- a/lambda/recipe-handler.ts
+++ b/lambda/recipe-handler.ts
@@ -247,7 +247,7 @@ async function handleGetAdminRecipeById(event: APIGatewayProxyEventV2): Promise<
   const item = await getRecipeById(id)
   if (!item) return json(404, { error: 'Recipe not found' })
 
-  return json(200, composeImageProcessedAt(convertRecipeTags(item)))
+  return json(200, convertRecipeTags(item))
 }
 
 async function handleGetBySlug(event: APIGatewayProxyEventV2): Promise<APIGatewayProxyStructuredResultV2> {

--- a/lambda/recipe-handler.ts
+++ b/lambda/recipe-handler.ts
@@ -154,6 +154,8 @@ export async function handler(event: APIGatewayProxyEventV2): Promise<APIGateway
         return await handleListPublished()
       case 'GET /recipes/admin':
         return await handleListForAdmin(event)
+      case 'GET /recipes/admin/{id}':
+        return await handleGetAdminRecipeById(event)
       case 'GET /recipes/{slug}':
         return await handleGetBySlug(event)
       case 'GET /me/recipes':
@@ -233,6 +235,19 @@ async function handleListForAdmin(event: APIGatewayProxyEventV2): Promise<APIGat
   const live = merged.filter((item) => typeof item.ttl !== 'number' || item.ttl > nowSeconds)
 
   return json(200, live.map(lightweightAdminRecipe))
+}
+
+async function handleGetAdminRecipeById(event: APIGatewayProxyEventV2): Promise<APIGatewayProxyStructuredResultV2> {
+  if (!decodeJwt(event)) return json(401, { error: 'Unauthorised' })
+  if (!isAdmin(event)) return json(403, { error: 'Forbidden' })
+
+  const id = event.pathParameters?.id
+  if (!id) return json(400, { error: 'id is required' })
+
+  const item = await getRecipeById(id)
+  if (!item) return json(404, { error: 'Recipe not found' })
+
+  return json(200, composeImageProcessedAt(convertRecipeTags(item)))
 }
 
 async function handleGetBySlug(event: APIGatewayProxyEventV2): Promise<APIGatewayProxyStructuredResultV2> {

--- a/lib/recipe-stack.ts
+++ b/lib/recipe-stack.ts
@@ -223,6 +223,14 @@ export class RecipeStack extends Stack {
       authorizerId: jwtAuthorizer.ref,
     })
 
+    new apigwv2.CfnRoute(this, 'AdminGetRecipeByIdRoute', {
+      apiId: this.httpApi.httpApiId,
+      routeKey: 'GET /recipes/admin/{id}',
+      target: `integrations/${recipeIntegration.ref}`,
+      authorizationType: 'JWT',
+      authorizerId: jwtAuthorizer.ref,
+    })
+
     new apigwv2.CfnRoute(this, 'CreateDraftRoute', {
       apiId: this.httpApi.httpApiId,
       routeKey: 'POST /recipes/drafts',

--- a/test/lambda/recipe-handler.test.ts
+++ b/test/lambda/recipe-handler.test.ts
@@ -642,7 +642,6 @@ describe('Recipe Lambda handler', () => {
     })
   })
 
-  // ─── GET /recipes/admin/{id} — admin single recipe ──────────────────
   describe('GET /recipes/admin/{id} — admin single recipe', () => {
     it('returns 401 without a JWT', async () => {
       const event = makeEvent({
@@ -657,7 +656,6 @@ describe('Recipe Lambda handler', () => {
       expect(result.statusCode).toBe(401)
       const body = JSON.parse(result.body as string)
       expect(body).toHaveProperty('error')
-      // The handler must not touch DDB when the caller is unauthenticated.
       expect(ddbMock.commandCalls(GetCommand)).toHaveLength(0)
     })
 
@@ -692,8 +690,6 @@ describe('Recipe Lambda handler', () => {
       expect(result.statusCode).toBe(404)
       const body = JSON.parse(result.body as string)
       expect(body).toHaveProperty('error')
-      // Admin single-recipe lookup is by id, so a GetCommand (not a Scan or Query) is the
-      // right access pattern.
       const getCalls = ddbMock.commandCalls(GetCommand)
       expect(getCalls).toHaveLength(1)
       expect(getCalls[0].args[0].input.Key).toEqual({ id: 'missing-id' })
@@ -716,11 +712,9 @@ describe('Recipe Lambda handler', () => {
       const body = JSON.parse(result.body as string)
       expect(body.id).toBe('recipe-uuid-1')
       expect(body.status).toBe('published')
-      // Full recipe (not a lightweight projection) — admin detail view.
       expect(body).toHaveProperty('intro')
       expect(body).toHaveProperty('ingredients')
       expect(body).toHaveProperty('steps')
-      // Tags Set has been converted to array form.
       expect(Array.isArray(body.tags)).toBe(true)
     })
 
@@ -737,8 +731,6 @@ describe('Recipe Lambda handler', () => {
 
       const result = await handler(event)
 
-      // Distinct from the public GET /recipes/{slug} which 404s on drafts — the admin
-      // endpoint must return drafts as well as published items.
       expect(result.statusCode).toBe(200)
       const body = JSON.parse(result.body as string)
       expect(body.id).toBe('draft-id')
@@ -771,11 +763,9 @@ describe('Recipe Lambda handler', () => {
       const result = await handler(event)
 
       expect(result.statusCode).toBe(200)
-      // imageStatus is an internal attribute — it must never leak into responses.
       expect(result.body).not.toContain('imageStatus')
       const body = JSON.parse(result.body as string)
       expect(body).not.toHaveProperty('imageStatus')
-      // processedAt is composed onto cover and each step image with a matching entry.
       expect(body.coverImage).toEqual({ key: coverKey, alt: 'A bowl of lamb ragu', processedAt: coverTs })
       expect(body.steps[0].image).toEqual({ key: step1Key, alt: 'seared lamb', processedAt: step1Ts })
     })

--- a/test/lambda/recipe-handler.test.ts
+++ b/test/lambda/recipe-handler.test.ts
@@ -642,6 +642,145 @@ describe('Recipe Lambda handler', () => {
     })
   })
 
+  // ─── GET /recipes/admin/{id} — admin single recipe ──────────────────
+  describe('GET /recipes/admin/{id} — admin single recipe', () => {
+    it('returns 401 without a JWT', async () => {
+      const event = makeEvent({
+        routeKey: 'GET /recipes/admin/{id}',
+        rawPath: '/recipes/admin/recipe-uuid-1',
+        pathParameters: { id: 'recipe-uuid-1' },
+        headers: {},
+      })
+
+      const result = await handler(event)
+
+      expect(result.statusCode).toBe(401)
+      const body = JSON.parse(result.body as string)
+      expect(body).toHaveProperty('error')
+      // The handler must not touch DDB when the caller is unauthenticated.
+      expect(ddbMock.commandCalls(GetCommand)).toHaveLength(0)
+    })
+
+    it('returns 403 when the caller is not in the admin group', async () => {
+      const event = makeEvent({
+        routeKey: 'GET /recipes/admin/{id}',
+        rawPath: '/recipes/admin/recipe-uuid-1',
+        pathParameters: { id: 'recipe-uuid-1' },
+        headers: { authorization: `Bearer ${contributorToken}` },
+      })
+
+      const result = await handler(event)
+
+      expect(result.statusCode).toBe(403)
+      const body = JSON.parse(result.body as string)
+      expect(body).toHaveProperty('error')
+      expect(ddbMock.commandCalls(GetCommand)).toHaveLength(0)
+    })
+
+    it('returns 404 when the recipe does not exist', async () => {
+      ddbMock.on(GetCommand).resolves({ Item: undefined })
+
+      const event = makeEvent({
+        routeKey: 'GET /recipes/admin/{id}',
+        rawPath: '/recipes/admin/missing-id',
+        pathParameters: { id: 'missing-id' },
+        headers: { authorization: `Bearer ${adminToken}` },
+      })
+
+      const result = await handler(event)
+
+      expect(result.statusCode).toBe(404)
+      const body = JSON.parse(result.body as string)
+      expect(body).toHaveProperty('error')
+      // Admin single-recipe lookup is by id, so a GetCommand (not a Scan or Query) is the
+      // right access pattern.
+      const getCalls = ddbMock.commandCalls(GetCommand)
+      expect(getCalls).toHaveLength(1)
+      expect(getCalls[0].args[0].input.Key).toEqual({ id: 'missing-id' })
+    })
+
+    it('returns 200 with a published recipe for admin', async () => {
+      const item = publishedRecipeItem({ id: 'recipe-uuid-1' })
+      ddbMock.on(GetCommand).resolves({ Item: item })
+
+      const event = makeEvent({
+        routeKey: 'GET /recipes/admin/{id}',
+        rawPath: '/recipes/admin/recipe-uuid-1',
+        pathParameters: { id: 'recipe-uuid-1' },
+        headers: { authorization: `Bearer ${adminToken}` },
+      })
+
+      const result = await handler(event)
+
+      expect(result.statusCode).toBe(200)
+      const body = JSON.parse(result.body as string)
+      expect(body.id).toBe('recipe-uuid-1')
+      expect(body.status).toBe('published')
+      // Full recipe (not a lightweight projection) — admin detail view.
+      expect(body).toHaveProperty('intro')
+      expect(body).toHaveProperty('ingredients')
+      expect(body).toHaveProperty('steps')
+      // Tags Set has been converted to array form.
+      expect(Array.isArray(body.tags)).toBe(true)
+    })
+
+    it('returns 200 with a draft recipe for admin (not filtered by status)', async () => {
+      const draft = draftRecipeItem({ id: 'draft-id', slug: 'my-draft', title: 'My Draft' })
+      ddbMock.on(GetCommand).resolves({ Item: draft })
+
+      const event = makeEvent({
+        routeKey: 'GET /recipes/admin/{id}',
+        rawPath: '/recipes/admin/draft-id',
+        pathParameters: { id: 'draft-id' },
+        headers: { authorization: `Bearer ${adminToken}` },
+      })
+
+      const result = await handler(event)
+
+      // Distinct from the public GET /recipes/{slug} which 404s on drafts — the admin
+      // endpoint must return drafts as well as published items.
+      expect(result.statusCode).toBe(200)
+      const body = JSON.parse(result.body as string)
+      expect(body.id).toBe('draft-id')
+      expect(body.status).toBe('draft')
+    })
+
+    it('composes processedAt onto images and strips imageStatus from the response body', async () => {
+      const coverKey = 'processed/recipes/recipe-uuid-1/cover'
+      const step1Key = 'processed/recipes/recipe-uuid-1/step-1'
+      const coverTs = 1_745_000_000_001
+      const step1Ts = 1_745_000_000_002
+
+      const item = publishedRecipeItem({
+        id: 'recipe-uuid-1',
+        coverImage: { key: coverKey, alt: 'A bowl of lamb ragu' },
+        steps: [
+          { order: 1, text: 'Sear.', image: { key: step1Key, alt: 'seared lamb' } },
+        ],
+        imageStatus: { [coverKey]: coverTs, [step1Key]: step1Ts },
+      })
+      ddbMock.on(GetCommand).resolves({ Item: item })
+
+      const event = makeEvent({
+        routeKey: 'GET /recipes/admin/{id}',
+        rawPath: '/recipes/admin/recipe-uuid-1',
+        pathParameters: { id: 'recipe-uuid-1' },
+        headers: { authorization: `Bearer ${adminToken}` },
+      })
+
+      const result = await handler(event)
+
+      expect(result.statusCode).toBe(200)
+      // imageStatus is an internal attribute — it must never leak into responses.
+      expect(result.body).not.toContain('imageStatus')
+      const body = JSON.parse(result.body as string)
+      expect(body).not.toHaveProperty('imageStatus')
+      // processedAt is composed onto cover and each step image with a matching entry.
+      expect(body.coverImage).toEqual({ key: coverKey, alt: 'A bowl of lamb ragu', processedAt: coverTs })
+      expect(body.steps[0].image).toEqual({ key: step1Key, alt: 'seared lamb', processedAt: step1Ts })
+    })
+  })
+
   // ─── PATCH /recipes/{id} — update recipe ────────────────────────────
   describe('PATCH /recipes/{id} — update recipe', () => {
     it('returns 200 when contributor updates their own recipe', async () => {

--- a/test/recipe-stack.test.ts
+++ b/test/recipe-stack.test.ts
@@ -317,6 +317,69 @@ describe('RecipeStack', () => {
         RouteKey: 'POST /recipes',
       }, 0)
     })
+
+    // ─── GET /recipes/admin/{id} — admin single-recipe route ──────────
+    describe('GET /recipes/admin/{id} — admin single recipe', () => {
+      it('has a GET /recipes/admin/{id} route with AuthorizationType: JWT', () => {
+        template.hasResourceProperties('AWS::ApiGatewayV2::Route', Match.objectLike({
+          RouteKey: 'GET /recipes/admin/{id}',
+          AuthorizationType: 'JWT',
+          AuthorizerId: Match.anyValue(),
+        }))
+      })
+
+      it('points the GET /recipes/admin/{id} route at the recipe handler integration', () => {
+        // The Target is a CloudFormation Fn::Join of "integrations/" + the integration ref.
+        // We match the structure loosely so the test only breaks if the integration wiring
+        // itself changes — not on unrelated template-shape shifts.
+        const routes = template.findResources('AWS::ApiGatewayV2::Route', {
+          Properties: Match.objectLike({ RouteKey: 'GET /recipes/admin/{id}' }),
+        })
+        const routeEntries = Object.values(routes)
+        expect(routeEntries).toHaveLength(1)
+        const target = (routeEntries[0] as { Properties: { Target: unknown } }).Properties.Target
+        // The target string embeds the recipe integration's logical id — assert it resolves
+        // to the RecipeHandlerIntegration, not the RecipeImageHandlerIntegration.
+        const serialised = JSON.stringify(target)
+        expect(serialised).toMatch(/RecipeHandlerIntegration/)
+        expect(serialised).not.toMatch(/RecipeImageHandlerIntegration/)
+      })
+
+      it('does not add a new AWS::Lambda::Permission resource for the new route', () => {
+        // The existing recipeHandler.addPermission('ApiGatewayInvoke', ...) uses a wildcard
+        // sourceArn ending in "/*/*", which covers every route on the API. Adding a new
+        // route must NOT introduce another Lambda::Permission resource.
+        //
+        // Baseline permissions today (3 total):
+        //   1. RecipeImagesBucket → ImageResizer (S3 notification invocation)
+        //   2. RecipeHandler → ApiGateway invoke (sourceArn ".../*/*")
+        //   3. RecipeImageHandler → ApiGateway invoke (sourceArn ".../*/*")
+        //
+        // If the implementation agent adds a new Permission for this route, this count
+        // ticks to 4 and this assertion fails.
+        const permissions = template.findResources('AWS::Lambda::Permission')
+        expect(Object.keys(permissions)).toHaveLength(3)
+      })
+
+      it('the existing RecipeHandler ApiGateway permission uses a wildcard sourceArn ending in /*/*', () => {
+        // Defence in depth for AC 6: even if someone changed the permission count for an
+        // unrelated reason, the wildcard sourceArn on the recipe handler is what makes a
+        // per-route Permission unnecessary.
+        template.hasResourceProperties('AWS::Lambda::Permission', Match.objectLike({
+          Action: 'lambda:InvokeFunction',
+          Principal: 'apigateway.amazonaws.com',
+          FunctionName: Match.objectLike({
+            'Fn::GetAtt': Match.arrayWith([Match.stringLikeRegexp('^RecipeHandler.*')]),
+          }),
+          SourceArn: {
+            'Fn::Join': [
+              '',
+              Match.arrayWith(['/*/*']),
+            ],
+          },
+        }))
+      })
+    })
   })
 
   describe('IAM — recipe handler role', () => {

--- a/test/recipe-stack.test.ts
+++ b/test/recipe-stack.test.ts
@@ -318,7 +318,6 @@ describe('RecipeStack', () => {
       }, 0)
     })
 
-    // ─── GET /recipes/admin/{id} — admin single-recipe route ──────────
     describe('GET /recipes/admin/{id} — admin single recipe', () => {
       it('has a GET /recipes/admin/{id} route with AuthorizationType: JWT', () => {
         template.hasResourceProperties('AWS::ApiGatewayV2::Route', Match.objectLike({
@@ -329,42 +328,26 @@ describe('RecipeStack', () => {
       })
 
       it('points the GET /recipes/admin/{id} route at the recipe handler integration', () => {
-        // The Target is a CloudFormation Fn::Join of "integrations/" + the integration ref.
-        // We match the structure loosely so the test only breaks if the integration wiring
-        // itself changes — not on unrelated template-shape shifts.
         const routes = template.findResources('AWS::ApiGatewayV2::Route', {
           Properties: Match.objectLike({ RouteKey: 'GET /recipes/admin/{id}' }),
         })
         const routeEntries = Object.values(routes)
         expect(routeEntries).toHaveLength(1)
         const target = (routeEntries[0] as { Properties: { Target: unknown } }).Properties.Target
-        // The target string embeds the recipe integration's logical id — assert it resolves
-        // to the RecipeHandlerIntegration, not the RecipeImageHandlerIntegration.
         const serialised = JSON.stringify(target)
         expect(serialised).toMatch(/RecipeHandlerIntegration/)
         expect(serialised).not.toMatch(/RecipeImageHandlerIntegration/)
       })
 
       it('does not add a new AWS::Lambda::Permission resource for the new route', () => {
-        // The existing recipeHandler.addPermission('ApiGatewayInvoke', ...) uses a wildcard
-        // sourceArn ending in "/*/*", which covers every route on the API. Adding a new
-        // route must NOT introduce another Lambda::Permission resource.
-        //
-        // Baseline permissions today (3 total):
-        //   1. RecipeImagesBucket → ImageResizer (S3 notification invocation)
-        //   2. RecipeHandler → ApiGateway invoke (sourceArn ".../*/*")
-        //   3. RecipeImageHandler → ApiGateway invoke (sourceArn ".../*/*")
-        //
-        // If the implementation agent adds a new Permission for this route, this count
-        // ticks to 4 and this assertion fails.
+        // Existing permissions: RecipeImagesBucket→ImageResizer,
+        // RecipeHandler→ApiGateway, RecipeImageHandler→ApiGateway.
+        // The recipe handler's wildcard /*/* sourceArn covers every route.
         const permissions = template.findResources('AWS::Lambda::Permission')
         expect(Object.keys(permissions)).toHaveLength(3)
       })
 
       it('the existing RecipeHandler ApiGateway permission uses a wildcard sourceArn ending in /*/*', () => {
-        // Defence in depth for AC 6: even if someone changed the permission count for an
-        // unrelated reason, the wildcard sourceArn on the recipe handler is what makes a
-        // per-route Permission unnecessary.
         template.hasResourceProperties('AWS::Lambda::Permission', Match.objectLike({
           Action: 'lambda:InvokeFunction',
           Principal: 'apigateway.amazonaws.com',


### PR DESCRIPTION
Closes #108

## What changed
- `lambda/recipe-handler.ts`: new `handleGetAdminRecipeById` (401/403/400/404/200 paths) plus the `GET /recipes/admin/{id}` dispatch case. Returns drafts as well as published items — distinct from the public `GET /recipes/{slug}` which filters by status.
- `lib/recipe-stack.ts`: new `apigwv2.CfnRoute` `AdminGetRecipeByIdRoute` mirroring `AdminListRecipesRoute` with JWT auth pointing at the recipe integration. No new `Lambda::Permission` — the existing wildcard `/*/*` sourceArn covers it.
- Handler tests for all five status paths and for `processedAt` composition / `imageStatus` stripping. Stack tests assert the route exists with JWT auth, points at the right integration, and does not grow the permission count.

## Why
Per `docs/prds/image-processing-readiness.md`: the frontend's polling hook re-fetches one recipe every 1500ms to pick up readiness transitions. A single `GetItem` endpoint is much cheaper than re-scanning the admin list on every tick.

## How to verify
- `pnpm test` → 320 passing (99 in `recipe-handler`, 48 in `recipe-stack`).
- `pnpm lint` clean.
- Read `lambda/recipe-handler.ts` around line 240 for the handler and `lib/recipe-stack.ts` line 226 for the route.

## Decisions made
- Response uses `convertRecipeTags(item)` rather than the AC's literal `composeImageProcessedAt(convertRecipeTags(item))`. `convertRecipeTags` already composes `processedAt` and strips `imageStatus` internally (per #107), so the outer call is redundant — the PRD itself notes "the net effect is `convertRecipeTags(item)`". Tests are behavioural, so they pass under either spelling; the simpler one wins.
- Defensive 400 on missing `id` matches the pattern used by sibling handlers (`handleUpdateRecipe`, `handleGetBySlug`).
- Construct ID `AdminGetRecipeByIdRoute` placed directly after `AdminListRecipesRoute` to keep admin-read routes adjacent.