### PR TITLE
Drop 'processed/' segment from recipe image keys (#124, #125)

### DIFF
--- a/lambda/image-variants.ts
+++ b/lambda/image-variants.ts
@@ -2,15 +2,19 @@ export const VARIANT_SUFFIXES = ['thumb', 'medium', 'full'] as const
 
 export type VariantSuffix = (typeof VARIANT_SUFFIXES)[number]
 
-// S3 key prefixes for the image pipeline. Uploads land under UPLOAD_PREFIX
-// (what the resizer S3 trigger listens for); processed variants are written
-// under PROCESSED_PREFIX (where the site serves `<prefix><name>-<variant>.webp`).
 export const UPLOAD_PREFIX = 'uploads/'
-export const PROCESSED_PREFIX = 'processed/'
+export const PROCESSED_PREFIX = 'recipes/'
 
 export const toProcessedKey = (uploadKey: string): string => {
   if (!uploadKey.startsWith(UPLOAD_PREFIX)) {
     throw new Error(`Expected key to start with "${UPLOAD_PREFIX}", got "${uploadKey}"`)
   }
-  return PROCESSED_PREFIX + uploadKey.slice(UPLOAD_PREFIX.length)
+  const afterUpload = uploadKey.slice(UPLOAD_PREFIX.length)
+  if (afterUpload.length === 0) {
+    throw new Error(`Expected key to have content after "${UPLOAD_PREFIX}", got "${uploadKey}"`)
+  }
+  const stripped = afterUpload.startsWith(PROCESSED_PREFIX)
+    ? afterUpload.slice(PROCESSED_PREFIX.length)
+    : afterUpload
+  return PROCESSED_PREFIX + stripped
 }

--- a/lambda/recipe-handler.ts
+++ b/lambda/recipe-handler.ts
@@ -3,7 +3,7 @@ import { DynamoDBClient } from '@aws-sdk/client-dynamodb'
 import { S3Client, ListObjectsV2Command, DeleteObjectsCommand } from '@aws-sdk/client-s3'
 import { DynamoDBDocumentClient, QueryCommand, GetCommand, PutCommand, UpdateCommand, DeleteCommand, ScanCommand } from '@aws-sdk/lib-dynamodb'
 import type { APIGatewayProxyEventV2, APIGatewayProxyStructuredResultV2 } from 'aws-lambda'
-import { VARIANT_SUFFIXES } from './image-variants'
+import { VARIANT_SUFFIXES, PROCESSED_PREFIX } from './image-variants'
 
 const ddbClient = new DynamoDBClient({})
 const docClient = DynamoDBDocumentClient.from(ddbClient)
@@ -638,7 +638,7 @@ async function handleDeleteRecipe(event: APIGatewayProxyEventV2): Promise<APIGat
   const listResult = await s3Client.send(
     new ListObjectsV2Command({
       Bucket: IMAGE_BUCKET_NAME,
-      Prefix: `processed/recipes/${id}/`,
+      Prefix: `${PROCESSED_PREFIX}${id}/`,
     }),
   )
 

--- a/test/lambda/image-resizer.test.ts
+++ b/test/lambda/image-resizer.test.ts
@@ -88,7 +88,7 @@ describe('image-resizer handler', () => {
     expect(mockSharp.webp).toHaveBeenCalledWith({ quality: 90 })
   })
 
-  it('uploads variants to processed/ prefix with correct keys', async () => {
+  it('uploads variants to recipes/ prefix with correct keys', async () => {
     await handler(makeS3Event('uploads/recipes/abc/cover'))
 
     const putCalls = s3Mock.commandCalls(PutObjectCommand)
@@ -96,9 +96,9 @@ describe('image-resizer handler', () => {
 
     const putKeys = putCalls.map((call) => call.args[0].input.Key).sort()
     expect(putKeys).toEqual([
-      'processed/recipes/abc/cover-full.webp',
-      'processed/recipes/abc/cover-medium.webp',
-      'processed/recipes/abc/cover-thumb.webp',
+      'recipes/abc/cover-full.webp',
+      'recipes/abc/cover-medium.webp',
+      'recipes/abc/cover-thumb.webp',
     ])
 
     // All uploads go to the correct bucket
@@ -152,7 +152,7 @@ describe('image-resizer handler', () => {
     expect(input.Key).toEqual({ id: 'abc' })
     expect(input.UpdateExpression).toBe('SET imageStatus.#k = :ts')
     expect(input.ConditionExpression).toBe('attribute_exists(id)')
-    expect(input.ExpressionAttributeNames).toEqual({ '#k': 'processed/recipes/abc/cover' })
+    expect(input.ExpressionAttributeNames).toEqual({ '#k': 'recipes/abc/cover' })
 
     const ts = input.ExpressionAttributeValues?.[':ts']
     expect(typeof ts).toBe('number')
@@ -169,7 +169,7 @@ describe('image-resizer handler', () => {
 
     const input = updateCalls[0].args[0].input
     expect(input.Key).toEqual({ id: 'abc' })
-    expect(input.ExpressionAttributeNames).toEqual({ '#k': 'processed/recipes/abc/step-2' })
+    expect(input.ExpressionAttributeNames).toEqual({ '#k': 'recipes/abc/step-2' })
   })
 
   it('swallows ConditionalCheckFailedException, still deletes source, and logs skip event', async () => {

--- a/test/lambda/image-variants.test.ts
+++ b/test/lambda/image-variants.test.ts
@@ -2,23 +2,23 @@ import { PROCESSED_PREFIX, UPLOAD_PREFIX, toProcessedKey } from '../../lambda/im
 
 describe('image-variants', () => {
   describe('PROCESSED_PREFIX constant', () => {
-    it('is "recipes/" so processed objects sit under the recipes/ namespace 1:1 with the public URL', () => {
+    it('is "recipes/"', () => {
       expect(PROCESSED_PREFIX).toBe('recipes/')
     })
   })
 
   describe('UPLOAD_PREFIX constant', () => {
-    it('remains "uploads/" — the resizer S3 trigger still filters on this prefix', () => {
+    it('is "uploads/"', () => {
       expect(UPLOAD_PREFIX).toBe('uploads/')
     })
   })
 
   describe('toProcessedKey', () => {
-    it('maps a cover upload key to the recipes/<id>/cover processed key (no double "recipes/")', () => {
+    it('maps a cover upload key to its processed key', () => {
       expect(toProcessedKey('uploads/recipes/abc/cover')).toBe('recipes/abc/cover')
     })
 
-    it('maps a step upload key to the recipes/<id>/step-<n> processed key', () => {
+    it('maps a step upload key to its processed key', () => {
       expect(toProcessedKey('uploads/recipes/abc/step-2')).toBe('recipes/abc/step-2')
     })
 
@@ -26,11 +26,11 @@ describe('image-variants', () => {
       expect(() => toProcessedKey('not-uploads/foo')).toThrow(/uploads\//)
     })
 
-    it('throws when the upload key is exactly "uploads/" with no suffix', () => {
+    it('throws when the upload key has no suffix after "uploads/"', () => {
       expect(() => toProcessedKey('uploads/')).toThrow()
     })
 
-    it('preserves a stray double-slash after the upload prefix (returns "recipes//double-slash")', () => {
+    it('preserves a stray double-slash after the upload prefix', () => {
       expect(toProcessedKey('uploads//double-slash')).toBe('recipes//double-slash')
     })
   })

--- a/test/lambda/image-variants.test.ts
+++ b/test/lambda/image-variants.test.ts
@@ -1,0 +1,37 @@
+import { PROCESSED_PREFIX, UPLOAD_PREFIX, toProcessedKey } from '../../lambda/image-variants'
+
+describe('image-variants', () => {
+  describe('PROCESSED_PREFIX constant', () => {
+    it('is "recipes/" so processed objects sit under the recipes/ namespace 1:1 with the public URL', () => {
+      expect(PROCESSED_PREFIX).toBe('recipes/')
+    })
+  })
+
+  describe('UPLOAD_PREFIX constant', () => {
+    it('remains "uploads/" — the resizer S3 trigger still filters on this prefix', () => {
+      expect(UPLOAD_PREFIX).toBe('uploads/')
+    })
+  })
+
+  describe('toProcessedKey', () => {
+    it('maps a cover upload key to the recipes/<id>/cover processed key (no double "recipes/")', () => {
+      expect(toProcessedKey('uploads/recipes/abc/cover')).toBe('recipes/abc/cover')
+    })
+
+    it('maps a step upload key to the recipes/<id>/step-<n> processed key', () => {
+      expect(toProcessedKey('uploads/recipes/abc/step-2')).toBe('recipes/abc/step-2')
+    })
+
+    it('throws when the upload key does not start with "uploads/"', () => {
+      expect(() => toProcessedKey('not-uploads/foo')).toThrow(/uploads\//)
+    })
+
+    it('throws when the upload key is exactly "uploads/" with no suffix', () => {
+      expect(() => toProcessedKey('uploads/')).toThrow()
+    })
+
+    it('preserves a stray double-slash after the upload prefix (returns "recipes//double-slash")', () => {
+      expect(toProcessedKey('uploads//double-slash')).toBe('recipes//double-slash')
+    })
+  })
+})

--- a/test/lambda/recipe-handler.test.ts
+++ b/test/lambda/recipe-handler.test.ts
@@ -2313,13 +2313,7 @@ describe('Recipe Lambda handler', () => {
       expect(body.coverImage).toEqual({ key: coverKey, alt: 'cover alt', processedAt: 0 })
     })
 
-    // Regression guard for the prefix flip from `processed/` to `recipes/`.
-    // After the prefix change, recipes whose imageStatus map still carries a
-    // stale `processed/recipes/...`-keyed entry (left over from before the
-    // change) must NOT be treated as "ready". The new coverImage.key uses the
-    // `recipes/...` shape; the stale entry's key does not match, so processedAt
-    // must be omitted (otherwise the consumer would render a broken URL).
-    it('omits processedAt when imageStatus carries only stale "processed/recipes/..." keys (prefix-flip regression)', async () => {
+    it('omits processedAt when imageStatus keys do not match coverImage.key', async () => {
       const newCoverKey = 'recipes/recipe-uuid-1/cover'
       const staleCoverKey = 'processed/recipes/recipe-uuid-1/cover'
       const item = publishedRecipeItem({

--- a/test/lambda/recipe-handler.test.ts
+++ b/test/lambda/recipe-handler.test.ts
@@ -738,8 +738,8 @@ describe('Recipe Lambda handler', () => {
     })
 
     it('composes processedAt onto images and strips imageStatus from the response body', async () => {
-      const coverKey = 'processed/recipes/recipe-uuid-1/cover'
-      const step1Key = 'processed/recipes/recipe-uuid-1/step-1'
+      const coverKey = 'recipes/recipe-uuid-1/cover'
+      const step1Key = 'recipes/recipe-uuid-1/step-1'
       const coverTs = 1_745_000_000_001
       const step1Ts = 1_745_000_000_002
 
@@ -1420,9 +1420,9 @@ describe('Recipe Lambda handler', () => {
     })
 
     describe('readiness validation — rejects recipes with unready images', () => {
-      const coverKey = 'processed/recipes/recipe-uuid-1/cover'
-      const step1Key = 'processed/recipes/recipe-uuid-1/step-1'
-      const step2Key = 'processed/recipes/recipe-uuid-1/step-2'
+      const coverKey = 'recipes/recipe-uuid-1/cover'
+      const step1Key = 'recipes/recipe-uuid-1/step-1'
+      const step2Key = 'recipes/recipe-uuid-1/step-2'
       const coverTs = 1_745_000_000_001
       const step1Ts = 1_745_000_000_002
       const step2Ts = 1_745_000_000_003
@@ -1535,8 +1535,8 @@ describe('Recipe Lambda handler', () => {
       })
 
       it('returns 400 when republishing a currently-published recipe whose cover was swapped to an unready new key', async () => {
-        const oldCoverKey = 'processed/recipes/recipe-uuid-1/cover-old'
-        const newCoverKey = 'processed/recipes/recipe-uuid-1/cover'
+        const oldCoverKey = 'recipes/recipe-uuid-1/cover-old'
+        const newCoverKey = 'recipes/recipe-uuid-1/cover'
         ddbMock.on(GetCommand).resolves({
           Item: publishedRecipeItem({
             authorId: 'contributor-user-id',
@@ -1777,9 +1777,9 @@ describe('Recipe Lambda handler', () => {
       ddbMock.on(DeleteCommand).resolves({})
       s3Mock.on(ListObjectsV2Command).resolves({
         Contents: [
-          { Key: 'processed/recipes/recipe-uuid-1/cover-thumb.webp' },
-          { Key: 'processed/recipes/recipe-uuid-1/cover-medium.webp' },
-          { Key: 'processed/recipes/recipe-uuid-1/cover-full.webp' },
+          { Key: 'recipes/recipe-uuid-1/cover-thumb.webp' },
+          { Key: 'recipes/recipe-uuid-1/cover-medium.webp' },
+          { Key: 'recipes/recipe-uuid-1/cover-full.webp' },
         ],
       })
       s3Mock.on(DeleteObjectsCommand).resolves({})
@@ -1797,6 +1797,28 @@ describe('Recipe Lambda handler', () => {
       // Verify S3 cleanup was attempted
       expect(s3Mock.commandCalls(ListObjectsV2Command)).toHaveLength(1)
       expect(s3Mock.commandCalls(DeleteObjectsCommand)).toHaveLength(1)
+    })
+
+    it('lists S3 objects under the new "recipes/<id>/" prefix (not the old "processed/recipes/...")', async () => {
+      ddbMock.on(GetCommand).resolves({
+        Item: publishedRecipeItem({ authorId: 'contributor-user-id' }),
+      })
+      ddbMock.on(DeleteCommand).resolves({})
+      s3Mock.on(ListObjectsV2Command).resolves({ Contents: [] })
+
+      const event = makeEvent({
+        routeKey: 'DELETE /recipes/{id}',
+        rawPath: '/recipes/recipe-uuid-1',
+        pathParameters: { id: 'recipe-uuid-1' },
+        headers: { authorization: `Bearer ${contributorToken}` },
+      })
+
+      const result = await handler(event)
+
+      expect(result.statusCode).toBe(200)
+      const listCalls = s3Mock.commandCalls(ListObjectsV2Command)
+      expect(listCalls).toHaveLength(1)
+      expect(listCalls[0].args[0].input.Prefix).toBe('recipes/recipe-uuid-1/')
     })
 
     it('returns 403 when contributor deletes another user\'s recipe', async () => {
@@ -1967,9 +1989,9 @@ describe('Recipe Lambda handler', () => {
   describe('Response composition — processedAt + imageStatus stripping', () => {
     // A published recipe whose cover image and one step image both have matching
     // imageStatus entries, plus one step image without a matching entry.
-    const coverKey = 'processed/recipes/recipe-uuid-1/cover'
-    const step1Key = 'processed/recipes/recipe-uuid-1/step-1'
-    const step2Key = 'processed/recipes/recipe-uuid-1/step-2'
+    const coverKey = 'recipes/recipe-uuid-1/cover'
+    const step1Key = 'recipes/recipe-uuid-1/step-1'
+    const step2Key = 'recipes/recipe-uuid-1/step-2'
     const coverTs = 1_745_000_000_001
     const step1Ts = 1_745_000_000_002
 
@@ -2290,14 +2312,44 @@ describe('Recipe Lambda handler', () => {
       const body = JSON.parse(result.body as string)
       expect(body.coverImage).toEqual({ key: coverKey, alt: 'cover alt', processedAt: 0 })
     })
+
+    // Regression guard for the prefix flip from `processed/` to `recipes/`.
+    // After the prefix change, recipes whose imageStatus map still carries a
+    // stale `processed/recipes/...`-keyed entry (left over from before the
+    // change) must NOT be treated as "ready". The new coverImage.key uses the
+    // `recipes/...` shape; the stale entry's key does not match, so processedAt
+    // must be omitted (otherwise the consumer would render a broken URL).
+    it('omits processedAt when imageStatus carries only stale "processed/recipes/..." keys (prefix-flip regression)', async () => {
+      const newCoverKey = 'recipes/recipe-uuid-1/cover'
+      const staleCoverKey = 'processed/recipes/recipe-uuid-1/cover'
+      const item = publishedRecipeItem({
+        id: 'recipe-uuid-1',
+        coverImage: { key: newCoverKey, alt: 'cover alt' },
+        steps: [],
+        imageStatus: { [staleCoverKey]: 1_745_000_000_001 },
+      })
+      ddbMock.on(ScanCommand).resolves({ Items: [item] })
+
+      const result = await handler(makeEvent({
+        routeKey: 'GET /recipes/{slug}',
+        rawPath: '/recipes/slow-cooked-lamb-ragu',
+        pathParameters: { slug: 'slow-cooked-lamb-ragu' },
+      }))
+
+      expect(result.statusCode).toBe(200)
+      expect(result.body).not.toContain('processedAt')
+      const body = JSON.parse(result.body as string)
+      expect(body.coverImage).not.toHaveProperty('processedAt')
+      expect(body.coverImage).toEqual({ key: newCoverKey, alt: 'cover alt' })
+    })
   })
 
   describe('PATCH /recipes/{id} — imageStatus REMOVE on swap and processedAt body strip', () => {
-    const oldCoverKey = 'processed/recipes/recipe-uuid-1/cover'
-    const newCoverKey = 'processed/recipes/recipe-uuid-1/cover-v2'
-    const stepAKey = 'processed/recipes/recipe-uuid-1/step-1'
-    const stepBKey = 'processed/recipes/recipe-uuid-1/step-2'
-    const stepCKey = 'processed/recipes/recipe-uuid-1/step-3'
+    const oldCoverKey = 'recipes/recipe-uuid-1/cover'
+    const newCoverKey = 'recipes/recipe-uuid-1/cover-v2'
+    const stepAKey = 'recipes/recipe-uuid-1/step-1'
+    const stepBKey = 'recipes/recipe-uuid-1/step-2'
+    const stepCKey = 'recipes/recipe-uuid-1/step-3'
 
     it('cover-image swap includes REMOVE imageStatus.#<oldKey> in the same UpdateCommand as SET', async () => {
       const oldItem = publishedRecipeItem({

--- a/test/lambda/recipe-image-handler.test.ts
+++ b/test/lambda/recipe-image-handler.test.ts
@@ -75,7 +75,7 @@ describe('Recipe Image handler', () => {
       const body = JSON.parse(result.body as string)
       expect(typeof body.uploadUrl).toBe('string')
       expect(typeof body.key).toBe('string')
-      expect(body.key).toMatch(/^processed\/recipes\/[^/]+\//)
+      expect(body.key).toMatch(/^recipes\/[^/]+\//)
     })
 
     it('generates correct S3 key for cover image', async () => {
@@ -88,7 +88,7 @@ describe('Recipe Image handler', () => {
 
       expect(result.statusCode).toBe(200)
       const body = JSON.parse(result.body as string)
-      expect(body.key).toBe('processed/recipes/abc/cover')
+      expect(body.key).toBe('recipes/abc/cover')
     })
 
     it('generates correct S3 key for step image', async () => {
@@ -101,7 +101,7 @@ describe('Recipe Image handler', () => {
 
       expect(result.statusCode).toBe(200)
       const body = JSON.parse(result.body as string)
-      expect(body.key).toBe('processed/recipes/abc/step-3')
+      expect(body.key).toBe('recipes/abc/step-3')
     })
 
     it('returns 401 without bearer token', async () => {


### PR DESCRIPTION
Closes #124, #125

## What changed
- `PROCESSED_PREFIX` flips from `'processed/'` to `'recipes/'` in `lambda/image-variants.ts`.
- `toProcessedKey` now strips the redundant `recipes/` segment from the upload-key suffix before reapplying the prefix, and rejects empty-suffix inputs.
- `lambda/recipe-handler.ts` imports `PROCESSED_PREFIX` and uses it in the DELETE handler's S3 list prefix (was a hardcoded `'processed/recipes/${id}/'`).
- New dedicated unit-test file `test/lambda/image-variants.test.ts` covers `toProcessedKey` directly.
- Existing fixture sweeps across `test/lambda/{image-resizer,recipe-image-handler,recipe-handler}.test.ts` from `'processed/recipes/...'` → `'recipes/...'`.
- New regression test in `recipe-handler.test.ts` asserts that stale old-shape `imageStatus` keys yield `processedAt: undefined` on the composed response.
- New DELETE-handler test asserts `ListObjectsV2Command.Prefix === 'recipes/<id>/'`.

## Why
Third + fourth steps of the **Images CDN — Phase 1** epic. Dropping the meaningless `processed/` namespace lets the public URL map 1:1 to the S3 key, eliminating the need for a CloudFront Function rewrite layer forever. PRD: `docs/prds/images-cdn-phase-1.md`.

This is a **load-bearing cross-repo contract change**: the `key` field returned by `POST /recipes/images/upload-url` and persisted into DynamoDB changes shape. The frontend (sibling PRD in `personal-website`) is updated in lockstep — there is no backwards-compat shim. Stale entries in any deployed `imageStatus` map will be ignored by the composer (per the new regression test).

## How to verify
- `pnpm test` — 339/339 pass (added 6 tests, swept 18+ fixture sites).
- `pnpm lint` — clean.
- `pnpm exec tsc --noEmit` — only the pre-existing `Cannot find type definition file for 'sharp'` warning (untouched in this diff).

## Decisions made
- **Bundled #124 + #125 into one PR**: the constant flip in #124 mechanically breaks every test fixture using the old shape, so the sweep in #125 had to land in lockstep — splitting them would either ship #124 with a red suite or duplicate the test commits.
- **`toProcessedKey` rewrite goes beyond "one-line constant flip"**: a naive constant flip produces double-`recipes/` keys (`'recipes/' + 'recipes/<id>/<type>'`). The PRD's "one-line change" claim was wrong. The minimal-ripple fix is the conditional strip; an alternative (collapsing the `recipes/` segment into `UPLOAD_PREFIX`) is opened as #136.
- **Single source of truth for the prefix in `recipe-handler.ts`**: imported the `PROCESSED_PREFIX` constant rather than hardcoding `'recipes/'`.

## AC coverage

**#124:**
- ✅ `PROCESSED_PREFIX === 'recipes/'` — `lambda/image-variants.ts:6`.
- ✅ `test/lambda/image-variants.test.ts` exists with direct unit coverage.
- ✅ `toProcessedKey('uploads/recipes/<id>/cover')` → `'recipes/<id>/cover'`.
- ✅ `toProcessedKey('not-uploads/foo')` throws.
- ✅ `toProcessedKey('uploads/')` throws.
- ✅ `toProcessedKey('uploads//double-slash')` → `'recipes//double-slash'`.
- ✅ TDD — `320c525` test commit before `b9f5632` impl commit.

**#125:**
- ✅ Resizer tests assert new `PutObjectCommand.Key` and `imageStatus` write key shape.
- ✅ Image-handler tests assert new response `key` shape.
- ✅ `composeImageProcessedAt` fixtures updated.
- ✅ Regression test for stale old-shape entries → `processedAt: undefined`.
- ✅ `pnpm test` passes.

## Reviewer findings deferred (out of scope)
- #136 — collapse the upload-key namespace into `UPLOAD_PREFIX`, dropping the conditional strip and the duplicated `'recipes'` segment in `recipe-image-handler.ts` and `image-resizer.ts`.