### PR TITLE
Expose RecipeImagesBucket from RecipeStack (#123)

### DIFF
--- a/lib/recipe-stack.ts
+++ b/lib/recipe-stack.ts
@@ -20,6 +20,7 @@ interface RecipeStackProps extends StackProps {
 
 export class RecipeStack extends Stack {
   public readonly httpApi: HttpApi
+  public readonly imageBucket: s3.IBucket
 
   constructor(scope: Construct, id: string, props: RecipeStackProps) {
     super(scope, id, props)
@@ -69,6 +70,7 @@ export class RecipeStack extends Stack {
         },
       ],
     })
+    this.imageBucket = imageBucket
 
     // HTTP API with CORS
     this.httpApi = new HttpApi(this, 'RecipeHttpApi', {


### PR DESCRIPTION
Closes #123

## What changed
- `RecipeStack` now exposes `public readonly imageBucket: s3.IBucket`, mirroring the existing `httpApi` exposure at `lib/recipe-stack.ts:22`.
- The bucket construct is unchanged — only a class field is added and assigned after construction.

## Why
Second prerequisite for the **Images CDN — Phase 1** epic. The future `ImagesStack` (#126) needs a reference to the recipe-images bucket so it can attach an OAC and add a bucket policy granting `s3:GetObject` to the CloudFront service principal. Per `docs/prds/images-cdn-phase-1.md` line 110, the bucket should stay owned by `RecipeStack` and be passed into `ImagesStack` via props.

## How to verify
- `pnpm test` — 330/330 pass; `test/recipe-stack.test.ts` synthesis tests unchanged.
- `pnpm lint` — clean.
- `pnpm exec tsc --noEmit` — only the pre-existing `Cannot find type definition file for 'sharp'` warning (unrelated, untouched in this diff).
- `cdk synth` — no template-level change; this is a TypeScript-signature-only diff.

## Decisions made
- **Typed as `s3.IBucket`, not `s3.Bucket`** — gives downstream stacks the read-only interface, per the PRD recommendation (line 124).
- **Local const + assign to `this.imageBucket`** rather than rewriting all 9 internal `imageBucket.grant*`/`addEventNotification` callsites. Lower-diff approach; the local construct still has the full mutating API for in-stack wiring.

## AC coverage
- ✅ `RecipeStack.imageBucket` exposed as `public readonly` typed `s3.IBucket` — `lib/recipe-stack.ts:23,73`.
- ⏸ `bin/akli-infrastructure.ts` passes `recipeStack.imageBucket` into `ImagesStack` props — bound to #126 since `ImagesStack` doesn't exist yet.
- ✅ Existing `RecipeStack` synthesis tests still pass.
- ✅ `pnpm test` and `pnpm lint` pass.