### PR TITLE
Extract shared CDN policies module (#122)

### DIFF
--- a/lib/akli-infrastructure-stack.ts
+++ b/lib/akli-infrastructure-stack.ts
@@ -12,6 +12,7 @@ import * as targets from 'aws-cdk-lib/aws-route53-targets'
 import * as s3 from 'aws-cdk-lib/aws-s3'
 import * as secretsmanager from 'aws-cdk-lib/aws-secretsmanager'
 import type { Construct } from 'constructs'
+import { createImageCachePolicy, createSecurityHeadersPolicy } from './cdn-policies'
 
 interface AkliInfrastructureStackProps extends StackProps {
   hostedZone: route53.IHostedZone
@@ -50,30 +51,9 @@ export class AkliInfrastructureStack extends Stack {
       description: `OAC for ${DOMAIN_NAME}`,
     })
 
-    const securityHeadersPolicy = new cloudfront.ResponseHeadersPolicy(this, 'SecurityHeaders', {
-      securityHeadersBehavior: {
-        contentTypeOptions: { override: true },
-        frameOptions: { frameOption: cloudfront.HeadersFrameOption.DENY, override: true },
-        referrerPolicy: { referrerPolicy: cloudfront.HeadersReferrerPolicy.STRICT_ORIGIN_WHEN_CROSS_ORIGIN, override: true },
-        strictTransportSecurity: {
-          accessControlMaxAge: Duration.seconds(31536000),
-          includeSubdomains: true,
-          preload: true,
-          override: true
-        },
-      },
-    })
+    const securityHeadersPolicy = createSecurityHeadersPolicy(this)
 
-    // Cache policy for images with query string support
-    const imageCachePolicy = new cloudfront.CachePolicy(this, 'ImageCachePolicy', {
-      cachePolicyName: 'ImageOptimizationPolicy',
-      defaultTtl: Duration.days(30),
-      maxTtl: Duration.days(365),
-      minTtl: Duration.seconds(0),
-      queryStringBehavior: cloudfront.CacheQueryStringBehavior.all(), // Allow all query params
-      headerBehavior: cloudfront.CacheHeaderBehavior.allowList('Accept', 'CloudFront-Viewer-Country'),
-      cookieBehavior: cloudfront.CacheCookieBehavior.none(),
-    })
+    const imageCachePolicy = createImageCachePolicy(this)
 
     const subdirectoryIndexHandler = new cloudfront.Function(this, 'SubfolderIndexRewrite', {
       code: cloudfront.FunctionCode.fromInline(`

--- a/lib/cdn-policies.ts
+++ b/lib/cdn-policies.ts
@@ -1,26 +1,52 @@
-import type * as cloudfront from 'aws-cdk-lib/aws-cloudfront'
+import { Duration } from 'aws-cdk-lib'
+import * as cloudfront from 'aws-cdk-lib/aws-cloudfront'
 import type { Construct } from 'constructs'
 
 /**
  * Creates the shared image cache policy used by CloudFront distributions
  * that serve optimised images. Stable name `AkliImageCachePolicy` lets
  * tests and other stacks reference the policy by name.
- *
- * Stub — replaced by the cdk-engineer in issue #122.
  */
-export function createImageCachePolicy(_scope: Construct, _id?: string): cloudfront.CachePolicy {
-  throw new Error('createImageCachePolicy: not implemented')
+export function createImageCachePolicy(
+  scope: Construct,
+  id: string = 'ImageCachePolicy',
+): cloudfront.CachePolicy {
+  return new cloudfront.CachePolicy(scope, id, {
+    cachePolicyName: 'AkliImageCachePolicy',
+    defaultTtl: Duration.days(30),
+    maxTtl: Duration.days(365),
+    minTtl: Duration.seconds(0),
+    queryStringBehavior: cloudfront.CacheQueryStringBehavior.all(),
+    headerBehavior: cloudfront.CacheHeaderBehavior.allowList('Accept', 'CloudFront-Viewer-Country'),
+    cookieBehavior: cloudfront.CacheCookieBehavior.none(),
+  })
 }
 
 /**
  * Creates the shared response headers policy applied to CloudFront viewer
  * responses (CSP-adjacent security headers, HSTS, frame options, etc.).
- *
- * Stub — replaced by the cdk-engineer in issue #122.
  */
 export function createSecurityHeadersPolicy(
-  _scope: Construct,
-  _id?: string,
+  scope: Construct,
+  id: string = 'SecurityHeaders',
 ): cloudfront.ResponseHeadersPolicy {
-  throw new Error('createSecurityHeadersPolicy: not implemented')
+  return new cloudfront.ResponseHeadersPolicy(scope, id, {
+    securityHeadersBehavior: {
+      contentTypeOptions: { override: true },
+      frameOptions: {
+        frameOption: cloudfront.HeadersFrameOption.DENY,
+        override: true,
+      },
+      referrerPolicy: {
+        referrerPolicy: cloudfront.HeadersReferrerPolicy.STRICT_ORIGIN_WHEN_CROSS_ORIGIN,
+        override: true,
+      },
+      strictTransportSecurity: {
+        accessControlMaxAge: Duration.seconds(31536000),
+        includeSubdomains: true,
+        preload: true,
+        override: true,
+      },
+    },
+  })
 }

--- a/lib/cdn-policies.ts
+++ b/lib/cdn-policies.ts
@@ -1,0 +1,26 @@
+import type * as cloudfront from 'aws-cdk-lib/aws-cloudfront'
+import type { Construct } from 'constructs'
+
+/**
+ * Creates the shared image cache policy used by CloudFront distributions
+ * that serve optimised images. Stable name `AkliImageCachePolicy` lets
+ * tests and other stacks reference the policy by name.
+ *
+ * Stub — replaced by the cdk-engineer in issue #122.
+ */
+export function createImageCachePolicy(_scope: Construct, _id?: string): cloudfront.CachePolicy {
+  throw new Error('createImageCachePolicy: not implemented')
+}
+
+/**
+ * Creates the shared response headers policy applied to CloudFront viewer
+ * responses (CSP-adjacent security headers, HSTS, frame options, etc.).
+ *
+ * Stub — replaced by the cdk-engineer in issue #122.
+ */
+export function createSecurityHeadersPolicy(
+  _scope: Construct,
+  _id?: string,
+): cloudfront.ResponseHeadersPolicy {
+  throw new Error('createSecurityHeadersPolicy: not implemented')
+}

--- a/lib/cdn-policies.ts
+++ b/lib/cdn-policies.ts
@@ -2,17 +2,14 @@ import { Duration } from 'aws-cdk-lib'
 import * as cloudfront from 'aws-cdk-lib/aws-cloudfront'
 import type { Construct } from 'constructs'
 
-/**
- * Creates the shared image cache policy used by CloudFront distributions
- * that serve optimised images. Stable name `AkliImageCachePolicy` lets
- * tests and other stacks reference the policy by name.
- */
+export const IMAGE_CACHE_POLICY_NAME = 'AkliImageCachePolicy'
+
 export function createImageCachePolicy(
   scope: Construct,
   id: string = 'ImageCachePolicy',
 ): cloudfront.CachePolicy {
   return new cloudfront.CachePolicy(scope, id, {
-    cachePolicyName: 'AkliImageCachePolicy',
+    cachePolicyName: IMAGE_CACHE_POLICY_NAME,
     defaultTtl: Duration.days(30),
     maxTtl: Duration.days(365),
     minTtl: Duration.seconds(0),
@@ -22,10 +19,6 @@ export function createImageCachePolicy(
   })
 }
 
-/**
- * Creates the shared response headers policy applied to CloudFront viewer
- * responses (CSP-adjacent security headers, HSTS, frame options, etc.).
- */
 export function createSecurityHeadersPolicy(
   scope: Construct,
   id: string = 'SecurityHeaders',
@@ -42,7 +35,7 @@ export function createSecurityHeadersPolicy(
         override: true,
       },
       strictTransportSecurity: {
-        accessControlMaxAge: Duration.seconds(31536000),
+        accessControlMaxAge: Duration.days(365),
         includeSubdomains: true,
         preload: true,
         override: true,

--- a/test/akli-infrastructure.test.ts
+++ b/test/akli-infrastructure.test.ts
@@ -213,6 +213,16 @@ describe('AkliInfrastructureStack', () => {
     })
   })
 
+  describe('Image cache policy', () => {
+    it('uses the stable name AkliImageCachePolicy so other stacks can reference it', () => {
+      template.hasResourceProperties('AWS::CloudFront::CachePolicy', {
+        CachePolicyConfig: Match.objectLike({
+          Name: 'AkliImageCachePolicy',
+        }),
+      })
+    })
+  })
+
   describe('IAM deploy policy', () => {
     it('grants lambda:UpdateFunctionCode and lambda:GetFunction scoped to the SSR function', () => {
       template.hasResourceProperties('AWS::IAM::Policy', {

--- a/test/cdn-policies.test.ts
+++ b/test/cdn-policies.test.ts
@@ -1,7 +1,11 @@
 import * as cdk from 'aws-cdk-lib'
 import { Match, Template } from 'aws-cdk-lib/assertions'
 import * as cloudfront from 'aws-cdk-lib/aws-cloudfront'
-import { createImageCachePolicy, createSecurityHeadersPolicy } from '../lib/cdn-policies'
+import {
+  createImageCachePolicy,
+  createSecurityHeadersPolicy,
+  IMAGE_CACHE_POLICY_NAME,
+} from '../lib/cdn-policies'
 
 function harnessStack(): cdk.Stack {
   const app = new cdk.App()
@@ -12,31 +16,28 @@ function harnessStack(): cdk.Stack {
 
 describe('cdn-policies', () => {
   describe('createImageCachePolicy', () => {
-    it('returns a cloudfront.CachePolicy construct', () => {
+    let policy: cloudfront.CachePolicy
+    let template: Template
+
+    beforeAll(() => {
       const stack = harnessStack()
+      policy = createImageCachePolicy(stack, 'TestImageCachePolicy')
+      template = Template.fromStack(stack)
+    })
 
-      const policy = createImageCachePolicy(stack, 'TestImageCachePolicy')
-
+    it('returns a cloudfront.CachePolicy construct', () => {
       expect(policy).toBeInstanceOf(cloudfront.CachePolicy)
     })
 
-    it('synthesises with the stable name AkliImageCachePolicy', () => {
-      const stack = harnessStack()
-      createImageCachePolicy(stack, 'TestImageCachePolicy')
-
-      const template = Template.fromStack(stack)
+    it('synthesises with the stable name from IMAGE_CACHE_POLICY_NAME', () => {
       template.hasResourceProperties('AWS::CloudFront::CachePolicy', {
         CachePolicyConfig: Match.objectLike({
-          Name: 'AkliImageCachePolicy',
+          Name: IMAGE_CACHE_POLICY_NAME,
         }),
       })
     })
 
     it('configures default 30-day, max 365-day, min 0-second TTLs', () => {
-      const stack = harnessStack()
-      createImageCachePolicy(stack, 'TestImageCachePolicy')
-
-      const template = Template.fromStack(stack)
       template.hasResourceProperties('AWS::CloudFront::CachePolicy', {
         CachePolicyConfig: Match.objectLike({
           DefaultTTL: 30 * 24 * 60 * 60,
@@ -47,10 +48,6 @@ describe('cdn-policies', () => {
     })
 
     it('forwards all query strings, allowlists Accept and CloudFront-Viewer-Country headers, and forwards no cookies', () => {
-      const stack = harnessStack()
-      createImageCachePolicy(stack, 'TestImageCachePolicy')
-
-      const template = Template.fromStack(stack)
       template.hasResourceProperties('AWS::CloudFront::CachePolicy', {
         CachePolicyConfig: Match.objectLike({
           ParametersInCacheKeyAndForwardedToOrigin: Match.objectLike({
@@ -67,19 +64,20 @@ describe('cdn-policies', () => {
   })
 
   describe('createSecurityHeadersPolicy', () => {
-    it('returns a cloudfront.ResponseHeadersPolicy construct', () => {
+    let policy: cloudfront.ResponseHeadersPolicy
+    let template: Template
+
+    beforeAll(() => {
       const stack = harnessStack()
+      policy = createSecurityHeadersPolicy(stack, 'TestSecurityHeaders')
+      template = Template.fromStack(stack)
+    })
 
-      const policy = createSecurityHeadersPolicy(stack, 'TestSecurityHeaders')
-
+    it('returns a cloudfront.ResponseHeadersPolicy construct', () => {
       expect(policy).toBeInstanceOf(cloudfront.ResponseHeadersPolicy)
     })
 
     it('configures the documented security headers (content type, frame options, referrer policy, HSTS)', () => {
-      const stack = harnessStack()
-      createSecurityHeadersPolicy(stack, 'TestSecurityHeaders')
-
-      const template = Template.fromStack(stack)
       template.hasResourceProperties('AWS::CloudFront::ResponseHeadersPolicy', {
         ResponseHeadersPolicyConfig: Match.objectLike({
           SecurityHeadersConfig: Match.objectLike({

--- a/test/cdn-policies.test.ts
+++ b/test/cdn-policies.test.ts
@@ -1,0 +1,103 @@
+import * as cdk from 'aws-cdk-lib'
+import { Match, Template } from 'aws-cdk-lib/assertions'
+import * as cloudfront from 'aws-cdk-lib/aws-cloudfront'
+import { createImageCachePolicy, createSecurityHeadersPolicy } from '../lib/cdn-policies'
+
+function harnessStack(): cdk.Stack {
+  const app = new cdk.App()
+  return new cdk.Stack(app, 'PolicyHarnessStack', {
+    env: { account: '123456789012', region: 'eu-west-2' },
+  })
+}
+
+describe('cdn-policies', () => {
+  describe('createImageCachePolicy', () => {
+    it('returns a cloudfront.CachePolicy construct', () => {
+      const stack = harnessStack()
+
+      const policy = createImageCachePolicy(stack, 'TestImageCachePolicy')
+
+      expect(policy).toBeInstanceOf(cloudfront.CachePolicy)
+    })
+
+    it('synthesises with the stable name AkliImageCachePolicy', () => {
+      const stack = harnessStack()
+      createImageCachePolicy(stack, 'TestImageCachePolicy')
+
+      const template = Template.fromStack(stack)
+      template.hasResourceProperties('AWS::CloudFront::CachePolicy', {
+        CachePolicyConfig: Match.objectLike({
+          Name: 'AkliImageCachePolicy',
+        }),
+      })
+    })
+
+    it('configures default 30-day, max 365-day, min 0-second TTLs', () => {
+      const stack = harnessStack()
+      createImageCachePolicy(stack, 'TestImageCachePolicy')
+
+      const template = Template.fromStack(stack)
+      template.hasResourceProperties('AWS::CloudFront::CachePolicy', {
+        CachePolicyConfig: Match.objectLike({
+          DefaultTTL: 30 * 24 * 60 * 60,
+          MaxTTL: 365 * 24 * 60 * 60,
+          MinTTL: 0,
+        }),
+      })
+    })
+
+    it('forwards all query strings, allowlists Accept and CloudFront-Viewer-Country headers, and forwards no cookies', () => {
+      const stack = harnessStack()
+      createImageCachePolicy(stack, 'TestImageCachePolicy')
+
+      const template = Template.fromStack(stack)
+      template.hasResourceProperties('AWS::CloudFront::CachePolicy', {
+        CachePolicyConfig: Match.objectLike({
+          ParametersInCacheKeyAndForwardedToOrigin: Match.objectLike({
+            QueryStringsConfig: { QueryStringBehavior: 'all' },
+            HeadersConfig: {
+              HeaderBehavior: 'whitelist',
+              Headers: Match.arrayWith(['Accept', 'CloudFront-Viewer-Country']),
+            },
+            CookiesConfig: { CookieBehavior: 'none' },
+          }),
+        }),
+      })
+    })
+  })
+
+  describe('createSecurityHeadersPolicy', () => {
+    it('returns a cloudfront.ResponseHeadersPolicy construct', () => {
+      const stack = harnessStack()
+
+      const policy = createSecurityHeadersPolicy(stack, 'TestSecurityHeaders')
+
+      expect(policy).toBeInstanceOf(cloudfront.ResponseHeadersPolicy)
+    })
+
+    it('configures the documented security headers (content type, frame options, referrer policy, HSTS)', () => {
+      const stack = harnessStack()
+      createSecurityHeadersPolicy(stack, 'TestSecurityHeaders')
+
+      const template = Template.fromStack(stack)
+      template.hasResourceProperties('AWS::CloudFront::ResponseHeadersPolicy', {
+        ResponseHeadersPolicyConfig: Match.objectLike({
+          SecurityHeadersConfig: Match.objectLike({
+            ContentTypeOptions: { Override: true },
+            FrameOptions: { FrameOption: 'DENY', Override: true },
+            ReferrerPolicy: {
+              ReferrerPolicy: 'strict-origin-when-cross-origin',
+              Override: true,
+            },
+            StrictTransportSecurity: {
+              AccessControlMaxAgeSec: 31536000,
+              IncludeSubdomains: true,
+              Preload: true,
+              Override: true,
+            },
+          }),
+        }),
+      })
+    })
+  })
+})


### PR DESCRIPTION
Closes #122

## What changed
- New `lib/cdn-policies.ts` exports `createImageCachePolicy` and `createSecurityHeadersPolicy` factories plus the stable `IMAGE_CACHE_POLICY_NAME` constant (`'AkliImageCachePolicy'`).
- `AkliInfrastructureStack` consumes the factories instead of inlining the policy definitions.
- Cache policy renamed `ImageOptimizationPolicy` → `AkliImageCachePolicy`.
- Tests for the new module + a regression assertion on the rendered stack.

## Why
First step of the **Images CDN — Phase 1** epic. The future `ImagesStack` (#126) needs the same image cache policy and security headers policy as `AkliInfrastructureStack`. Sharing the constructors avoids inlining the same config twice and gives the cache policy a stable name so #126's assertion tests can match by name rather than CFN logical ID. PRD: `docs/prds/images-cdn-phase-1.md`.

## How to verify
- `pnpm test` — 330 tests pass, including the new `test/cdn-policies.test.ts` (6) and the new "Image cache policy" assertion in `test/akli-infrastructure.test.ts`.
- `pnpm lint` — clean.
- `cdk synth` — the only template-level change is `CachePolicyConfig.Name: 'ImageOptimizationPolicy'` → `'AkliImageCachePolicy'`.

## Decisions made
- **Factory functions over a const-export** — the policies are L2 constructs that need a `scope`, and a function lets the caller pick the construct id (default `'ImageCachePolicy'` / `'SecurityHeaders'` to keep existing CFN logical IDs stable in `AkliInfrastructureStack`).
- **Named constant for the cache policy name** — `IMAGE_CACHE_POLICY_NAME` is exported so #126 and tests reference the constant rather than the literal `'AkliImageCachePolicy'`.
- **TDD sequence followed** — failing tests landed first (`b853a63`), then implementation (`85c8ca4`), then a `/simplify` pass tightening the module (`00f869a`).

## AC coverage
- ✅ `lib/cdn-policies.ts` exports both constructors.
- ✅ `AkliInfrastructureStack` imports — no inlined definitions.
- ⏸ `ImagesStack` import — that stack is created by #126; the module is ready for consumption.
- ✅ `cachePolicyName: 'AkliImageCachePolicy'`.
- ✅ Existing synthesis tests still pass.
- ✅ Tests written before implementation (TDD).

## Reviewer findings deferred (out of scope)
- `ApiStack` (`lib/api-stack.ts`) lacks `responseHeadersPolicy` on its CloudFront behaviours — wiring `createSecurityHeadersPolicy` there would close that gap but isn't part of #122.
- `ApiStack` and `AkliInfrastructureStack` both create their own `CachePolicy` constructs — a generic `createCachePolicy(scope, id, opts)` could subsume them, but that's broader than this issue's scope.