### PR TITLE
Image Processing Readiness — Infrastructure milestone

### DIFF
--- a/lambda/image-resizer.ts
+++ b/lambda/image-resizer.ts
@@ -1,4 +1,4 @@
-import { DynamoDBClient } from '@aws-sdk/client-dynamodb'
+import { ConditionalCheckFailedException, DynamoDBClient } from '@aws-sdk/client-dynamodb'
 import { S3Client, GetObjectCommand, PutObjectCommand, DeleteObjectCommand } from '@aws-sdk/client-s3'
 import { DynamoDBDocumentClient, UpdateCommand } from '@aws-sdk/lib-dynamodb'
 import type { S3Event } from 'aws-lambda'
@@ -6,7 +6,7 @@ import sharp from 'sharp'
 import { VARIANT_SUFFIXES, toProcessedKey, UPLOAD_PREFIX, type VariantSuffix } from './image-variants'
 
 const s3 = new S3Client({})
-const ddb = DynamoDBDocumentClient.from(new DynamoDBClient({}))
+const docClient = DynamoDBDocumentClient.from(new DynamoDBClient({}))
 
 interface ImageVariant {
   readonly suffix: VariantSuffix
@@ -27,10 +27,11 @@ const VARIANTS: readonly ImageVariant[] = VARIANT_SUFFIXES.map((suffix) => ({
 
 const RECIPES_SEGMENT = 'recipes'
 
+// Accepts exactly `uploads/recipes/<id>/<type>` — extra trailing segments are rejected.
 function parseRecipeId(uploadKey: string): string | undefined {
   if (!uploadKey.startsWith(UPLOAD_PREFIX)) return undefined
   const segments = uploadKey.slice(UPLOAD_PREFIX.length).split('/')
-  if (segments.length < 3) return undefined
+  if (segments.length !== 3) return undefined
   if (segments[0] !== RECIPES_SEGMENT) return undefined
   const id = segments[1]
   if (!id) return undefined
@@ -75,12 +76,15 @@ export async function handler(event: S3Event): Promise<void> {
       }),
     )
 
+    const logSkip = (reason: string) =>
+      console.info({ event: 'resizer.writeback.skipped', reason, key })
+
     const recipeId = parseRecipeId(key)
     if (recipeId === undefined) {
-      console.info({ event: 'resizer.writeback.skipped', reason: 'unrecognised_key_shape', key })
+      logSkip('unrecognised_key_shape')
     } else {
       try {
-        await ddb.send(
+        await docClient.send(
           new UpdateCommand({
             TableName: tableName,
             Key: { id: recipeId },
@@ -91,8 +95,8 @@ export async function handler(event: S3Event): Promise<void> {
           }),
         )
       } catch (error) {
-        if (error instanceof Error && error.name === 'ConditionalCheckFailedException') {
-          console.info({ event: 'resizer.writeback.skipped', reason: 'recipe_deleted', key })
+        if (error instanceof ConditionalCheckFailedException) {
+          logSkip('recipe_deleted')
         } else {
           throw error
         }

--- a/lambda/image-resizer.ts
+++ b/lambda/image-resizer.ts
@@ -1,9 +1,12 @@
+import { DynamoDBClient } from '@aws-sdk/client-dynamodb'
 import { S3Client, GetObjectCommand, PutObjectCommand, DeleteObjectCommand } from '@aws-sdk/client-s3'
+import { DynamoDBDocumentClient, UpdateCommand } from '@aws-sdk/lib-dynamodb'
 import type { S3Event } from 'aws-lambda'
 import sharp from 'sharp'
-import { VARIANT_SUFFIXES, toProcessedKey, type VariantSuffix } from './image-variants'
+import { VARIANT_SUFFIXES, toProcessedKey, UPLOAD_PREFIX, type VariantSuffix } from './image-variants'
 
 const s3 = new S3Client({})
+const ddb = DynamoDBDocumentClient.from(new DynamoDBClient({}))
 
 interface ImageVariant {
   readonly suffix: VariantSuffix
@@ -22,9 +25,24 @@ const VARIANTS: readonly ImageVariant[] = VARIANT_SUFFIXES.map((suffix) => ({
   ...VARIANT_SIZING[suffix],
 }))
 
+const RECIPES_SEGMENT = 'recipes'
+
+function parseRecipeId(uploadKey: string): string | undefined {
+  if (!uploadKey.startsWith(UPLOAD_PREFIX)) return undefined
+  const segments = uploadKey.slice(UPLOAD_PREFIX.length).split('/')
+  if (segments.length < 3) return undefined
+  if (segments[0] !== RECIPES_SEGMENT) return undefined
+  const id = segments[1]
+  if (!id) return undefined
+  return id
+}
+
 export async function handler(event: S3Event): Promise<void> {
   const bucketName = process.env.IMAGE_BUCKET_NAME
   if (!bucketName) throw new Error('IMAGE_BUCKET_NAME not set')
+
+  const tableName = process.env.TABLE_NAME
+  if (!tableName) throw new Error('TABLE_NAME not set')
 
   for (const record of event.Records) {
     const key = record.s3.object.key
@@ -56,6 +74,30 @@ export async function handler(event: S3Event): Promise<void> {
         )
       }),
     )
+
+    const recipeId = parseRecipeId(key)
+    if (recipeId === undefined) {
+      console.info({ event: 'resizer.writeback.skipped', reason: 'unrecognised_key_shape', key })
+    } else {
+      try {
+        await ddb.send(
+          new UpdateCommand({
+            TableName: tableName,
+            Key: { id: recipeId },
+            UpdateExpression: 'SET imageStatus.#k = :ts',
+            ConditionExpression: 'attribute_exists(id)',
+            ExpressionAttributeNames: { '#k': processedKey },
+            ExpressionAttributeValues: { ':ts': Date.now() },
+          }),
+        )
+      } catch (error) {
+        if (error instanceof Error && error.name === 'ConditionalCheckFailedException') {
+          console.info({ event: 'resizer.writeback.skipped', reason: 'recipe_deleted', key })
+        } else {
+          throw error
+        }
+      }
+    }
 
     await s3.send(
       new DeleteObjectCommand({ Bucket: sourceBucket, Key: key }),

--- a/lambda/recipe-handler.ts
+++ b/lambda/recipe-handler.ts
@@ -127,7 +127,15 @@ function lightweightRecipe(recipe: Record<string, unknown>): Record<string, unkn
 function lightweightAdminRecipe(recipe: Record<string, unknown>): Record<string, unknown> {
   const composed = composeImageProcessedAt(recipe)
   return {
-    ...lightweightRecipe(composed),
+    id: composed.id,
+    title: composed.title,
+    slug: composed.slug,
+    coverImage: composed.coverImage,
+    tags: tagsToArray(composed.tags),
+    prepTime: composed.prepTime,
+    cookTime: composed.cookTime,
+    servings: composed.servings,
+    createdAt: composed.createdAt,
     status: composed.status,
     updatedAt: composed.updatedAt,
   }

--- a/lambda/recipe-handler.ts
+++ b/lambda/recipe-handler.ts
@@ -266,6 +266,7 @@ async function handleCreateDraft(event: APIGatewayProxyEventV2): Promise<APIGate
     intro: '',
     ingredients: [],
     steps: [],
+    imageStatus: {},
     authorId: payload.sub,
     authorName: payload.name ?? payload.email ?? '',
     createdAt: now,

--- a/lambda/recipe-handler.ts
+++ b/lambda/recipe-handler.ts
@@ -86,8 +86,12 @@ async function findUniqueSlug(baseSlug: string): Promise<string> {
   }
 }
 
+function imageStatusOf(item: Record<string, unknown>): Record<string, number> {
+  return (item.imageStatus as Record<string, number> | undefined) ?? {}
+}
+
 function composeImageProcessedAt<T extends Record<string, unknown>>(item: T): Omit<T, 'imageStatus'> {
-  const imageStatus = (item.imageStatus as Record<string, number> | undefined) ?? {}
+  const imageStatus = imageStatusOf(item)
   const coverImage = item.coverImage as { key?: string } | undefined
   const coverProcessedAt = coverImage?.key ? imageStatus[coverImage.key] : undefined
   const steps = Array.isArray(item.steps)
@@ -494,9 +498,9 @@ function validatePublishInput(item: Record<string, unknown>): PublishErrors {
     coverErrors.alt = 'coverImage.alt is required'
   }
 
-  const imageStatus = (item.imageStatus as Record<string, number> | undefined) ?? {}
+  const imageStatus = imageStatusOf(item)
 
-  if (typeof coverKey === 'string' && coverKey.trim().length > 0 && imageStatus[coverKey] === undefined) {
+  if (!coverErrors.key && imageStatus[coverKey as string] === undefined) {
     coverErrors.processedAt = 'Cover image still processing'
   }
 

--- a/lambda/recipe-handler.ts
+++ b/lambda/recipe-handler.ts
@@ -327,26 +327,6 @@ function stepImageKeySet(steps: unknown): Set<string> {
   return keys
 }
 
-function deletedImageKeysFromSwap(oldItem: Record<string, unknown>, updates: Record<string, unknown>): string[] {
-  const keysToDelete: string[] = []
-
-  if ('coverImage' in updates) {
-    const oldKey = imageKeyOf(oldItem.coverImage)
-    const newKey = imageKeyOf(updates.coverImage)
-    if (oldKey && oldKey !== newKey) keysToDelete.push(...variantKeysFor(oldKey))
-  }
-
-  if ('steps' in updates) {
-    const oldKeys = stepImageKeySet(oldItem.steps)
-    const newKeys = stepImageKeySet(updates.steps)
-    for (const oldKey of oldKeys) {
-      if (!newKeys.has(oldKey)) keysToDelete.push(...variantKeysFor(oldKey))
-    }
-  }
-
-  return keysToDelete
-}
-
 function droppedImageBaseKeys(oldItem: Record<string, unknown>, updates: Record<string, unknown>): string[] {
   const droppedKeys: string[] = []
 
@@ -458,7 +438,7 @@ async function handleUpdateRecipe(event: APIGatewayProxyEventV2): Promise<APIGat
 
   const atomicOld = updateResult.Attributes as Record<string, unknown>
 
-  const keysToDelete = deletedImageKeysFromSwap(atomicOld, updates)
+  const keysToDelete = droppedImageBaseKeys(atomicOld, updates).flatMap(variantKeysFor)
   if (keysToDelete.length > 0) {
     const deleteResult = await s3Client.send(
       new DeleteObjectsCommand({

--- a/lambda/recipe-handler.ts
+++ b/lambda/recipe-handler.ts
@@ -86,29 +86,50 @@ async function findUniqueSlug(baseSlug: string): Promise<string> {
   }
 }
 
+function composeImageProcessedAt<T extends Record<string, unknown>>(item: T): Omit<T, 'imageStatus'> {
+  const imageStatus = (item.imageStatus as Record<string, number> | undefined) ?? {}
+  const coverImage = item.coverImage as { key?: string } | undefined
+  const coverProcessedAt = coverImage?.key ? imageStatus[coverImage.key] : undefined
+  const steps = Array.isArray(item.steps)
+    ? item.steps.map((step) => {
+        const img = (step as { image?: { key?: string } }).image
+        if (!img?.key) return step
+        const processedAt = imageStatus[img.key]
+        return processedAt !== undefined ? { ...(step as object), image: { ...img, processedAt } } : step
+      })
+    : item.steps
+  const nextCover = coverImage && coverProcessedAt !== undefined
+    ? { ...coverImage, processedAt: coverProcessedAt }
+    : coverImage
+  const { imageStatus: _stripped, ...rest } = item
+  return { ...rest, coverImage: nextCover, steps } as Omit<T, 'imageStatus'>
+}
+
 function convertRecipeTags(recipe: Record<string, unknown>): Record<string, unknown> {
-  return { ...recipe, tags: tagsToArray(recipe.tags) }
+  return composeImageProcessedAt({ ...recipe, tags: tagsToArray(recipe.tags) })
 }
 
 function lightweightRecipe(recipe: Record<string, unknown>): Record<string, unknown> {
+  const composed = composeImageProcessedAt(recipe)
   return {
-    id: recipe.id,
-    title: recipe.title,
-    slug: recipe.slug,
-    coverImage: recipe.coverImage,
-    tags: tagsToArray(recipe.tags),
-    prepTime: recipe.prepTime,
-    cookTime: recipe.cookTime,
-    servings: recipe.servings,
-    createdAt: recipe.createdAt,
+    id: composed.id,
+    title: composed.title,
+    slug: composed.slug,
+    coverImage: composed.coverImage,
+    tags: tagsToArray(composed.tags),
+    prepTime: composed.prepTime,
+    cookTime: composed.cookTime,
+    servings: composed.servings,
+    createdAt: composed.createdAt,
   }
 }
 
 function lightweightAdminRecipe(recipe: Record<string, unknown>): Record<string, unknown> {
+  const composed = composeImageProcessedAt(recipe)
   return {
-    ...lightweightRecipe(recipe),
-    status: recipe.status,
-    updatedAt: recipe.updatedAt,
+    ...lightweightRecipe(composed),
+    status: composed.status,
+    updatedAt: composed.updatedAt,
   }
 }
 

--- a/lambda/recipe-handler.ts
+++ b/lambda/recipe-handler.ts
@@ -247,7 +247,7 @@ async function handleGetAdminRecipeById(event: APIGatewayProxyEventV2): Promise<
   const item = await getRecipeById(id)
   if (!item) return json(404, { error: 'Recipe not found' })
 
-  return json(200, composeImageProcessedAt(convertRecipeTags(item)))
+  return json(200, convertRecipeTags(item))
 }
 
 async function handleGetBySlug(event: APIGatewayProxyEventV2): Promise<APIGatewayProxyStructuredResultV2> {

--- a/lambda/recipe-handler.ts
+++ b/lambda/recipe-handler.ts
@@ -464,9 +464,10 @@ async function handleUpdateRecipe(event: APIGatewayProxyEventV2): Promise<APIGat
 interface PublishErrors {
   title?: string
   intro?: string
-  coverImage?: { key?: string; alt?: string }
+  coverImage?: { key?: string; alt?: string; processedAt?: string }
   ingredients?: string
   steps?: string
+  stepImages?: Array<{ order: number; processedAt: string }>
 }
 
 function validatePublishInput(item: Record<string, unknown>): PublishErrors {
@@ -483,7 +484,7 @@ function validatePublishInput(item: Record<string, unknown>): PublishErrors {
   }
 
   const coverImage = item.coverImage as { key?: unknown; alt?: unknown } | undefined
-  const coverErrors: { key?: string; alt?: string } = {}
+  const coverErrors: { key?: string; alt?: string; processedAt?: string } = {}
   const coverKey = coverImage?.key
   if (typeof coverKey !== 'string' || coverKey.trim().length === 0) {
     coverErrors.key = 'coverImage.key is required'
@@ -492,7 +493,14 @@ function validatePublishInput(item: Record<string, unknown>): PublishErrors {
   if (typeof coverAlt !== 'string' || coverAlt.trim().length === 0) {
     coverErrors.alt = 'coverImage.alt is required'
   }
-  if (coverErrors.key || coverErrors.alt) {
+
+  const imageStatus = (item.imageStatus as Record<string, number> | undefined) ?? {}
+
+  if (typeof coverKey === 'string' && coverKey.trim().length > 0 && imageStatus[coverKey] === undefined) {
+    coverErrors.processedAt = 'Cover image still processing'
+  }
+
+  if (coverErrors.key || coverErrors.alt || coverErrors.processedAt) {
     errors.coverImage = coverErrors
   }
 
@@ -511,6 +519,19 @@ function validatePublishInput(item: Record<string, unknown>): PublishErrors {
     })
     if (hasEmptyStep) {
       errors.steps = 'Every step must have non-empty text'
+    }
+
+    const stepImageErrors: Array<{ order: number; processedAt: string }> = []
+    for (const step of steps) {
+      const typedStep = step as { order?: unknown; image?: { key?: unknown } }
+      const imageKey = typedStep.image?.key
+      if (typeof imageKey !== 'string' || imageKey.trim().length === 0) continue
+      if (imageStatus[imageKey] !== undefined) continue
+      const order = typeof typedStep.order === 'number' ? typedStep.order : 0
+      stepImageErrors.push({ order, processedAt: 'Step image still processing' })
+    }
+    if (stepImageErrors.length > 0) {
+      errors.stepImages = stepImageErrors
     }
   }
 

--- a/lambda/recipe-handler.ts
+++ b/lambda/recipe-handler.ts
@@ -154,6 +154,8 @@ export async function handler(event: APIGatewayProxyEventV2): Promise<APIGateway
         return await handleListPublished()
       case 'GET /recipes/admin':
         return await handleListForAdmin(event)
+      case 'GET /recipes/admin/{id}':
+        return await handleGetAdminRecipeById(event)
       case 'GET /recipes/{slug}':
         return await handleGetBySlug(event)
       case 'GET /me/recipes':
@@ -233,6 +235,19 @@ async function handleListForAdmin(event: APIGatewayProxyEventV2): Promise<APIGat
   const live = merged.filter((item) => typeof item.ttl !== 'number' || item.ttl > nowSeconds)
 
   return json(200, live.map(lightweightAdminRecipe))
+}
+
+async function handleGetAdminRecipeById(event: APIGatewayProxyEventV2): Promise<APIGatewayProxyStructuredResultV2> {
+  if (!decodeJwt(event)) return json(401, { error: 'Unauthorised' })
+  if (!isAdmin(event)) return json(403, { error: 'Forbidden' })
+
+  const id = event.pathParameters?.id
+  if (!id) return json(400, { error: 'id is required' })
+
+  const item = await getRecipeById(id)
+  if (!item) return json(404, { error: 'Recipe not found' })
+
+  return json(200, composeImageProcessedAt(convertRecipeTags(item)))
 }
 
 async function handleGetBySlug(event: APIGatewayProxyEventV2): Promise<APIGatewayProxyStructuredResultV2> {

--- a/lambda/recipe-handler.ts
+++ b/lambda/recipe-handler.ts
@@ -347,6 +347,44 @@ function deletedImageKeysFromSwap(oldItem: Record<string, unknown>, updates: Rec
   return keysToDelete
 }
 
+function droppedImageBaseKeys(oldItem: Record<string, unknown>, updates: Record<string, unknown>): string[] {
+  const droppedKeys: string[] = []
+
+  if ('coverImage' in updates) {
+    const oldKey = imageKeyOf(oldItem.coverImage)
+    const newKey = imageKeyOf(updates.coverImage)
+    if (oldKey && oldKey !== newKey) droppedKeys.push(oldKey)
+  }
+
+  if ('steps' in updates) {
+    const oldKeys = stepImageKeySet(oldItem.steps)
+    const newKeys = stepImageKeySet(updates.steps)
+    for (const oldKey of oldKeys) {
+      if (!newKeys.has(oldKey)) droppedKeys.push(oldKey)
+    }
+  }
+
+  return droppedKeys
+}
+
+function stripProcessedAtFromBody(updates: Record<string, unknown>): void {
+  const coverImage = updates.coverImage
+  if (coverImage && typeof coverImage === 'object' && !Array.isArray(coverImage)) {
+    delete (coverImage as Record<string, unknown>).processedAt
+  }
+
+  const steps = updates.steps
+  if (Array.isArray(steps)) {
+    for (const step of steps) {
+      if (!step || typeof step !== 'object') continue
+      const image = (step as { image?: unknown }).image
+      if (image && typeof image === 'object' && !Array.isArray(image)) {
+        delete (image as Record<string, unknown>).processedAt
+      }
+    }
+  }
+}
+
 async function handleUpdateRecipe(event: APIGatewayProxyEventV2): Promise<APIGatewayProxyStructuredResultV2> {
   const payload = decodeJwt(event)
   if (!payload) return json(401, { error: 'Unauthorised' })
@@ -368,37 +406,50 @@ async function handleUpdateRecipe(event: APIGatewayProxyEventV2): Promise<APIGat
   delete updates.createdAt
   delete updates.status
   delete updates.ttl
+  stripProcessedAtFromBody(updates)
 
   const now = new Date().toISOString()
-  const expressionParts: string[] = []
+  const setParts: string[] = []
   const expressionNames: Record<string, string> = {}
   const expressionValues: Record<string, unknown> = {}
 
   for (const [key, value] of Object.entries(updates)) {
     const attrName = `#${key}`
     const attrValue = `:${key}`
-    expressionParts.push(`${attrName} = ${attrValue}`)
+    setParts.push(`${attrName} = ${attrValue}`)
     expressionNames[attrName] = key
     expressionValues[attrValue] = value
   }
 
-  expressionParts.push('#updatedAt = :updatedAt')
+  setParts.push('#updatedAt = :updatedAt')
   expressionNames['#updatedAt'] = 'updatedAt'
   expressionValues[':updatedAt'] = now
 
   const isDraft = existing.status === DRAFT
   const refreshedTtl = Math.floor(Date.now() / 1000) + DRAFT_TTL_SECONDS
   if (isDraft) {
-    expressionParts.push('#ttl = :ttl')
+    setParts.push('#ttl = :ttl')
     expressionNames['#ttl'] = 'ttl'
     expressionValues[':ttl'] = refreshedTtl
   }
+
+  const droppedKeys = droppedImageBaseKeys(existing, updates)
+  const removeParts: string[] = []
+  droppedKeys.forEach((droppedKey, index) => {
+    const placeholder = `#droppedImageKey${index}`
+    removeParts.push(`imageStatus.${placeholder}`)
+    expressionNames[placeholder] = droppedKey
+  })
+
+  const updateExpression = removeParts.length > 0
+    ? `SET ${setParts.join(', ')} REMOVE ${removeParts.join(', ')}`
+    : `SET ${setParts.join(', ')}`
 
   const updateResult = await docClient.send(
     new UpdateCommand({
       TableName: TABLE_NAME,
       Key: { id },
-      UpdateExpression: `SET ${expressionParts.join(', ')}`,
+      UpdateExpression: updateExpression,
       ExpressionAttributeNames: expressionNames,
       ExpressionAttributeValues: expressionValues,
       ReturnValues: 'ALL_OLD',

--- a/lib/recipe-stack.ts
+++ b/lib/recipe-stack.ts
@@ -133,6 +133,7 @@ export class RecipeStack extends Stack {
 
     imageBucket.grantReadWrite(imageResizer)
     imageBucket.grantDelete(imageResizer)
+    // Narrow ARN (no GSI wildcards): table.grant() would add /index/* which UpdateItem cannot target.
     imageResizer.addToRolePolicy(new iam.PolicyStatement({
       actions: ['dynamodb:UpdateItem'],
       resources: [table.tableArn],

--- a/lib/recipe-stack.ts
+++ b/lib/recipe-stack.ts
@@ -127,11 +127,16 @@ export class RecipeStack extends Stack {
       functionName: 'akli-image-resizer',
       environment: {
         IMAGE_BUCKET_NAME: imageBucket.bucketName,
+        TABLE_NAME: table.tableName,
       },
     })
 
     imageBucket.grantReadWrite(imageResizer)
     imageBucket.grantDelete(imageResizer)
+    imageResizer.addToRolePolicy(new iam.PolicyStatement({
+      actions: ['dynamodb:UpdateItem'],
+      resources: [table.tableArn],
+    }))
 
     // S3 event notification for image uploads
     imageBucket.addEventNotification(

--- a/lib/recipe-stack.ts
+++ b/lib/recipe-stack.ts
@@ -223,6 +223,14 @@ export class RecipeStack extends Stack {
       authorizerId: jwtAuthorizer.ref,
     })
 
+    new apigwv2.CfnRoute(this, 'AdminGetRecipeByIdRoute', {
+      apiId: this.httpApi.httpApiId,
+      routeKey: 'GET /recipes/admin/{id}',
+      target: `integrations/${recipeIntegration.ref}`,
+      authorizationType: 'JWT',
+      authorizerId: jwtAuthorizer.ref,
+    })
+
     new apigwv2.CfnRoute(this, 'CreateDraftRoute', {
       apiId: this.httpApi.httpApiId,
       routeKey: 'POST /recipes/drafts',

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "akli-infrastructure",
   "description": "Infrastructure as Code for akli.dev",
-  "version": "1.6.0",
+  "version": "1.7.0",
   "bin": {
     "akli-cdk": "bin/akli-cdk.js"
   },

--- a/test/lambda/image-resizer.test.ts
+++ b/test/lambda/image-resizer.test.ts
@@ -1,8 +1,10 @@
 import { S3Client, GetObjectCommand, PutObjectCommand, DeleteObjectCommand } from '@aws-sdk/client-s3'
+import { DynamoDBDocumentClient, UpdateCommand } from '@aws-sdk/lib-dynamodb'
 import type { S3Event } from 'aws-lambda'
 import { mockClient } from 'aws-sdk-client-mock'
 
 const s3Mock = mockClient(S3Client)
+const ddbMock = mockClient(DynamoDBDocumentClient)
 
 const mockSharp = {
   resize: jest.fn().mockReturnThis(),
@@ -12,6 +14,7 @@ const mockSharp = {
 jest.mock('sharp', () => jest.fn(() => mockSharp))
 
 process.env.IMAGE_BUCKET_NAME = 'test-image-bucket'
+process.env.TABLE_NAME = 'test-recipes-table'
 
 import { handler } from '../../lambda/image-resizer'
 
@@ -53,6 +56,7 @@ function makeS3Event(key: string, bucket = 'test-image-bucket'): S3Event {
 describe('image-resizer handler', () => {
   beforeEach(() => {
     s3Mock.reset()
+    ddbMock.reset()
     jest.clearAllMocks()
 
     s3Mock.on(GetObjectCommand).resolves({
@@ -62,6 +66,7 @@ describe('image-resizer handler', () => {
     })
     s3Mock.on(PutObjectCommand).resolves({})
     s3Mock.on(DeleteObjectCommand).resolves({})
+    ddbMock.on(UpdateCommand).resolves({})
   })
 
   it('generates three WebP variants with correct dimensions and quality', async () => {
@@ -121,5 +126,110 @@ describe('image-resizer handler', () => {
     for (const call of putCalls) {
       expect(call.args[0].input.ContentType).toBe('image/webp')
     }
+  })
+
+  it('throws a clear error when TABLE_NAME env var is unset', async () => {
+    const saved = process.env.TABLE_NAME
+    delete process.env.TABLE_NAME
+    try {
+      await expect(handler(makeS3Event('uploads/recipes/abc/cover'))).rejects.toThrow(/TABLE_NAME/)
+    } finally {
+      process.env.TABLE_NAME = saved
+    }
+  })
+
+  it('writes back imageStatus to DynamoDB after variant PUTs for a cover image', async () => {
+    const before = Date.now()
+    await handler(makeS3Event('uploads/recipes/abc/cover'))
+    const after = Date.now()
+
+    const updateCalls = ddbMock.commandCalls(UpdateCommand)
+    expect(updateCalls).toHaveLength(1)
+
+    const input = updateCalls[0].args[0].input
+    expect(input.TableName).toBe('test-recipes-table')
+    expect(input.Key).toEqual({ id: 'abc' })
+    expect(input.UpdateExpression).toBe('SET imageStatus.#k = :ts')
+    expect(input.ConditionExpression).toBe('attribute_exists(id)')
+    expect(input.ExpressionAttributeNames).toEqual({ '#k': 'processed/recipes/abc/cover' })
+
+    const ts = input.ExpressionAttributeValues?.[':ts']
+    expect(typeof ts).toBe('number')
+    expect(Number.isFinite(ts)).toBe(true)
+    expect(ts).toBeGreaterThanOrEqual(before)
+    expect(ts).toBeLessThanOrEqual(after)
+  })
+
+  it('writes back imageStatus to DynamoDB for a step image key', async () => {
+    await handler(makeS3Event('uploads/recipes/abc/step-2'))
+
+    const updateCalls = ddbMock.commandCalls(UpdateCommand)
+    expect(updateCalls).toHaveLength(1)
+
+    const input = updateCalls[0].args[0].input
+    expect(input.Key).toEqual({ id: 'abc' })
+    expect(input.ExpressionAttributeNames).toEqual({ '#k': 'processed/recipes/abc/step-2' })
+  })
+
+  it('swallows ConditionalCheckFailedException, still deletes source, and logs skip event', async () => {
+    const infoSpy = jest.spyOn(console, 'info').mockImplementation(() => {})
+
+    const condFailed = Object.assign(new Error('The conditional request failed'), {
+      name: 'ConditionalCheckFailedException',
+    })
+    ddbMock.on(UpdateCommand).rejects(condFailed)
+
+    await expect(handler(makeS3Event('uploads/recipes/abc/cover'))).resolves.toBeUndefined()
+
+    // Source-delete still runs.
+    const deleteCalls = s3Mock.commandCalls(DeleteObjectCommand)
+    expect(deleteCalls).toHaveLength(1)
+    expect(deleteCalls[0].args[0].input).toEqual({
+      Bucket: 'test-image-bucket',
+      Key: 'uploads/recipes/abc/cover',
+    })
+
+    // Structured info log is emitted.
+    expect(infoSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        event: 'resizer.writeback.skipped',
+        reason: 'recipe_deleted',
+      }),
+    )
+
+    infoSpy.mockRestore()
+  })
+
+  it('rethrows non-conditional DDB errors', async () => {
+    ddbMock.on(UpdateCommand).rejects(new Error('boom'))
+
+    await expect(handler(makeS3Event('uploads/recipes/abc/cover'))).rejects.toThrow('boom')
+  })
+
+  it('skips the DDB write for a malformed key that does not match uploads/recipes/<id>/...', async () => {
+    // This key passes the toProcessedKey prefix guard but isn't the recipes shape.
+    await handler(makeS3Event('uploads/not-recipes/x'))
+
+    expect(ddbMock.commandCalls(UpdateCommand)).toHaveLength(0)
+
+    // Variant writes and source-delete still happen.
+    expect(s3Mock.commandCalls(PutObjectCommand)).toHaveLength(3)
+    expect(s3Mock.commandCalls(DeleteObjectCommand)).toHaveLength(1)
+  })
+
+  it('invokes DDB UpdateCommand before the source DeleteObjectCommand', async () => {
+    // Sequencing is enforced via the handler's error-propagation contract: if the
+    // UpdateCommand is issued BEFORE the source DeleteObjectCommand, rejecting the
+    // UpdateCommand with a generic error must prevent the source-delete from firing.
+    // If the delete were issued first, it would run regardless of the DDB outcome.
+    ddbMock.on(UpdateCommand).rejects(new Error('sequencing-probe'))
+
+    await expect(handler(makeS3Event('uploads/recipes/abc/cover'))).rejects.toThrow(
+      'sequencing-probe',
+    )
+
+    expect(ddbMock.commandCalls(UpdateCommand)).toHaveLength(1)
+    // Source-delete never fires because the update threw first.
+    expect(s3Mock.commandCalls(DeleteObjectCommand)).toHaveLength(0)
   })
 })

--- a/test/lambda/image-resizer.test.ts
+++ b/test/lambda/image-resizer.test.ts
@@ -1,3 +1,4 @@
+import { ConditionalCheckFailedException } from '@aws-sdk/client-dynamodb'
 import { S3Client, GetObjectCommand, PutObjectCommand, DeleteObjectCommand } from '@aws-sdk/client-s3'
 import { DynamoDBDocumentClient, UpdateCommand } from '@aws-sdk/lib-dynamodb'
 import type { S3Event } from 'aws-lambda'
@@ -174,8 +175,9 @@ describe('image-resizer handler', () => {
   it('swallows ConditionalCheckFailedException, still deletes source, and logs skip event', async () => {
     const infoSpy = jest.spyOn(console, 'info').mockImplementation(() => {})
 
-    const condFailed = Object.assign(new Error('The conditional request failed'), {
-      name: 'ConditionalCheckFailedException',
+    const condFailed = new ConditionalCheckFailedException({
+      $metadata: {},
+      message: 'The conditional request failed',
     })
     ddbMock.on(UpdateCommand).rejects(condFailed)
 

--- a/test/lambda/recipe-handler.test.ts
+++ b/test/lambda/recipe-handler.test.ts
@@ -1977,4 +1977,183 @@ describe('Recipe Lambda handler', () => {
       expect(body.coverImage).toEqual({ key: coverKey, alt: 'cover alt', processedAt: 0 })
     })
   })
+
+  // ─── PATCH /recipes/{id} — imageStatus REMOVE on swap + processedAt strip ───
+  describe('PATCH /recipes/{id} — imageStatus REMOVE on swap and processedAt body strip', () => {
+    const oldCoverKey = 'processed/recipes/recipe-uuid-1/cover'
+    const newCoverKey = 'processed/recipes/recipe-uuid-1/cover-v2'
+    const stepAKey = 'processed/recipes/recipe-uuid-1/step-1'
+    const stepBKey = 'processed/recipes/recipe-uuid-1/step-2'
+    const stepCKey = 'processed/recipes/recipe-uuid-1/step-3'
+
+    // AC 1 + AC 5: cover-image swap REMOVEs imageStatus.#<oldCoverKey> in the same
+    // UpdateCommand as SET for updated fields, with ExpressionAttributeNames pointing
+    // at the dropped key.
+    it('cover-image swap includes REMOVE imageStatus.#<oldKey> in the same UpdateCommand as SET', async () => {
+      const oldItem = publishedRecipeItem({
+        id: 'recipe-uuid-1',
+        authorId: 'contributor-user-id',
+        coverImage: { key: oldCoverKey, alt: 'Old alt' },
+        imageStatus: { [oldCoverKey]: 1_745_000_000_001 },
+      })
+      ddbMock.on(GetCommand).resolves({ Item: oldItem })
+      ddbMock.on(UpdateCommand).resolves({ Attributes: oldItem })
+      s3Mock.on(DeleteObjectsCommand).resolves({})
+
+      const event = makeEvent({
+        routeKey: 'PATCH /recipes/{id}',
+        rawPath: '/recipes/recipe-uuid-1',
+        pathParameters: { id: 'recipe-uuid-1' },
+        headers: { authorization: `Bearer ${adminToken}` },
+        body: JSON.stringify({ coverImage: { key: newCoverKey, alt: 'New alt' } }),
+      })
+
+      const result = await handler(event)
+
+      expect(result.statusCode).toBe(200)
+
+      const updateCalls = ddbMock.commandCalls(UpdateCommand)
+      expect(updateCalls).toHaveLength(1)
+      const input = updateCalls[0].args[0].input
+      const expr = input.UpdateExpression as string
+
+      // Both SET (for the coverImage field) and REMOVE (for imageStatus entry) live in the same expression.
+      expect(expr).toMatch(/\bSET\b/)
+      expect(expr).toMatch(/\bREMOVE\b/)
+      expect(expr).toMatch(/REMOVE\s+imageStatus\.#/)
+
+      // An ExpressionAttributeName must point at the dropped old cover key.
+      const names = input.ExpressionAttributeNames as Record<string, string>
+      const nameValues = Object.values(names)
+      expect(nameValues).toContain(oldCoverKey)
+
+      // The name placeholder used in REMOVE must resolve to the old cover key.
+      const removeMatch = expr.match(/REMOVE\s+imageStatus\.(#[a-zA-Z0-9_]+)/)
+      expect(removeMatch).not.toBeNull()
+      const removePlaceholder = removeMatch![1]
+      expect(names[removePlaceholder]).toBe(oldCoverKey)
+    })
+
+    // AC 2: step-image swap REMOVEs only dropped step image keys; preserved keys stay.
+    it('step-image swap REMOVEs imageStatus entries for dropped keys only, preserving kept keys', async () => {
+      const oldItem = publishedRecipeItem({
+        id: 'recipe-uuid-1',
+        authorId: 'contributor-user-id',
+        coverImage: { key: oldCoverKey, alt: 'Cover alt' },
+        steps: [
+          { order: 1, text: 'A', image: { key: stepAKey, alt: 'a' } },
+          { order: 2, text: 'B', image: { key: stepBKey, alt: 'b' } },
+          { order: 3, text: 'C', image: { key: stepCKey, alt: 'c' } },
+        ],
+        imageStatus: {
+          [oldCoverKey]: 1_745_000_000_000,
+          [stepAKey]: 1_745_000_000_001,
+          [stepBKey]: 1_745_000_000_002,
+          [stepCKey]: 1_745_000_000_003,
+        },
+      })
+      ddbMock.on(GetCommand).resolves({ Item: oldItem })
+      ddbMock.on(UpdateCommand).resolves({ Attributes: oldItem })
+      s3Mock.on(DeleteObjectsCommand).resolves({})
+
+      const event = makeEvent({
+        routeKey: 'PATCH /recipes/{id}',
+        rawPath: '/recipes/recipe-uuid-1',
+        pathParameters: { id: 'recipe-uuid-1' },
+        headers: { authorization: `Bearer ${adminToken}` },
+        // Keep stepC, drop stepA and stepB. Cover unchanged.
+        body: JSON.stringify({
+          steps: [
+            { order: 1, text: 'C', image: { key: stepCKey, alt: 'c' } },
+          ],
+        }),
+      })
+
+      const result = await handler(event)
+
+      expect(result.statusCode).toBe(200)
+
+      const updateCalls = ddbMock.commandCalls(UpdateCommand)
+      expect(updateCalls).toHaveLength(1)
+      const input = updateCalls[0].args[0].input
+      const expr = input.UpdateExpression as string
+      const names = input.ExpressionAttributeNames as Record<string, string>
+
+      expect(expr).toMatch(/\bREMOVE\b/)
+
+      // Collect every imageStatus.#<placeholder> occurrence in the REMOVE segment.
+      const removeSegmentMatch = expr.match(/REMOVE\s+(.+)$/)
+      expect(removeSegmentMatch).not.toBeNull()
+      const removeSegment = removeSegmentMatch![1]
+      const placeholderMatches = Array.from(removeSegment.matchAll(/imageStatus\.(#[a-zA-Z0-9_]+)/g))
+      const removedKeys = placeholderMatches.map((m) => names[m[1]])
+
+      // Dropped step keys are REMOVEd.
+      expect(removedKeys).toContain(stepAKey)
+      expect(removedKeys).toContain(stepBKey)
+      // Preserved step key is NOT REMOVEd.
+      expect(removedKeys).not.toContain(stepCKey)
+      // Cover is unchanged — its imageStatus entry must be preserved too.
+      expect(removedKeys).not.toContain(oldCoverKey)
+      expect(removedKeys).toHaveLength(2)
+    })
+
+    // AC 3 + AC 4: client-supplied processedAt on nested coverImage and step.image is
+    // stripped before expression building; the outgoing UpdateCommand carries the cleaned
+    // objects and no value contains a processedAt field.
+    it('strips client-supplied processedAt from coverImage and step.image before the UpdateCommand runs', async () => {
+      const oldItem = publishedRecipeItem({
+        id: 'recipe-uuid-1',
+        authorId: 'contributor-user-id',
+        coverImage: { key: oldCoverKey, alt: 'Old cover alt' },
+        steps: [{ order: 1, text: 'A', image: { key: stepAKey, alt: 'a' } }],
+        imageStatus: { [oldCoverKey]: 1_745_000_000_000, [stepAKey]: 1_745_000_000_001 },
+      })
+      ddbMock.on(GetCommand).resolves({ Item: oldItem })
+      ddbMock.on(UpdateCommand).resolves({ Attributes: oldItem })
+
+      // Same keys — no image swap — so any UpdateExpression values that carry the nested
+      // image objects come straight from the (stripped) request body.
+      const event = makeEvent({
+        routeKey: 'PATCH /recipes/{id}',
+        rawPath: '/recipes/recipe-uuid-1',
+        pathParameters: { id: 'recipe-uuid-1' },
+        headers: { authorization: `Bearer ${adminToken}` },
+        body: JSON.stringify({
+          coverImage: { key: oldCoverKey, alt: 'Cover alt', processedAt: 9_999_999_999_999 },
+          steps: [
+            { order: 1, text: 'A', image: { key: stepAKey, alt: 'a', processedAt: 9_999_999_999_998 } },
+          ],
+        }),
+      })
+
+      const result = await handler(event)
+
+      expect(result.statusCode).toBe(200)
+
+      const updateCalls = ddbMock.commandCalls(UpdateCommand)
+      expect(updateCalls).toHaveLength(1)
+      const input = updateCalls[0].args[0].input
+      const values = input.ExpressionAttributeValues as Record<string, unknown>
+
+      // AC 4: no ExpressionAttributeValue key exists for a client-supplied processedAt
+      // (i.e. the strip happened on the parsed body before the handler built the expression).
+      expect(Object.keys(values)).not.toContain(':processedAt')
+
+      // The nested coverImage value carried in the UpdateCommand must not include processedAt.
+      const coverValue = values[':coverImage'] as Record<string, unknown> | undefined
+      expect(coverValue).toBeDefined()
+      expect(coverValue).not.toHaveProperty('processedAt')
+      expect(coverValue).toEqual({ key: oldCoverKey, alt: 'Cover alt' })
+
+      // Each nested step.image carried in the UpdateCommand must not include processedAt.
+      const stepsValue = values[':steps'] as Array<{ image?: Record<string, unknown> }> | undefined
+      expect(stepsValue).toBeDefined()
+      expect(stepsValue).toHaveLength(1)
+      const stepImage = stepsValue![0].image
+      expect(stepImage).toBeDefined()
+      expect(stepImage).not.toHaveProperty('processedAt')
+      expect(stepImage).toEqual({ key: stepAKey, alt: 'a' })
+    })
+  })
 })

--- a/test/lambda/recipe-handler.test.ts
+++ b/test/lambda/recipe-handler.test.ts
@@ -417,6 +417,28 @@ describe('Recipe Lambda handler', () => {
       }
     })
 
+    it('initialises imageStatus as an empty map on the new item', async () => {
+      ddbMock.on(ScanCommand).resolves({ Items: [] })
+      ddbMock.on(PutCommand).resolves({})
+
+      const event = makeEvent({
+        routeKey: 'POST /recipes/drafts',
+        rawPath: '/recipes/drafts',
+        headers: { authorization: `Bearer ${adminToken}` },
+        body: '{}',
+      })
+
+      const result = await handler(event)
+
+      expect(result.statusCode).toBe(201)
+
+      const putCalls = ddbMock.commandCalls(PutCommand)
+      expect(putCalls).toHaveLength(1)
+      const item = putCalls[0].args[0].input.Item as Record<string, unknown>
+      expect(item).toHaveProperty('imageStatus')
+      expect(item.imageStatus).toEqual({})
+    })
+
     it('defaults slug to draft-<uuid> when no title is provided', async () => {
       ddbMock.on(ScanCommand).resolves({ Items: [] })
       ddbMock.on(PutCommand).resolves({})

--- a/test/lambda/recipe-handler.test.ts
+++ b/test/lambda/recipe-handler.test.ts
@@ -1954,5 +1954,27 @@ describe('Recipe Lambda handler', () => {
       expect(body.steps[0].image).not.toHaveProperty('processedAt')
       expect(body.steps[0].image).toEqual({ key: step1Key, alt: 'step alt' })
     })
+
+    it('preserves processedAt: 0 when imageStatus records a falsy-but-valid timestamp', async () => {
+      // Guards against a future `if (processedAt)` truthiness regression — the code
+      // must keep the `!== undefined` check so 0 is treated as "ready", not "missing".
+      const item = publishedRecipeItem({
+        id: 'recipe-uuid-1',
+        coverImage: { key: coverKey, alt: 'cover alt' },
+        steps: [],
+        imageStatus: { [coverKey]: 0 },
+      })
+      ddbMock.on(ScanCommand).resolves({ Items: [item] })
+
+      const result = await handler(makeEvent({
+        routeKey: 'GET /recipes/{slug}',
+        rawPath: '/recipes/slow-cooked-lamb-ragu',
+        pathParameters: { slug: 'slow-cooked-lamb-ragu' },
+      }))
+
+      expect(result.statusCode).toBe(200)
+      const body = JSON.parse(result.body as string)
+      expect(body.coverImage).toEqual({ key: coverKey, alt: 'cover alt', processedAt: 0 })
+    })
   })
 })

--- a/test/lambda/recipe-handler.test.ts
+++ b/test/lambda/recipe-handler.test.ts
@@ -1290,7 +1290,6 @@ describe('Recipe Lambda handler', () => {
       })
     })
 
-    // ─── Publish readiness validation (issue #109) ────────────────────
     describe('readiness validation — rejects recipes with unready images', () => {
       const coverKey = 'processed/recipes/recipe-uuid-1/cover'
       const step1Key = 'processed/recipes/recipe-uuid-1/step-1'
@@ -1308,7 +1307,6 @@ describe('Recipe Lambda handler', () => {
         })
       }
 
-      // AC 1, AC 6 (cover-unready alone)
       it('returns 400 with errors.coverImage.processedAt when cover key has no imageStatus entry (steps either absent or fully ready)', async () => {
         ddbMock.on(GetCommand).resolves({
           Item: draftRecipeItem({
@@ -1317,12 +1315,9 @@ describe('Recipe Lambda handler', () => {
             steps: [
               { order: 1, text: 'Sear.', image: { key: step1Key, alt: 'seared' } },
             ],
-            // cover key missing from imageStatus → unready cover
             imageStatus: { [step1Key]: step1Ts },
           }),
         })
-        // Fallback to ensure a failure-to-reject returns 200 (not 500 from a
-        // missing UpdateCommand mock) so the failure signal is unambiguous.
         ddbMock.on(UpdateCommand).resolves({
           Attributes: publishedRecipeItem({ authorId: 'contributor-user-id' }),
         })
@@ -1337,7 +1332,6 @@ describe('Recipe Lambda handler', () => {
         expect(body.errors).not.toHaveProperty('stepImages')
       })
 
-      // AC 2, AC 6 (step-unready alone)
       it('returns 400 with errors.stepImages for each step whose image key has no imageStatus entry (cover ready)', async () => {
         ddbMock.on(GetCommand).resolves({
           Item: draftRecipeItem({
@@ -1347,7 +1341,6 @@ describe('Recipe Lambda handler', () => {
               { order: 1, text: 'Sear.', image: { key: step1Key, alt: 'seared' } },
               { order: 2, text: 'Simmer.', image: { key: step2Key, alt: 'simmering' } },
             ],
-            // cover + step 1 ready; step 2 unready
             imageStatus: { [coverKey]: coverTs, [step1Key]: step1Ts },
           }),
         })
@@ -1366,7 +1359,6 @@ describe('Recipe Lambda handler', () => {
         ])
       })
 
-      // AC 1, AC 2, AC 6 (both)
       it('returns 400 with both errors.coverImage.processedAt and errors.stepImages when cover and step images are unready', async () => {
         ddbMock.on(GetCommand).resolves({
           Item: draftRecipeItem({
@@ -1394,14 +1386,13 @@ describe('Recipe Lambda handler', () => {
         ])
       })
 
-      // AC 4, AC 6 (readiness + other validation error)
       it('returns 400 with readiness errors coexisting with other validation errors (e.g. missing title)', async () => {
         ddbMock.on(GetCommand).resolves({
           Item: draftRecipeItem({
             authorId: 'contributor-user-id',
-            title: '', // triggers existing `errors.title`
+            title: '',
             coverImage: { key: coverKey, alt: 'A bowl of lamb ragu' },
-            imageStatus: {}, // cover unready
+            imageStatus: {},
           }),
         })
 
@@ -1409,24 +1400,18 @@ describe('Recipe Lambda handler', () => {
 
         expect(result.statusCode).toBe(400)
         const body = JSON.parse(result.body as string)
-        // Existing title validation still fires
         expect(body.errors).toHaveProperty('title')
-        // Readiness error coexists on the same response
         expect(body.errors.coverImage).toBeDefined()
         expect(body.errors.coverImage.processedAt).toBe('Cover image still processing')
       })
 
-      // AC 5, AC 6 (republish with unready swapped image)
       it('returns 400 when republishing a currently-published recipe whose cover was swapped to an unready new key', async () => {
         const oldCoverKey = 'processed/recipes/recipe-uuid-1/cover-old'
         const newCoverKey = 'processed/recipes/recipe-uuid-1/cover'
         ddbMock.on(GetCommand).resolves({
           Item: publishedRecipeItem({
             authorId: 'contributor-user-id',
-            // Item is currently published — a cover swap landed via autosave PATCH,
-            // and the resizer hasn't yet written the new key's imageStatus entry.
             coverImage: { key: newCoverKey, alt: 'New cover' },
-            // imageStatus still holds only the OLD key's timestamp
             imageStatus: { [oldCoverKey]: coverTs },
           }),
         })
@@ -1440,7 +1425,6 @@ describe('Recipe Lambda handler', () => {
         expect(body.errors.coverImage.processedAt).toBe('Cover image still processing')
       })
 
-      // AC 3 (preserve existing errors.steps string shape)
       it('preserves the existing errors.steps string shape when steps have empty text (does NOT restructure into stepImages)', async () => {
         ddbMock.on(GetCommand).resolves({
           Item: draftRecipeItem({
@@ -1455,14 +1439,11 @@ describe('Recipe Lambda handler', () => {
 
         expect(result.statusCode).toBe(400)
         const body = JSON.parse(result.body as string)
-        // existing empty-text error is a string under `steps` — shape unchanged
         expect(body.errors).toHaveProperty('steps')
         expect(typeof body.errors.steps).toBe('string')
-        // readiness errors must NOT be smuggled into the `steps` key
         expect(body.errors.steps).not.toEqual(expect.any(Array))
       })
 
-      // Positive control: a recipe with every image ready publishes successfully.
       it('publishes successfully when every image key has a matching imageStatus entry', async () => {
         ddbMock.on(GetCommand).resolves({
           Item: draftRecipeItem({

--- a/test/lambda/recipe-handler.test.ts
+++ b/test/lambda/recipe-handler.test.ts
@@ -1130,7 +1130,10 @@ describe('Recipe Lambda handler', () => {
   describe('PATCH /recipes/{id}/publish — publish recipe (admin-only)', () => {
     it('returns 200 and sets status to published when admin publishes a valid draft', async () => {
       ddbMock.on(GetCommand).resolves({
-        Item: draftRecipeItem({ authorId: 'contributor-user-id' }),
+        Item: draftRecipeItem({
+          authorId: 'contributor-user-id',
+          imageStatus: { 'recipes/images/recipe-uuid-1/cover': 1_745_000_000_000 },
+        }),
       })
       ddbMock.on(UpdateCommand).resolves({
         Attributes: publishedRecipeItem({ authorId: 'contributor-user-id' }),
@@ -1152,7 +1155,10 @@ describe('Recipe Lambda handler', () => {
 
     it('removes ttl via UpdateExpression REMOVE (not SET ttl = null) on publish', async () => {
       ddbMock.on(GetCommand).resolves({
-        Item: draftRecipeItem({ authorId: 'contributor-user-id' }),
+        Item: draftRecipeItem({
+          authorId: 'contributor-user-id',
+          imageStatus: { 'recipes/images/recipe-uuid-1/cover': 1_745_000_000_000 },
+        }),
       })
       ddbMock.on(UpdateCommand).resolves({
         Attributes: publishedRecipeItem({ authorId: 'contributor-user-id' }),
@@ -1481,7 +1487,10 @@ describe('Recipe Lambda handler', () => {
 
     it('returns 200 (no-op) when publishing an already-published recipe that still passes validation', async () => {
       ddbMock.on(GetCommand).resolves({
-        Item: publishedRecipeItem({ authorId: 'contributor-user-id' }),
+        Item: publishedRecipeItem({
+          authorId: 'contributor-user-id',
+          imageStatus: { 'recipes/images/recipe-uuid-1/cover': 1_745_000_000_000 },
+        }),
       })
       ddbMock.on(UpdateCommand).resolves({
         Attributes: publishedRecipeItem({ authorId: 'contributor-user-id' }),

--- a/test/lambda/recipe-handler.test.ts
+++ b/test/lambda/recipe-handler.test.ts
@@ -1648,4 +1648,311 @@ describe('Recipe Lambda handler', () => {
       expect(body).toHaveProperty('error')
     })
   })
+
+  // ─── Response composition — processedAt + imageStatus stripping ─────
+  describe('Response composition — processedAt + imageStatus stripping', () => {
+    // A published recipe whose cover image and one step image both have matching
+    // imageStatus entries, plus one step image without a matching entry.
+    const coverKey = 'processed/recipes/recipe-uuid-1/cover'
+    const step1Key = 'processed/recipes/recipe-uuid-1/step-1'
+    const step2Key = 'processed/recipes/recipe-uuid-1/step-2'
+    const coverTs = 1_745_000_000_001
+    const step1Ts = 1_745_000_000_002
+
+    function recipeWithImageStatus(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+      return publishedRecipeItem({
+        id: 'recipe-uuid-1',
+        coverImage: { key: coverKey, alt: 'A bowl of lamb ragu' },
+        steps: [
+          { order: 1, text: 'Sear.', image: { key: step1Key, alt: 'seared lamb' } },
+          { order: 2, text: 'Simmer.', image: { key: step2Key, alt: 'simmering' } },
+        ],
+        imageStatus: { [coverKey]: coverTs, [step1Key]: step1Ts },
+        ...overrides,
+      })
+    }
+
+    // AC 1: GET /recipes composes processedAt onto cover image.
+    it('GET /recipes composes processedAt onto cover image from imageStatus', async () => {
+      ddbMock.on(QueryCommand).resolves({ Items: [recipeWithImageStatus()] })
+
+      const result = await handler(makeEvent({ routeKey: 'GET /recipes', rawPath: '/recipes' }))
+
+      expect(result.statusCode).toBe(200)
+      const body = JSON.parse(result.body as string)
+      expect(body[0].coverImage).toEqual({ key: coverKey, alt: 'A bowl of lamb ragu', processedAt: coverTs })
+    })
+
+    // AC 2: GET /recipes/{slug} composes onto cover AND each step.image.
+    it('GET /recipes/{slug} composes processedAt onto coverImage and each step.image', async () => {
+      ddbMock.on(ScanCommand).resolves({ Items: [recipeWithImageStatus()] })
+
+      const result = await handler(makeEvent({
+        routeKey: 'GET /recipes/{slug}',
+        rawPath: '/recipes/slow-cooked-lamb-ragu',
+        pathParameters: { slug: 'slow-cooked-lamb-ragu' },
+      }))
+
+      expect(result.statusCode).toBe(200)
+      const body = JSON.parse(result.body as string)
+      expect(body.coverImage).toEqual({ key: coverKey, alt: 'A bowl of lamb ragu', processedAt: coverTs })
+      // step 1 has a matching imageStatus entry → processedAt composed
+      expect(body.steps[0].image).toEqual({ key: step1Key, alt: 'seared lamb', processedAt: step1Ts })
+      // step 2 has no matching entry → processedAt absent (not null, not undefined-serialised)
+      expect(body.steps[1].image).toEqual({ key: step2Key, alt: 'simmering' })
+      expect(body.steps[1].image).not.toHaveProperty('processedAt')
+    })
+
+    // AC 3: GET /me/recipes composes processedAt on returned items.
+    it('GET /me/recipes composes processedAt on returned items', async () => {
+      ddbMock.on(QueryCommand).resolves({ Items: [recipeWithImageStatus({ authorId: 'contributor-user-id' })] })
+
+      const result = await handler(makeEvent({
+        routeKey: 'GET /me/recipes',
+        rawPath: '/me/recipes',
+        headers: { authorization: `Bearer ${contributorToken}` },
+      }))
+
+      expect(result.statusCode).toBe(200)
+      const body = JSON.parse(result.body as string)
+      expect(body).toHaveLength(1)
+      expect(body[0].coverImage).toEqual({ key: coverKey, alt: 'A bowl of lamb ragu', processedAt: coverTs })
+    })
+
+    // AC 4: GET /recipes/admin composes processedAt on returned items.
+    it('GET /recipes/admin composes processedAt on returned items', async () => {
+      ddbMock.on(QueryCommand)
+        .resolvesOnce({ Items: [recipeWithImageStatus()] })
+        .resolvesOnce({ Items: [] })
+
+      const result = await handler(makeEvent({
+        routeKey: 'GET /recipes/admin',
+        rawPath: '/recipes/admin',
+        headers: { authorization: `Bearer ${adminToken}` },
+      }))
+
+      expect(result.statusCode).toBe(200)
+      const body = JSON.parse(result.body as string)
+      expect(body).toHaveLength(1)
+      expect(body[0].coverImage).toEqual({ key: coverKey, alt: 'A bowl of lamb ragu', processedAt: coverTs })
+    })
+
+    // AC 5: PATCH /recipes/{id} response composes processedAt.
+    it('PATCH /recipes/{id} response composes processedAt onto the returned recipe', async () => {
+      const oldItem = recipeWithImageStatus({ authorId: 'contributor-user-id' })
+      ddbMock.on(GetCommand).resolves({ Item: oldItem })
+      ddbMock.on(UpdateCommand).resolves({ Attributes: oldItem })
+
+      const result = await handler(makeEvent({
+        routeKey: 'PATCH /recipes/{id}',
+        rawPath: '/recipes/recipe-uuid-1',
+        pathParameters: { id: 'recipe-uuid-1' },
+        headers: { authorization: `Bearer ${adminToken}` },
+        body: JSON.stringify({ title: 'Updated Title' }),
+      }))
+
+      expect(result.statusCode).toBe(200)
+      const body = JSON.parse(result.body as string)
+      expect(body.coverImage).toEqual({ key: coverKey, alt: 'A bowl of lamb ragu', processedAt: coverTs })
+      expect(body.steps[0].image).toEqual({ key: step1Key, alt: 'seared lamb', processedAt: step1Ts })
+    })
+
+    // AC 6: PATCH /recipes/{id}/publish response composes processedAt.
+    it('PATCH /recipes/{id}/publish response composes processedAt onto the returned recipe', async () => {
+      // Draft we read for validation passes all existing checks AND has readiness on every image.
+      const fullyReadyDraft = recipeWithImageStatus({
+        status: 'draft',
+        authorId: 'contributor-user-id',
+        steps: [
+          { order: 1, text: 'Sear.', image: { key: step1Key, alt: 'seared lamb' } },
+        ],
+        imageStatus: { [coverKey]: coverTs, [step1Key]: step1Ts },
+      })
+      ddbMock.on(GetCommand).resolves({ Item: fullyReadyDraft })
+      ddbMock.on(UpdateCommand).resolves({
+        Attributes: { ...fullyReadyDraft, status: 'published' },
+      })
+
+      const result = await handler(makeEvent({
+        routeKey: 'PATCH /recipes/{id}/publish',
+        rawPath: '/recipes/recipe-uuid-1/publish',
+        pathParameters: { id: 'recipe-uuid-1' },
+        headers: { authorization: `Bearer ${adminToken}` },
+      }))
+
+      expect(result.statusCode).toBe(200)
+      const body = JSON.parse(result.body as string)
+      expect(body.coverImage).toEqual({ key: coverKey, alt: 'A bowl of lamb ragu', processedAt: coverTs })
+      expect(body.steps[0].image).toEqual({ key: step1Key, alt: 'seared lamb', processedAt: step1Ts })
+    })
+
+    // AC 7: PATCH /recipes/{id}/unpublish response composes processedAt.
+    it('PATCH /recipes/{id}/unpublish response composes processedAt onto the returned recipe', async () => {
+      const oldItem = recipeWithImageStatus({ authorId: 'contributor-user-id' })
+      ddbMock.on(GetCommand).resolves({ Item: oldItem })
+      ddbMock.on(UpdateCommand).resolves({
+        Attributes: { ...oldItem, status: 'draft' },
+      })
+
+      const result = await handler(makeEvent({
+        routeKey: 'PATCH /recipes/{id}/unpublish',
+        rawPath: '/recipes/recipe-uuid-1/unpublish',
+        pathParameters: { id: 'recipe-uuid-1' },
+        headers: { authorization: `Bearer ${adminToken}` },
+      }))
+
+      expect(result.statusCode).toBe(200)
+      const body = JSON.parse(result.body as string)
+      expect(body.coverImage).toEqual({ key: coverKey, alt: 'A bowl of lamb ragu', processedAt: coverTs })
+    })
+
+    // AC 8: imageStatus is stripped from every response body.
+    describe('imageStatus is stripped from every response body', () => {
+      it('GET /recipes strips imageStatus', async () => {
+        ddbMock.on(QueryCommand).resolves({ Items: [recipeWithImageStatus()] })
+
+        const result = await handler(makeEvent({ routeKey: 'GET /recipes', rawPath: '/recipes' }))
+
+        expect(result.statusCode).toBe(200)
+        expect(result.body).not.toContain('imageStatus')
+        const body = JSON.parse(result.body as string)
+        expect(body[0]).not.toHaveProperty('imageStatus')
+      })
+
+      it('GET /recipes/{slug} strips imageStatus', async () => {
+        ddbMock.on(ScanCommand).resolves({ Items: [recipeWithImageStatus()] })
+
+        const result = await handler(makeEvent({
+          routeKey: 'GET /recipes/{slug}',
+          rawPath: '/recipes/slow-cooked-lamb-ragu',
+          pathParameters: { slug: 'slow-cooked-lamb-ragu' },
+        }))
+
+        expect(result.statusCode).toBe(200)
+        expect(result.body).not.toContain('imageStatus')
+        const body = JSON.parse(result.body as string)
+        expect(body).not.toHaveProperty('imageStatus')
+      })
+
+      it('GET /me/recipes strips imageStatus', async () => {
+        ddbMock.on(QueryCommand).resolves({ Items: [recipeWithImageStatus({ authorId: 'contributor-user-id' })] })
+
+        const result = await handler(makeEvent({
+          routeKey: 'GET /me/recipes',
+          rawPath: '/me/recipes',
+          headers: { authorization: `Bearer ${contributorToken}` },
+        }))
+
+        expect(result.statusCode).toBe(200)
+        expect(result.body).not.toContain('imageStatus')
+        const body = JSON.parse(result.body as string)
+        expect(body[0]).not.toHaveProperty('imageStatus')
+      })
+
+      it('GET /recipes/admin strips imageStatus', async () => {
+        ddbMock.on(QueryCommand)
+          .resolvesOnce({ Items: [recipeWithImageStatus()] })
+          .resolvesOnce({ Items: [] })
+
+        const result = await handler(makeEvent({
+          routeKey: 'GET /recipes/admin',
+          rawPath: '/recipes/admin',
+          headers: { authorization: `Bearer ${adminToken}` },
+        }))
+
+        expect(result.statusCode).toBe(200)
+        expect(result.body).not.toContain('imageStatus')
+        const body = JSON.parse(result.body as string)
+        expect(body[0]).not.toHaveProperty('imageStatus')
+      })
+
+      it('PATCH /recipes/{id} strips imageStatus', async () => {
+        const oldItem = recipeWithImageStatus({ authorId: 'contributor-user-id' })
+        ddbMock.on(GetCommand).resolves({ Item: oldItem })
+        ddbMock.on(UpdateCommand).resolves({ Attributes: oldItem })
+
+        const result = await handler(makeEvent({
+          routeKey: 'PATCH /recipes/{id}',
+          rawPath: '/recipes/recipe-uuid-1',
+          pathParameters: { id: 'recipe-uuid-1' },
+          headers: { authorization: `Bearer ${adminToken}` },
+          body: JSON.stringify({ title: 'Updated Title' }),
+        }))
+
+        expect(result.statusCode).toBe(200)
+        expect(result.body).not.toContain('imageStatus')
+        const body = JSON.parse(result.body as string)
+        expect(body).not.toHaveProperty('imageStatus')
+      })
+
+      it('PATCH /recipes/{id}/publish strips imageStatus', async () => {
+        const fullyReadyDraft = recipeWithImageStatus({
+          status: 'draft',
+          authorId: 'contributor-user-id',
+          steps: [{ order: 1, text: 'Sear.', image: { key: step1Key, alt: 'seared lamb' } }],
+          imageStatus: { [coverKey]: coverTs, [step1Key]: step1Ts },
+        })
+        ddbMock.on(GetCommand).resolves({ Item: fullyReadyDraft })
+        ddbMock.on(UpdateCommand).resolves({ Attributes: { ...fullyReadyDraft, status: 'published' } })
+
+        const result = await handler(makeEvent({
+          routeKey: 'PATCH /recipes/{id}/publish',
+          rawPath: '/recipes/recipe-uuid-1/publish',
+          pathParameters: { id: 'recipe-uuid-1' },
+          headers: { authorization: `Bearer ${adminToken}` },
+        }))
+
+        expect(result.statusCode).toBe(200)
+        expect(result.body).not.toContain('imageStatus')
+        const body = JSON.parse(result.body as string)
+        expect(body).not.toHaveProperty('imageStatus')
+      })
+
+      it('PATCH /recipes/{id}/unpublish strips imageStatus', async () => {
+        const oldItem = recipeWithImageStatus({ authorId: 'contributor-user-id' })
+        ddbMock.on(GetCommand).resolves({ Item: oldItem })
+        ddbMock.on(UpdateCommand).resolves({ Attributes: { ...oldItem, status: 'draft' } })
+
+        const result = await handler(makeEvent({
+          routeKey: 'PATCH /recipes/{id}/unpublish',
+          rawPath: '/recipes/recipe-uuid-1/unpublish',
+          pathParameters: { id: 'recipe-uuid-1' },
+          headers: { authorization: `Bearer ${adminToken}` },
+        }))
+
+        expect(result.statusCode).toBe(200)
+        expect(result.body).not.toContain('imageStatus')
+        const body = JSON.parse(result.body as string)
+        expect(body).not.toHaveProperty('imageStatus')
+      })
+    })
+
+    // AC 9: No processedAt added when imageStatus entry missing.
+    it('GET /recipes/{slug} omits processedAt when imageStatus has no entry for the cover key', async () => {
+      const item = publishedRecipeItem({
+        id: 'recipe-uuid-1',
+        coverImage: { key: coverKey, alt: 'no-entry alt' },
+        steps: [{ order: 1, text: 'step', image: { key: step1Key, alt: 'step alt' } }],
+        // imageStatus is an empty map — no entries for either key.
+        imageStatus: {},
+      })
+      ddbMock.on(ScanCommand).resolves({ Items: [item] })
+
+      const result = await handler(makeEvent({
+        routeKey: 'GET /recipes/{slug}',
+        rawPath: '/recipes/slow-cooked-lamb-ragu',
+        pathParameters: { slug: 'slow-cooked-lamb-ragu' },
+      }))
+
+      expect(result.statusCode).toBe(200)
+      // Literal check: the serialised body must not contain a processedAt key at all
+      // (guards against `processedAt: null` or `processedAt: undefined` slip-through).
+      expect(result.body).not.toContain('processedAt')
+      const body = JSON.parse(result.body as string)
+      expect(body.coverImage).not.toHaveProperty('processedAt')
+      expect(body.coverImage).toEqual({ key: coverKey, alt: 'no-entry alt' })
+      expect(body.steps[0].image).not.toHaveProperty('processedAt')
+      expect(body.steps[0].image).toEqual({ key: step1Key, alt: 'step alt' })
+    })
+  })
 })

--- a/test/lambda/recipe-handler.test.ts
+++ b/test/lambda/recipe-handler.test.ts
@@ -1978,7 +1978,6 @@ describe('Recipe Lambda handler', () => {
     })
   })
 
-  // ─── PATCH /recipes/{id} — imageStatus REMOVE on swap + processedAt strip ───
   describe('PATCH /recipes/{id} — imageStatus REMOVE on swap and processedAt body strip', () => {
     const oldCoverKey = 'processed/recipes/recipe-uuid-1/cover'
     const newCoverKey = 'processed/recipes/recipe-uuid-1/cover-v2'
@@ -1986,9 +1985,6 @@ describe('Recipe Lambda handler', () => {
     const stepBKey = 'processed/recipes/recipe-uuid-1/step-2'
     const stepCKey = 'processed/recipes/recipe-uuid-1/step-3'
 
-    // AC 1 + AC 5: cover-image swap REMOVEs imageStatus.#<oldCoverKey> in the same
-    // UpdateCommand as SET for updated fields, with ExpressionAttributeNames pointing
-    // at the dropped key.
     it('cover-image swap includes REMOVE imageStatus.#<oldKey> in the same UpdateCommand as SET', async () => {
       const oldItem = publishedRecipeItem({
         id: 'recipe-uuid-1',
@@ -2017,24 +2013,20 @@ describe('Recipe Lambda handler', () => {
       const input = updateCalls[0].args[0].input
       const expr = input.UpdateExpression as string
 
-      // Both SET (for the coverImage field) and REMOVE (for imageStatus entry) live in the same expression.
       expect(expr).toMatch(/\bSET\b/)
       expect(expr).toMatch(/\bREMOVE\b/)
       expect(expr).toMatch(/REMOVE\s+imageStatus\.#/)
 
-      // An ExpressionAttributeName must point at the dropped old cover key.
       const names = input.ExpressionAttributeNames as Record<string, string>
       const nameValues = Object.values(names)
       expect(nameValues).toContain(oldCoverKey)
 
-      // The name placeholder used in REMOVE must resolve to the old cover key.
       const removeMatch = expr.match(/REMOVE\s+imageStatus\.(#[a-zA-Z0-9_]+)/)
       expect(removeMatch).not.toBeNull()
       const removePlaceholder = removeMatch![1]
       expect(names[removePlaceholder]).toBe(oldCoverKey)
     })
 
-    // AC 2: step-image swap REMOVEs only dropped step image keys; preserved keys stay.
     it('step-image swap REMOVEs imageStatus entries for dropped keys only, preserving kept keys', async () => {
       const oldItem = publishedRecipeItem({
         id: 'recipe-uuid-1',
@@ -2061,7 +2053,6 @@ describe('Recipe Lambda handler', () => {
         rawPath: '/recipes/recipe-uuid-1',
         pathParameters: { id: 'recipe-uuid-1' },
         headers: { authorization: `Bearer ${adminToken}` },
-        // Keep stepC, drop stepA and stepB. Cover unchanged.
         body: JSON.stringify({
           steps: [
             { order: 1, text: 'C', image: { key: stepCKey, alt: 'c' } },
@@ -2081,26 +2072,19 @@ describe('Recipe Lambda handler', () => {
 
       expect(expr).toMatch(/\bREMOVE\b/)
 
-      // Collect every imageStatus.#<placeholder> occurrence in the REMOVE segment.
       const removeSegmentMatch = expr.match(/REMOVE\s+(.+)$/)
       expect(removeSegmentMatch).not.toBeNull()
       const removeSegment = removeSegmentMatch![1]
       const placeholderMatches = Array.from(removeSegment.matchAll(/imageStatus\.(#[a-zA-Z0-9_]+)/g))
       const removedKeys = placeholderMatches.map((m) => names[m[1]])
 
-      // Dropped step keys are REMOVEd.
       expect(removedKeys).toContain(stepAKey)
       expect(removedKeys).toContain(stepBKey)
-      // Preserved step key is NOT REMOVEd.
       expect(removedKeys).not.toContain(stepCKey)
-      // Cover is unchanged — its imageStatus entry must be preserved too.
       expect(removedKeys).not.toContain(oldCoverKey)
       expect(removedKeys).toHaveLength(2)
     })
 
-    // AC 3 + AC 4: client-supplied processedAt on nested coverImage and step.image is
-    // stripped before expression building; the outgoing UpdateCommand carries the cleaned
-    // objects and no value contains a processedAt field.
     it('strips client-supplied processedAt from coverImage and step.image before the UpdateCommand runs', async () => {
       const oldItem = publishedRecipeItem({
         id: 'recipe-uuid-1',
@@ -2112,8 +2096,6 @@ describe('Recipe Lambda handler', () => {
       ddbMock.on(GetCommand).resolves({ Item: oldItem })
       ddbMock.on(UpdateCommand).resolves({ Attributes: oldItem })
 
-      // Same keys — no image swap — so any UpdateExpression values that carry the nested
-      // image objects come straight from the (stripped) request body.
       const event = makeEvent({
         routeKey: 'PATCH /recipes/{id}',
         rawPath: '/recipes/recipe-uuid-1',
@@ -2136,17 +2118,13 @@ describe('Recipe Lambda handler', () => {
       const input = updateCalls[0].args[0].input
       const values = input.ExpressionAttributeValues as Record<string, unknown>
 
-      // AC 4: no ExpressionAttributeValue key exists for a client-supplied processedAt
-      // (i.e. the strip happened on the parsed body before the handler built the expression).
       expect(Object.keys(values)).not.toContain(':processedAt')
 
-      // The nested coverImage value carried in the UpdateCommand must not include processedAt.
       const coverValue = values[':coverImage'] as Record<string, unknown> | undefined
       expect(coverValue).toBeDefined()
       expect(coverValue).not.toHaveProperty('processedAt')
       expect(coverValue).toEqual({ key: oldCoverKey, alt: 'Cover alt' })
 
-      // Each nested step.image carried in the UpdateCommand must not include processedAt.
       const stepsValue = values[':steps'] as Array<{ image?: Record<string, unknown> }> | undefined
       expect(stepsValue).toBeDefined()
       expect(stepsValue).toHaveLength(1)

--- a/test/lambda/recipe-handler.test.ts
+++ b/test/lambda/recipe-handler.test.ts
@@ -642,7 +642,6 @@ describe('Recipe Lambda handler', () => {
     })
   })
 
-  // ─── GET /recipes/admin/{id} — admin single recipe ──────────────────
   describe('GET /recipes/admin/{id} — admin single recipe', () => {
     it('returns 401 without a JWT', async () => {
       const event = makeEvent({
@@ -657,7 +656,6 @@ describe('Recipe Lambda handler', () => {
       expect(result.statusCode).toBe(401)
       const body = JSON.parse(result.body as string)
       expect(body).toHaveProperty('error')
-      // The handler must not touch DDB when the caller is unauthenticated.
       expect(ddbMock.commandCalls(GetCommand)).toHaveLength(0)
     })
 
@@ -692,8 +690,6 @@ describe('Recipe Lambda handler', () => {
       expect(result.statusCode).toBe(404)
       const body = JSON.parse(result.body as string)
       expect(body).toHaveProperty('error')
-      // Admin single-recipe lookup is by id, so a GetCommand (not a Scan or Query) is the
-      // right access pattern.
       const getCalls = ddbMock.commandCalls(GetCommand)
       expect(getCalls).toHaveLength(1)
       expect(getCalls[0].args[0].input.Key).toEqual({ id: 'missing-id' })
@@ -716,11 +712,9 @@ describe('Recipe Lambda handler', () => {
       const body = JSON.parse(result.body as string)
       expect(body.id).toBe('recipe-uuid-1')
       expect(body.status).toBe('published')
-      // Full recipe (not a lightweight projection) — admin detail view.
       expect(body).toHaveProperty('intro')
       expect(body).toHaveProperty('ingredients')
       expect(body).toHaveProperty('steps')
-      // Tags Set has been converted to array form.
       expect(Array.isArray(body.tags)).toBe(true)
     })
 
@@ -737,8 +731,6 @@ describe('Recipe Lambda handler', () => {
 
       const result = await handler(event)
 
-      // Distinct from the public GET /recipes/{slug} which 404s on drafts — the admin
-      // endpoint must return drafts as well as published items.
       expect(result.statusCode).toBe(200)
       const body = JSON.parse(result.body as string)
       expect(body.id).toBe('draft-id')
@@ -771,11 +763,9 @@ describe('Recipe Lambda handler', () => {
       const result = await handler(event)
 
       expect(result.statusCode).toBe(200)
-      // imageStatus is an internal attribute — it must never leak into responses.
       expect(result.body).not.toContain('imageStatus')
       const body = JSON.parse(result.body as string)
       expect(body).not.toHaveProperty('imageStatus')
-      // processedAt is composed onto cover and each step image with a matching entry.
       expect(body.coverImage).toEqual({ key: coverKey, alt: 'A bowl of lamb ragu', processedAt: coverTs })
       expect(body.steps[0].image).toEqual({ key: step1Key, alt: 'seared lamb', processedAt: step1Ts })
     })

--- a/test/lambda/recipe-handler.test.ts
+++ b/test/lambda/recipe-handler.test.ts
@@ -642,6 +642,145 @@ describe('Recipe Lambda handler', () => {
     })
   })
 
+  // ─── GET /recipes/admin/{id} — admin single recipe ──────────────────
+  describe('GET /recipes/admin/{id} — admin single recipe', () => {
+    it('returns 401 without a JWT', async () => {
+      const event = makeEvent({
+        routeKey: 'GET /recipes/admin/{id}',
+        rawPath: '/recipes/admin/recipe-uuid-1',
+        pathParameters: { id: 'recipe-uuid-1' },
+        headers: {},
+      })
+
+      const result = await handler(event)
+
+      expect(result.statusCode).toBe(401)
+      const body = JSON.parse(result.body as string)
+      expect(body).toHaveProperty('error')
+      // The handler must not touch DDB when the caller is unauthenticated.
+      expect(ddbMock.commandCalls(GetCommand)).toHaveLength(0)
+    })
+
+    it('returns 403 when the caller is not in the admin group', async () => {
+      const event = makeEvent({
+        routeKey: 'GET /recipes/admin/{id}',
+        rawPath: '/recipes/admin/recipe-uuid-1',
+        pathParameters: { id: 'recipe-uuid-1' },
+        headers: { authorization: `Bearer ${contributorToken}` },
+      })
+
+      const result = await handler(event)
+
+      expect(result.statusCode).toBe(403)
+      const body = JSON.parse(result.body as string)
+      expect(body).toHaveProperty('error')
+      expect(ddbMock.commandCalls(GetCommand)).toHaveLength(0)
+    })
+
+    it('returns 404 when the recipe does not exist', async () => {
+      ddbMock.on(GetCommand).resolves({ Item: undefined })
+
+      const event = makeEvent({
+        routeKey: 'GET /recipes/admin/{id}',
+        rawPath: '/recipes/admin/missing-id',
+        pathParameters: { id: 'missing-id' },
+        headers: { authorization: `Bearer ${adminToken}` },
+      })
+
+      const result = await handler(event)
+
+      expect(result.statusCode).toBe(404)
+      const body = JSON.parse(result.body as string)
+      expect(body).toHaveProperty('error')
+      // Admin single-recipe lookup is by id, so a GetCommand (not a Scan or Query) is the
+      // right access pattern.
+      const getCalls = ddbMock.commandCalls(GetCommand)
+      expect(getCalls).toHaveLength(1)
+      expect(getCalls[0].args[0].input.Key).toEqual({ id: 'missing-id' })
+    })
+
+    it('returns 200 with a published recipe for admin', async () => {
+      const item = publishedRecipeItem({ id: 'recipe-uuid-1' })
+      ddbMock.on(GetCommand).resolves({ Item: item })
+
+      const event = makeEvent({
+        routeKey: 'GET /recipes/admin/{id}',
+        rawPath: '/recipes/admin/recipe-uuid-1',
+        pathParameters: { id: 'recipe-uuid-1' },
+        headers: { authorization: `Bearer ${adminToken}` },
+      })
+
+      const result = await handler(event)
+
+      expect(result.statusCode).toBe(200)
+      const body = JSON.parse(result.body as string)
+      expect(body.id).toBe('recipe-uuid-1')
+      expect(body.status).toBe('published')
+      // Full recipe (not a lightweight projection) — admin detail view.
+      expect(body).toHaveProperty('intro')
+      expect(body).toHaveProperty('ingredients')
+      expect(body).toHaveProperty('steps')
+      // Tags Set has been converted to array form.
+      expect(Array.isArray(body.tags)).toBe(true)
+    })
+
+    it('returns 200 with a draft recipe for admin (not filtered by status)', async () => {
+      const draft = draftRecipeItem({ id: 'draft-id', slug: 'my-draft', title: 'My Draft' })
+      ddbMock.on(GetCommand).resolves({ Item: draft })
+
+      const event = makeEvent({
+        routeKey: 'GET /recipes/admin/{id}',
+        rawPath: '/recipes/admin/draft-id',
+        pathParameters: { id: 'draft-id' },
+        headers: { authorization: `Bearer ${adminToken}` },
+      })
+
+      const result = await handler(event)
+
+      // Distinct from the public GET /recipes/{slug} which 404s on drafts — the admin
+      // endpoint must return drafts as well as published items.
+      expect(result.statusCode).toBe(200)
+      const body = JSON.parse(result.body as string)
+      expect(body.id).toBe('draft-id')
+      expect(body.status).toBe('draft')
+    })
+
+    it('composes processedAt onto images and strips imageStatus from the response body', async () => {
+      const coverKey = 'processed/recipes/recipe-uuid-1/cover'
+      const step1Key = 'processed/recipes/recipe-uuid-1/step-1'
+      const coverTs = 1_745_000_000_001
+      const step1Ts = 1_745_000_000_002
+
+      const item = publishedRecipeItem({
+        id: 'recipe-uuid-1',
+        coverImage: { key: coverKey, alt: 'A bowl of lamb ragu' },
+        steps: [
+          { order: 1, text: 'Sear.', image: { key: step1Key, alt: 'seared lamb' } },
+        ],
+        imageStatus: { [coverKey]: coverTs, [step1Key]: step1Ts },
+      })
+      ddbMock.on(GetCommand).resolves({ Item: item })
+
+      const event = makeEvent({
+        routeKey: 'GET /recipes/admin/{id}',
+        rawPath: '/recipes/admin/recipe-uuid-1',
+        pathParameters: { id: 'recipe-uuid-1' },
+        headers: { authorization: `Bearer ${adminToken}` },
+      })
+
+      const result = await handler(event)
+
+      expect(result.statusCode).toBe(200)
+      // imageStatus is an internal attribute — it must never leak into responses.
+      expect(result.body).not.toContain('imageStatus')
+      const body = JSON.parse(result.body as string)
+      expect(body).not.toHaveProperty('imageStatus')
+      // processedAt is composed onto cover and each step image with a matching entry.
+      expect(body.coverImage).toEqual({ key: coverKey, alt: 'A bowl of lamb ragu', processedAt: coverTs })
+      expect(body.steps[0].image).toEqual({ key: step1Key, alt: 'seared lamb', processedAt: step1Ts })
+    })
+  })
+
   // ─── PATCH /recipes/{id} — update recipe ────────────────────────────
   describe('PATCH /recipes/{id} — update recipe', () => {
     it('returns 200 when contributor updates their own recipe', async () => {

--- a/test/lambda/recipe-handler.test.ts
+++ b/test/lambda/recipe-handler.test.ts
@@ -1284,6 +1284,201 @@ describe('Recipe Lambda handler', () => {
       })
     })
 
+    // ─── Publish readiness validation (issue #109) ────────────────────
+    describe('readiness validation — rejects recipes with unready images', () => {
+      const coverKey = 'processed/recipes/recipe-uuid-1/cover'
+      const step1Key = 'processed/recipes/recipe-uuid-1/step-1'
+      const step2Key = 'processed/recipes/recipe-uuid-1/step-2'
+      const coverTs = 1_745_000_000_001
+      const step1Ts = 1_745_000_000_002
+      const step2Ts = 1_745_000_000_003
+
+      function publishEvent() {
+        return makeEvent({
+          routeKey: 'PATCH /recipes/{id}/publish',
+          rawPath: '/recipes/recipe-uuid-1/publish',
+          pathParameters: { id: 'recipe-uuid-1' },
+          headers: { authorization: `Bearer ${adminToken}` },
+        })
+      }
+
+      // AC 1, AC 6 (cover-unready alone)
+      it('returns 400 with errors.coverImage.processedAt when cover key has no imageStatus entry (steps either absent or fully ready)', async () => {
+        ddbMock.on(GetCommand).resolves({
+          Item: draftRecipeItem({
+            authorId: 'contributor-user-id',
+            coverImage: { key: coverKey, alt: 'A bowl of lamb ragu' },
+            steps: [
+              { order: 1, text: 'Sear.', image: { key: step1Key, alt: 'seared' } },
+            ],
+            // cover key missing from imageStatus → unready cover
+            imageStatus: { [step1Key]: step1Ts },
+          }),
+        })
+        // Fallback to ensure a failure-to-reject returns 200 (not 500 from a
+        // missing UpdateCommand mock) so the failure signal is unambiguous.
+        ddbMock.on(UpdateCommand).resolves({
+          Attributes: publishedRecipeItem({ authorId: 'contributor-user-id' }),
+        })
+
+        const result = await handler(publishEvent())
+
+        expect(result.statusCode).toBe(400)
+        const body = JSON.parse(result.body as string)
+        expect(body.errors).toBeDefined()
+        expect(body.errors.coverImage).toBeDefined()
+        expect(body.errors.coverImage.processedAt).toBe('Cover image still processing')
+        expect(body.errors).not.toHaveProperty('stepImages')
+      })
+
+      // AC 2, AC 6 (step-unready alone)
+      it('returns 400 with errors.stepImages for each step whose image key has no imageStatus entry (cover ready)', async () => {
+        ddbMock.on(GetCommand).resolves({
+          Item: draftRecipeItem({
+            authorId: 'contributor-user-id',
+            coverImage: { key: coverKey, alt: 'A bowl of lamb ragu' },
+            steps: [
+              { order: 1, text: 'Sear.', image: { key: step1Key, alt: 'seared' } },
+              { order: 2, text: 'Simmer.', image: { key: step2Key, alt: 'simmering' } },
+            ],
+            // cover + step 1 ready; step 2 unready
+            imageStatus: { [coverKey]: coverTs, [step1Key]: step1Ts },
+          }),
+        })
+        ddbMock.on(UpdateCommand).resolves({
+          Attributes: publishedRecipeItem({ authorId: 'contributor-user-id' }),
+        })
+
+        const result = await handler(publishEvent())
+
+        expect(result.statusCode).toBe(400)
+        const body = JSON.parse(result.body as string)
+        expect(body.errors).toBeDefined()
+        expect(body.errors).not.toHaveProperty('coverImage')
+        expect(body.errors.stepImages).toEqual([
+          { order: 2, processedAt: 'Step image still processing' },
+        ])
+      })
+
+      // AC 1, AC 2, AC 6 (both)
+      it('returns 400 with both errors.coverImage.processedAt and errors.stepImages when cover and step images are unready', async () => {
+        ddbMock.on(GetCommand).resolves({
+          Item: draftRecipeItem({
+            authorId: 'contributor-user-id',
+            coverImage: { key: coverKey, alt: 'A bowl of lamb ragu' },
+            steps: [
+              { order: 1, text: 'Sear.', image: { key: step1Key, alt: 'seared' } },
+              { order: 2, text: 'Simmer.', image: { key: step2Key, alt: 'simmering' } },
+            ],
+            imageStatus: {},
+          }),
+        })
+        ddbMock.on(UpdateCommand).resolves({
+          Attributes: publishedRecipeItem({ authorId: 'contributor-user-id' }),
+        })
+
+        const result = await handler(publishEvent())
+
+        expect(result.statusCode).toBe(400)
+        const body = JSON.parse(result.body as string)
+        expect(body.errors.coverImage.processedAt).toBe('Cover image still processing')
+        expect(body.errors.stepImages).toEqual([
+          { order: 1, processedAt: 'Step image still processing' },
+          { order: 2, processedAt: 'Step image still processing' },
+        ])
+      })
+
+      // AC 4, AC 6 (readiness + other validation error)
+      it('returns 400 with readiness errors coexisting with other validation errors (e.g. missing title)', async () => {
+        ddbMock.on(GetCommand).resolves({
+          Item: draftRecipeItem({
+            authorId: 'contributor-user-id',
+            title: '', // triggers existing `errors.title`
+            coverImage: { key: coverKey, alt: 'A bowl of lamb ragu' },
+            imageStatus: {}, // cover unready
+          }),
+        })
+
+        const result = await handler(publishEvent())
+
+        expect(result.statusCode).toBe(400)
+        const body = JSON.parse(result.body as string)
+        // Existing title validation still fires
+        expect(body.errors).toHaveProperty('title')
+        // Readiness error coexists on the same response
+        expect(body.errors.coverImage).toBeDefined()
+        expect(body.errors.coverImage.processedAt).toBe('Cover image still processing')
+      })
+
+      // AC 5, AC 6 (republish with unready swapped image)
+      it('returns 400 when republishing a currently-published recipe whose cover was swapped to an unready new key', async () => {
+        const oldCoverKey = 'processed/recipes/recipe-uuid-1/cover-old'
+        const newCoverKey = 'processed/recipes/recipe-uuid-1/cover'
+        ddbMock.on(GetCommand).resolves({
+          Item: publishedRecipeItem({
+            authorId: 'contributor-user-id',
+            // Item is currently published — a cover swap landed via autosave PATCH,
+            // and the resizer hasn't yet written the new key's imageStatus entry.
+            coverImage: { key: newCoverKey, alt: 'New cover' },
+            // imageStatus still holds only the OLD key's timestamp
+            imageStatus: { [oldCoverKey]: coverTs },
+          }),
+        })
+
+        const result = await handler(publishEvent())
+
+        expect(result.statusCode).toBe(400)
+        const body = JSON.parse(result.body as string)
+        expect(body.errors).toBeDefined()
+        expect(body.errors.coverImage).toBeDefined()
+        expect(body.errors.coverImage.processedAt).toBe('Cover image still processing')
+      })
+
+      // AC 3 (preserve existing errors.steps string shape)
+      it('preserves the existing errors.steps string shape when steps have empty text (does NOT restructure into stepImages)', async () => {
+        ddbMock.on(GetCommand).resolves({
+          Item: draftRecipeItem({
+            authorId: 'contributor-user-id',
+            coverImage: { key: coverKey, alt: 'A bowl of lamb ragu' },
+            steps: [{ order: 1, text: '' }, { order: 2, text: '   ' }],
+            imageStatus: { [coverKey]: coverTs },
+          }),
+        })
+
+        const result = await handler(publishEvent())
+
+        expect(result.statusCode).toBe(400)
+        const body = JSON.parse(result.body as string)
+        // existing empty-text error is a string under `steps` — shape unchanged
+        expect(body.errors).toHaveProperty('steps')
+        expect(typeof body.errors.steps).toBe('string')
+        // readiness errors must NOT be smuggled into the `steps` key
+        expect(body.errors.steps).not.toEqual(expect.any(Array))
+      })
+
+      // Positive control: a recipe with every image ready publishes successfully.
+      it('publishes successfully when every image key has a matching imageStatus entry', async () => {
+        ddbMock.on(GetCommand).resolves({
+          Item: draftRecipeItem({
+            authorId: 'contributor-user-id',
+            coverImage: { key: coverKey, alt: 'A bowl of lamb ragu' },
+            steps: [
+              { order: 1, text: 'Sear.', image: { key: step1Key, alt: 'seared' } },
+              { order: 2, text: 'Simmer.', image: { key: step2Key, alt: 'simmering' } },
+            ],
+            imageStatus: { [coverKey]: coverTs, [step1Key]: step1Ts, [step2Key]: step2Ts },
+          }),
+        })
+        ddbMock.on(UpdateCommand).resolves({
+          Attributes: publishedRecipeItem({ authorId: 'contributor-user-id' }),
+        })
+
+        const result = await handler(publishEvent())
+
+        expect(result.statusCode).toBe(200)
+      })
+    })
+
     it('returns 200 (no-op) when publishing an already-published recipe that still passes validation', async () => {
       ddbMock.on(GetCommand).resolves({
         Item: publishedRecipeItem({ authorId: 'contributor-user-id' }),

--- a/test/recipe-stack.test.ts
+++ b/test/recipe-stack.test.ts
@@ -376,66 +376,25 @@ describe('RecipeStack', () => {
     })
 
     it('does not grant dynamodb:PutItem, dynamodb:DeleteItem, or dynamodb:Scan on the image-resizer role', () => {
-      template.hasResourceProperties('AWS::IAM::Policy', {
-        Roles: Match.arrayWith([
-          { Ref: Match.stringLikeRegexp('^ImageResizerServiceRole.*') },
-        ]),
-        PolicyDocument: Match.objectLike({
-          Statement: Match.not(Match.arrayWith([
-            Match.objectLike({ Action: Match.arrayWith(['dynamodb:PutItem']) }),
-          ])),
-        }),
-      })
-      template.hasResourceProperties('AWS::IAM::Policy', {
-        Roles: Match.arrayWith([
-          { Ref: Match.stringLikeRegexp('^ImageResizerServiceRole.*') },
-        ]),
-        PolicyDocument: Match.objectLike({
-          Statement: Match.not(Match.arrayWith([
-            Match.objectLike({ Action: 'dynamodb:PutItem' }),
-          ])),
-        }),
-      })
-      template.hasResourceProperties('AWS::IAM::Policy', {
-        Roles: Match.arrayWith([
-          { Ref: Match.stringLikeRegexp('^ImageResizerServiceRole.*') },
-        ]),
-        PolicyDocument: Match.objectLike({
-          Statement: Match.not(Match.arrayWith([
-            Match.objectLike({ Action: Match.arrayWith(['dynamodb:DeleteItem']) }),
-          ])),
-        }),
-      })
-      template.hasResourceProperties('AWS::IAM::Policy', {
-        Roles: Match.arrayWith([
-          { Ref: Match.stringLikeRegexp('^ImageResizerServiceRole.*') },
-        ]),
-        PolicyDocument: Match.objectLike({
-          Statement: Match.not(Match.arrayWith([
-            Match.objectLike({ Action: 'dynamodb:DeleteItem' }),
-          ])),
-        }),
-      })
-      template.hasResourceProperties('AWS::IAM::Policy', {
-        Roles: Match.arrayWith([
-          { Ref: Match.stringLikeRegexp('^ImageResizerServiceRole.*') },
-        ]),
-        PolicyDocument: Match.objectLike({
-          Statement: Match.not(Match.arrayWith([
-            Match.objectLike({ Action: Match.arrayWith(['dynamodb:Scan']) }),
-          ])),
-        }),
-      })
-      template.hasResourceProperties('AWS::IAM::Policy', {
-        Roles: Match.arrayWith([
-          { Ref: Match.stringLikeRegexp('^ImageResizerServiceRole.*') },
-        ]),
-        PolicyDocument: Match.objectLike({
-          Statement: Match.not(Match.arrayWith([
-            Match.objectLike({ Action: 'dynamodb:Scan' }),
-          ])),
-        }),
-      })
+      const assertResizerLacks = (action: string) => {
+        // CDK consolidates actions into either a string or string[] — assert both forms.
+        for (const actionMatcher of [action, Match.arrayWith([action])]) {
+          template.hasResourceProperties('AWS::IAM::Policy', {
+            Roles: Match.arrayWith([
+              { Ref: Match.stringLikeRegexp('^ImageResizerServiceRole.*') },
+            ]),
+            PolicyDocument: Match.objectLike({
+              Statement: Match.not(Match.arrayWith([
+                Match.objectLike({ Action: actionMatcher }),
+              ])),
+            }),
+          })
+        }
+      }
+
+      for (const action of ['dynamodb:PutItem', 'dynamodb:DeleteItem', 'dynamodb:Scan']) {
+        assertResizerLacks(action)
+      }
     })
   })
 

--- a/test/recipe-stack.test.ts
+++ b/test/recipe-stack.test.ts
@@ -317,6 +317,69 @@ describe('RecipeStack', () => {
         RouteKey: 'POST /recipes',
       }, 0)
     })
+
+    // ─── GET /recipes/admin/{id} — admin single-recipe route ──────────
+    describe('GET /recipes/admin/{id} — admin single recipe', () => {
+      it('has a GET /recipes/admin/{id} route with AuthorizationType: JWT', () => {
+        template.hasResourceProperties('AWS::ApiGatewayV2::Route', Match.objectLike({
+          RouteKey: 'GET /recipes/admin/{id}',
+          AuthorizationType: 'JWT',
+          AuthorizerId: Match.anyValue(),
+        }))
+      })
+
+      it('points the GET /recipes/admin/{id} route at the recipe handler integration', () => {
+        // The Target is a CloudFormation Fn::Join of "integrations/" + the integration ref.
+        // We match the structure loosely so the test only breaks if the integration wiring
+        // itself changes — not on unrelated template-shape shifts.
+        const routes = template.findResources('AWS::ApiGatewayV2::Route', {
+          Properties: Match.objectLike({ RouteKey: 'GET /recipes/admin/{id}' }),
+        })
+        const routeEntries = Object.values(routes)
+        expect(routeEntries).toHaveLength(1)
+        const target = (routeEntries[0] as { Properties: { Target: unknown } }).Properties.Target
+        // The target string embeds the recipe integration's logical id — assert it resolves
+        // to the RecipeHandlerIntegration, not the RecipeImageHandlerIntegration.
+        const serialised = JSON.stringify(target)
+        expect(serialised).toMatch(/RecipeHandlerIntegration/)
+        expect(serialised).not.toMatch(/RecipeImageHandlerIntegration/)
+      })
+
+      it('does not add a new AWS::Lambda::Permission resource for the new route', () => {
+        // The existing recipeHandler.addPermission('ApiGatewayInvoke', ...) uses a wildcard
+        // sourceArn ending in "/*/*", which covers every route on the API. Adding a new
+        // route must NOT introduce another Lambda::Permission resource.
+        //
+        // Baseline permissions today (3 total):
+        //   1. RecipeImagesBucket → ImageResizer (S3 notification invocation)
+        //   2. RecipeHandler → ApiGateway invoke (sourceArn ".../*/*")
+        //   3. RecipeImageHandler → ApiGateway invoke (sourceArn ".../*/*")
+        //
+        // If the implementation agent adds a new Permission for this route, this count
+        // ticks to 4 and this assertion fails.
+        const permissions = template.findResources('AWS::Lambda::Permission')
+        expect(Object.keys(permissions)).toHaveLength(3)
+      })
+
+      it('the existing RecipeHandler ApiGateway permission uses a wildcard sourceArn ending in /*/*', () => {
+        // Defence in depth for AC 6: even if someone changed the permission count for an
+        // unrelated reason, the wildcard sourceArn on the recipe handler is what makes a
+        // per-route Permission unnecessary.
+        template.hasResourceProperties('AWS::Lambda::Permission', Match.objectLike({
+          Action: 'lambda:InvokeFunction',
+          Principal: 'apigateway.amazonaws.com',
+          FunctionName: Match.objectLike({
+            'Fn::GetAtt': Match.arrayWith([Match.stringLikeRegexp('^RecipeHandler.*')]),
+          }),
+          SourceArn: {
+            'Fn::Join': [
+              '',
+              Match.arrayWith(['/*/*']),
+            ],
+          },
+        }))
+      })
+    })
   })
 
   describe('IAM — recipe handler role', () => {

--- a/test/recipe-stack.test.ts
+++ b/test/recipe-stack.test.ts
@@ -346,6 +346,99 @@ describe('RecipeStack', () => {
     })
   })
 
+  describe('IAM — image-resizer role', () => {
+    it('image-resizer Lambda environment includes TABLE_NAME set to the recipes table name', () => {
+      template.hasResourceProperties('AWS::Lambda::Function', Match.objectLike({
+        FunctionName: 'akli-image-resizer',
+        Environment: {
+          Variables: Match.objectLike({
+            TABLE_NAME: { Ref: Match.stringLikeRegexp('^RecipesTable.*') },
+          }),
+        },
+      }))
+    })
+
+    it('grants dynamodb:UpdateItem on the recipes table ARN', () => {
+      template.hasResourceProperties('AWS::IAM::Policy', {
+        Roles: Match.arrayWith([
+          { Ref: Match.stringLikeRegexp('^ImageResizerServiceRole.*') },
+        ]),
+        PolicyDocument: Match.objectLike({
+          Statement: Match.arrayWith([
+            Match.objectLike({
+              Action: 'dynamodb:UpdateItem',
+              Effect: 'Allow',
+              Resource: { 'Fn::GetAtt': [Match.stringLikeRegexp('^RecipesTable.*'), 'Arn'] },
+            }),
+          ]),
+        }),
+      })
+    })
+
+    it('does not grant dynamodb:PutItem, dynamodb:DeleteItem, or dynamodb:Scan on the image-resizer role', () => {
+      template.hasResourceProperties('AWS::IAM::Policy', {
+        Roles: Match.arrayWith([
+          { Ref: Match.stringLikeRegexp('^ImageResizerServiceRole.*') },
+        ]),
+        PolicyDocument: Match.objectLike({
+          Statement: Match.not(Match.arrayWith([
+            Match.objectLike({ Action: Match.arrayWith(['dynamodb:PutItem']) }),
+          ])),
+        }),
+      })
+      template.hasResourceProperties('AWS::IAM::Policy', {
+        Roles: Match.arrayWith([
+          { Ref: Match.stringLikeRegexp('^ImageResizerServiceRole.*') },
+        ]),
+        PolicyDocument: Match.objectLike({
+          Statement: Match.not(Match.arrayWith([
+            Match.objectLike({ Action: 'dynamodb:PutItem' }),
+          ])),
+        }),
+      })
+      template.hasResourceProperties('AWS::IAM::Policy', {
+        Roles: Match.arrayWith([
+          { Ref: Match.stringLikeRegexp('^ImageResizerServiceRole.*') },
+        ]),
+        PolicyDocument: Match.objectLike({
+          Statement: Match.not(Match.arrayWith([
+            Match.objectLike({ Action: Match.arrayWith(['dynamodb:DeleteItem']) }),
+          ])),
+        }),
+      })
+      template.hasResourceProperties('AWS::IAM::Policy', {
+        Roles: Match.arrayWith([
+          { Ref: Match.stringLikeRegexp('^ImageResizerServiceRole.*') },
+        ]),
+        PolicyDocument: Match.objectLike({
+          Statement: Match.not(Match.arrayWith([
+            Match.objectLike({ Action: 'dynamodb:DeleteItem' }),
+          ])),
+        }),
+      })
+      template.hasResourceProperties('AWS::IAM::Policy', {
+        Roles: Match.arrayWith([
+          { Ref: Match.stringLikeRegexp('^ImageResizerServiceRole.*') },
+        ]),
+        PolicyDocument: Match.objectLike({
+          Statement: Match.not(Match.arrayWith([
+            Match.objectLike({ Action: Match.arrayWith(['dynamodb:Scan']) }),
+          ])),
+        }),
+      })
+      template.hasResourceProperties('AWS::IAM::Policy', {
+        Roles: Match.arrayWith([
+          { Ref: Match.stringLikeRegexp('^ImageResizerServiceRole.*') },
+        ]),
+        PolicyDocument: Match.objectLike({
+          Statement: Match.not(Match.arrayWith([
+            Match.objectLike({ Action: 'dynamodb:Scan' }),
+          ])),
+        }),
+      })
+    })
+  })
+
   describe('JWT Authoriser', () => {
     it('creates a JWT authoriser', () => {
       template.hasResourceProperties('AWS::ApiGatewayV2::Authorizer', {

--- a/test/recipe-stack.test.ts
+++ b/test/recipe-stack.test.ts
@@ -318,7 +318,6 @@ describe('RecipeStack', () => {
       }, 0)
     })
 
-    // ─── GET /recipes/admin/{id} — admin single-recipe route ──────────
     describe('GET /recipes/admin/{id} — admin single recipe', () => {
       it('has a GET /recipes/admin/{id} route with AuthorizationType: JWT', () => {
         template.hasResourceProperties('AWS::ApiGatewayV2::Route', Match.objectLike({
@@ -329,42 +328,26 @@ describe('RecipeStack', () => {
       })
 
       it('points the GET /recipes/admin/{id} route at the recipe handler integration', () => {
-        // The Target is a CloudFormation Fn::Join of "integrations/" + the integration ref.
-        // We match the structure loosely so the test only breaks if the integration wiring
-        // itself changes — not on unrelated template-shape shifts.
         const routes = template.findResources('AWS::ApiGatewayV2::Route', {
           Properties: Match.objectLike({ RouteKey: 'GET /recipes/admin/{id}' }),
         })
         const routeEntries = Object.values(routes)
         expect(routeEntries).toHaveLength(1)
         const target = (routeEntries[0] as { Properties: { Target: unknown } }).Properties.Target
-        // The target string embeds the recipe integration's logical id — assert it resolves
-        // to the RecipeHandlerIntegration, not the RecipeImageHandlerIntegration.
         const serialised = JSON.stringify(target)
         expect(serialised).toMatch(/RecipeHandlerIntegration/)
         expect(serialised).not.toMatch(/RecipeImageHandlerIntegration/)
       })
 
       it('does not add a new AWS::Lambda::Permission resource for the new route', () => {
-        // The existing recipeHandler.addPermission('ApiGatewayInvoke', ...) uses a wildcard
-        // sourceArn ending in "/*/*", which covers every route on the API. Adding a new
-        // route must NOT introduce another Lambda::Permission resource.
-        //
-        // Baseline permissions today (3 total):
-        //   1. RecipeImagesBucket → ImageResizer (S3 notification invocation)
-        //   2. RecipeHandler → ApiGateway invoke (sourceArn ".../*/*")
-        //   3. RecipeImageHandler → ApiGateway invoke (sourceArn ".../*/*")
-        //
-        // If the implementation agent adds a new Permission for this route, this count
-        // ticks to 4 and this assertion fails.
+        // Existing permissions: RecipeImagesBucket→ImageResizer,
+        // RecipeHandler→ApiGateway, RecipeImageHandler→ApiGateway.
+        // The recipe handler's wildcard /*/* sourceArn covers every route.
         const permissions = template.findResources('AWS::Lambda::Permission')
         expect(Object.keys(permissions)).toHaveLength(3)
       })
 
       it('the existing RecipeHandler ApiGateway permission uses a wildcard sourceArn ending in /*/*', () => {
-        // Defence in depth for AC 6: even if someone changed the permission count for an
-        // unrelated reason, the wildcard sourceArn on the recipe handler is what makes a
-        // per-route Permission unnecessary.
         template.hasResourceProperties('AWS::Lambda::Permission', Match.objectLike({
           Action: 'lambda:InvokeFunction',
           Principal: 'apigateway.amazonaws.com',


### PR DESCRIPTION
Closes #112

## What shipped
End-to-end readiness pipeline for recipe images: the resizer records `imageStatus` in DynamoDB after variant generation, the publish guard rejects recipes with unready images, PATCH cleans up orphan entries on image-swap, and a new admin single-recipe endpoint lets the frontend poll cheaply for readiness transitions.

### Issues in this milestone
- **#104** — wire resizer Lambda to the recipes DDB table (narrow IAM grant)
- **#105** — initialise `imageStatus` on draft creation
- **#106** — resizer write-back: update `imageStatus` after variant PUTs
- **#107** — response composition: expose `processedAt` on every recipe-returning route and strip `imageStatus`
- **#108** — add `GET /recipes/admin/{id}` admin single-recipe endpoint
- **#109** — publish validation rejects recipes with unready images (`errors.coverImage.processedAt`, `errors.stepImages`)
- **#110** — PATCH image-swap REMOVEs orphan `imageStatus` entries and strips client-supplied `processedAt`
- **#111** — Manual QA: deployed, end-to-end happy path verified, publish-guard and race-test confirmed

## Why
The frontend needs to know when an uploaded image is ready to serve so it can flip the UI from a "still processing" state to the real image, and the backend must refuse to publish recipes whose images aren't ready — otherwise a stale tab or a direct API call could ship broken URLs. See `docs/prds/image-processing-readiness.md` for the full spec.

## Verification
- `pnpm test` → 320 passing across 14 suites.
- `pnpm lint` clean.
- `cdk diff --all` reviewed; `cdk deploy --all` succeeded.
- End-to-end QA via the frontend (upload → resizer write-back → frontend poll → publish-guard → race test → step-image-swap cleanup) all green.

## Version bump
`1.6.0 → 1.7.0` (minor — new features: readiness pipeline, new admin endpoint, new server-side validation).

## Decisions made
- `imageStatus` is an internal attribute never exposed in responses — composition happens in `convertRecipeTags`, which strips the field before returning.
- Cover-image readiness lives under `errors.coverImage.processedAt` (nested), step-image readiness lives under `errors.stepImages` (array of `{ order, processedAt }`) — keeps the existing `errors.steps` empty-text contract binary-compatible.
- `imageStatus[key] === undefined` (not a truthy check) so a `0` timestamp counts as ready — guards against a future regression around falsy-but-valid timestamps.
- New admin route needs no new `Lambda::Permission` — the existing wildcard `/*/*` sourceArn already covers it.