### PR TITLE
Add dedicated ImagesCert to CertificateStack

### DIFF
--- a/lib/certificate-stack.ts
+++ b/lib/certificate-stack.ts
@@ -1,5 +1,5 @@
 import type { StackProps } from 'aws-cdk-lib';
-import { Stack } from 'aws-cdk-lib'
+import { CfnOutput, Stack } from 'aws-cdk-lib'
 import * as certificatemanager from 'aws-cdk-lib/aws-certificatemanager'
 import * as route53 from 'aws-cdk-lib/aws-route53'
 import type { Construct } from 'constructs'
@@ -7,6 +7,7 @@ import type { Construct } from 'constructs'
 const DOMAIN_NAME = 'akli.dev'
 const WWW_DOMAIN_NAME = `www.${DOMAIN_NAME}`
 const API_DOMAIN_NAME = `api.${DOMAIN_NAME}`
+const IMAGES_DOMAIN_NAME = `images.${DOMAIN_NAME}`
 
 /**
  * Separate stack for ACM certificates and Route 53 hosted zone.
@@ -17,6 +18,7 @@ export class CertificateStack extends Stack {
   public readonly hostedZone: route53.HostedZone
   public readonly certificate: certificatemanager.Certificate
   public readonly apiCertificate: certificatemanager.Certificate
+  public readonly imagesCertificate: certificatemanager.Certificate
 
   constructor(scope: Construct, id: string, props?: StackProps) {
     super(scope, id, props)
@@ -36,6 +38,18 @@ export class CertificateStack extends Stack {
     this.apiCertificate = new certificatemanager.Certificate(this, 'ApiCert', {
       domainName: API_DOMAIN_NAME,
       validation: certificatemanager.CertificateValidation.fromDns(this.hostedZone),
+    })
+
+    // Dedicated certificate for images.akli.dev — separate cert avoids replacing SiteCert (which would
+    // break cross-region SSM exports consumed by AkliInfrastructureStack). See images-cdn-phase-1 PRD.
+    this.imagesCertificate = new certificatemanager.Certificate(this, 'ImagesCert', {
+      domainName: IMAGES_DOMAIN_NAME,
+      validation: certificatemanager.CertificateValidation.fromDns(this.hostedZone),
+    })
+
+    new CfnOutput(this, 'ImagesCertArn', {
+      value: this.imagesCertificate.certificateArn,
+      description: 'ACM certificate ARN for images.akli.dev (consumed cross-region by ImagesStack)',
     })
   }
 }

--- a/lib/certificate-stack.ts
+++ b/lib/certificate-stack.ts
@@ -1,5 +1,5 @@
 import type { StackProps } from 'aws-cdk-lib';
-import { CfnOutput, Stack } from 'aws-cdk-lib'
+import { Stack } from 'aws-cdk-lib'
 import * as certificatemanager from 'aws-cdk-lib/aws-certificatemanager'
 import * as route53 from 'aws-cdk-lib/aws-route53'
 import type { Construct } from 'constructs'
@@ -40,16 +40,10 @@ export class CertificateStack extends Stack {
       validation: certificatemanager.CertificateValidation.fromDns(this.hostedZone),
     })
 
-    // Dedicated certificate for images.akli.dev — separate cert avoids replacing SiteCert (which would
-    // break cross-region SSM exports consumed by AkliInfrastructureStack). See images-cdn-phase-1 PRD.
+    // Separate certificate for images.akli.dev — avoids replacing the site cert which would break cross-stack exports
     this.imagesCertificate = new certificatemanager.Certificate(this, 'ImagesCert', {
       domainName: IMAGES_DOMAIN_NAME,
       validation: certificatemanager.CertificateValidation.fromDns(this.hostedZone),
-    })
-
-    new CfnOutput(this, 'ImagesCertArn', {
-      value: this.imagesCertificate.certificateArn,
-      description: 'ACM certificate ARN for images.akli.dev (consumed cross-region by ImagesStack)',
     })
   }
 }

--- a/test/certificate-stack.test.ts
+++ b/test/certificate-stack.test.ts
@@ -2,14 +2,17 @@ import * as cdk from 'aws-cdk-lib'
 import { Match, Template } from 'aws-cdk-lib/assertions'
 import { CertificateStack } from '../lib/certificate-stack'
 
-function createTestStack(): Template {
+function createStack(): CertificateStack {
   const app = new cdk.App()
 
-  const stack = new CertificateStack(app, 'TestCertificateStack', {
+  return new CertificateStack(app, 'TestCertificateStack', {
     env: { account: '123456789012', region: 'us-east-1' },
+    crossRegionReferences: true,
   })
+}
 
-  return Template.fromStack(stack)
+function createTestStack(): Template {
+  return Template.fromStack(createStack())
 }
 
 describe('CertificateStack', () => {
@@ -26,6 +29,13 @@ describe('CertificateStack', () => {
         SubjectAlternativeNames: Match.arrayWith(['www.akli.dev']),
       })
     })
+
+    it('does not change the SiteCert domain or subject alternative names (regression guard)', () => {
+      template.hasResourceProperties('AWS::CertificateManager::Certificate', {
+        DomainName: 'akli.dev',
+        SubjectAlternativeNames: ['www.akli.dev'],
+      })
+    })
   })
 
   describe('API certificate', () => {
@@ -33,6 +43,42 @@ describe('CertificateStack', () => {
       template.hasResourceProperties('AWS::CertificateManager::Certificate', {
         DomainName: 'api.akli.dev',
       })
+    })
+  })
+
+  describe('Images certificate', () => {
+    it('creates a dedicated certificate for images.akli.dev with DNS validation', () => {
+      template.hasResourceProperties(
+        'AWS::CertificateManager::Certificate',
+        Match.objectLike({
+          DomainName: 'images.akli.dev',
+          ValidationMethod: 'DNS',
+        }),
+      )
+    })
+
+    it('exports an ImagesCertArn CloudFormation output referencing the new certificate', () => {
+      template.hasOutput(
+        'ImagesCertArn',
+        Match.objectLike({
+          Value: Match.objectLike({ Ref: Match.stringLikeRegexp('^ImagesCert') }),
+        }),
+      )
+    })
+  })
+
+  describe('Certificate count', () => {
+    it('synthesises exactly three ACM certificates (Site, Api, Images)', () => {
+      template.resourceCountIs('AWS::CertificateManager::Certificate', 3)
+    })
+  })
+
+  describe('Cross-region references', () => {
+    it('enables crossRegionReferences on the stack instance', () => {
+      const stack = createStack()
+      // CDK exposes the resolved value as `_crossRegionReferences` on the Stack instance
+      // (the public `crossRegionReferences` is on StackProps, the input).
+      expect(stack._crossRegionReferences).toBe(true)
     })
   })
 

--- a/test/certificate-stack.test.ts
+++ b/test/certificate-stack.test.ts
@@ -11,26 +11,17 @@ function createStack(): CertificateStack {
   })
 }
 
-function createTestStack(): Template {
-  return Template.fromStack(createStack())
-}
-
 describe('CertificateStack', () => {
+  let stack: CertificateStack
   let template: Template
 
   beforeAll(() => {
-    template = createTestStack()
+    stack = createStack()
+    template = Template.fromStack(stack)
   })
 
   describe('Site certificate', () => {
-    it('creates a certificate for akli.dev', () => {
-      template.hasResourceProperties('AWS::CertificateManager::Certificate', {
-        DomainName: 'akli.dev',
-        SubjectAlternativeNames: Match.arrayWith(['www.akli.dev']),
-      })
-    })
-
-    it('does not change the SiteCert domain or subject alternative names (regression guard)', () => {
+    it('creates a certificate for akli.dev with exactly www.akli.dev as SAN', () => {
       template.hasResourceProperties('AWS::CertificateManager::Certificate', {
         DomainName: 'akli.dev',
         SubjectAlternativeNames: ['www.akli.dev'],
@@ -56,15 +47,6 @@ describe('CertificateStack', () => {
         }),
       )
     })
-
-    it('exports an ImagesCertArn CloudFormation output referencing the new certificate', () => {
-      template.hasOutput(
-        'ImagesCertArn',
-        Match.objectLike({
-          Value: Match.objectLike({ Ref: Match.stringLikeRegexp('^ImagesCert') }),
-        }),
-      )
-    })
   })
 
   describe('Certificate count', () => {
@@ -75,7 +57,6 @@ describe('CertificateStack', () => {
 
   describe('Cross-region references', () => {
     it('enables crossRegionReferences on the stack instance', () => {
-      const stack = createStack()
       // CDK exposes the resolved value as `_crossRegionReferences` on the Stack instance
       // (the public `crossRegionReferences` is on StackProps, the input).
       expect(stack._crossRegionReferences).toBe(true)


### PR DESCRIPTION
Closes #121

## What changed
- Adds `ImagesCert` (ACM, us-east-1) for `images.akli.dev` to `CertificateStack`, validated via DNS against the existing `akli.dev` hosted zone.
- Exposes the cert as `public readonly imagesCertificate` on the stack — mirrors the existing `apiCertificate` pattern.
- `SiteCert` and `apiCertificate` are untouched (regression guard test asserts the SAN array).
- Test harness now constructs the stack once via `beforeAll` and shares it across the synthesised template + the `crossRegionReferences` instance assertion.

## Why
First step of the **Images CDN — Phase 1** milestone (PRD `docs/prds/images-cdn-phase-1.md`). A new dedicated cert is required so `ImagesStack` (added in #126) can serve `images.akli.dev` from a CloudFront distribution. A separate cert is used (not a SAN extension on `SiteCert`) because `SiteCert` is consumed cross-region by `AkliInfrastructureStack`, and a SAN extension would be a CFN replacement that risks ordering issues during a single deploy.

## How to verify
- `pnpm test` — all 323 tests pass; new tests live in `test/certificate-stack.test.ts`:
  - cert with `DomainName: 'images.akli.dev'` + DNS validation
  - certificate-count guard (Site + Api + Images = 3)
  - SiteCert SAN regression guard
  - `crossRegionReferences: true` set on the stack instance
- `pnpm lint` clean.
- `pnpm exec tsc --noEmit` produces no new errors (pre-existing `sharp` type-definition error in untouched code).

## Decisions made
- **No `CfnOutput` for `ImagesCertArn`.** The issue's AC #2 hedged with "(or equivalent)". The `public readonly imagesCertificate` property is the equivalent — `crossRegionReferences: true` causes CDK to auto-synthesise an SSM parameter for cross-region consumers (matches how `SiteCert` and `ApiCert` are consumed today; neither has a `CfnOutput`). Adding an output that nothing reads would be dead weight. /simplify pass flagged this; resolved by removing the output and the corresponding test.
- **`stack._crossRegionReferences` for the cross-region assertion.** CDK exposes the resolved input prop on the Stack instance with an underscore prefix; the public-typed `crossRegionReferences` lives on `StackProps` only. The test comment makes the trade-off explicit. Acceptable per the AC's literal phrasing ("read the stack instance's property").
- **Inline cert construction kept.** Three near-identical cert blocks now exist in `CertificateStack`. Extracting a helper would save ~6 lines while obscuring per-cert config that may diverge (SANs, validation method). Premature — revisit at cert #4.

## Commits (TDD progression)
1. `c8abf75` test: add failing tests for ImagesCert (TDD for #121)
2. `5f65391` feat: add ImagesCert for images.akli.dev (tests pass)
3. `bfcd098` refactor: drop unused CfnOutput and tighten tests (/simplify pass)

🤖 Generated with [Claude Code](https://claude.com/claude-code)