### PR TITLE
Docs: ImagesStack in CLAUDE.md + supersedes notes on prior PRDs (#129)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,13 +14,14 @@ Before implementing any new feature, check `docs/prds/` for a relevant PRD. If o
 
 ## Architecture
 
-Six stacks deployed across regions:
+Seven stacks deployed across regions:
 
 - **CertificateStack** (us-east-1): Route 53 hosted zone + ACM certificates (CloudFront requires us-east-1)
 - **AkliInfrastructureStack** (eu-west-2): S3, CloudFront, Route 53 records, IAM users, Secrets Manager
 - **PokedexStack** (eu-west-2): DynamoDB table, HTTP API Gateway, Lambda handlers
 - **AuthStack** (eu-west-2): Cognito user pool, HTTP API Gateway, Lambda handlers, JWT authoriser, CloudWatch alarms
 - **RecipeStack** (eu-west-2): DynamoDB table, S3 image bucket, HTTP API Gateway, Lambda handlers (CRUD, image upload, image resizer), JWT authoriser
+- **ImagesStack** (eu-west-2): CloudFront distribution serving `images.akli.dev` with the recipe-images bucket as origin
 - **ApiStack** (eu-west-2): CloudFront distribution for api.akli.dev, routes to Pokedex, Auth, and Recipe APIs
 
 Cross-region references are enabled so the main stack can consume the certificate.

--- a/docs/prds/image-processing-readiness.md
+++ b/docs/prds/image-processing-readiness.md
@@ -3,6 +3,8 @@
 > **Sibling PRD:** [`personal-website/docs/prds/image-processing-readiness.md`](../../../personal-website/docs/prds/image-processing-readiness.md) — covers the editor polling hook, processing skeletons across all image surfaces, and client-side publish-guard mirroring.
 >
 > **Context:** Follow-up to [`draft-recipes.md`](./draft-recipes.md), which shipped the async upload contract without a readiness signal, causing processed-variant 404s on admin surfaces.
+>
+> **URL pattern note:** the `https://akli.dev/images/processed/recipes/...` URL referenced in the Problem Statement below is replaced by the new `https://images.akli.dev/recipes/...` shape introduced in [`images-cdn-phase-1.md`](./images-cdn-phase-1.md). The readiness contract — `imageStatus[key]` written by the resizer, composed into `processedAt` on the API response, gating publish — is unaffected; only the URL host and key prefix change.
 
 ## Overview
 The recipes DynamoDB item gains a per-image readiness signal written by the image-resizer Lambda after variant PUTs succeed. The recipe handler composes that signal into the API response, extends publish validation to require readiness on every image, and adds a lightweight admin single-recipe endpoint that the frontend uses for polling.

--- a/docs/prds/recipe-api-infrastructure.md
+++ b/docs/prds/recipe-api-infrastructure.md
@@ -100,6 +100,8 @@ All endpoints are under the existing `api.akli.dev` CloudFront distribution.
 
 ### Image URLs
 
+> **Superseded by:** [`images-cdn-phase-1.md`](./images-cdn-phase-1.md). The `images/recipes/*` behaviour on the site CloudFront distribution described here was never implemented. Recipe images are now served from a dedicated `images.akli.dev` subdomain with the recipe-images bucket as a first-class origin, and the S3 key shape was flattened (no `processed/` prefix) so URLs map 1:1 to S3 keys.
+
 Images are stored in S3 under the `processed/` prefix and served via the site CloudFront distribution. The image `key` in the data model references the processed path. Three variants are generated on upload:
 
 - `{key}-thumb.webp` — 400px wide (listing cards, thumbnails)
@@ -174,6 +176,8 @@ All Lambda functions use Node.js 22, following existing conventions:
 - CORS: Allow origin `https://akli.dev`, methods GET/POST/PUT/PATCH/DELETE, headers `Content-Type` and `Authorization`.
 
 ### CloudFront/API Stack Changes
+
+> **Superseded by:** [`images-cdn-phase-1.md`](./images-cdn-phase-1.md) for the image-serving bullets below. The `images/recipes/*` behaviour on the site distribution was never implemented; recipe images are served from a dedicated `images.akli.dev` distribution (`ImagesStack`) instead. The API-side bullets (`/recipes/*` on `api.akli.dev`) shipped as described.
 
 - The `ApiStack` receives the recipe API endpoint as a prop (`recipeApiUrl: string`).
 - New CloudFront behaviour: `/recipes/*` routed to the recipe API origin.


### PR DESCRIPTION
Closes #129

## What changed
- `CLAUDE.md` Architecture section gains a bullet for `ImagesStack` (eu-west-2). Stack count updated from six to seven.
- `docs/prds/recipe-api-infrastructure.md` — Image URLs section and CloudFront/API Stack Changes section each get a `**Superseded by:**` note pointing to `images-cdn-phase-1.md`. The `images/recipes/*` behaviour on the site distribution that PRD originally described was never implemented.
- `docs/prds/image-processing-readiness.md` — adds a brief informational note in the preamble that the `https://akli.dev/images/processed/recipes/...` URL referenced in its Problem Statement is replaced by the new `https://images.akli.dev/recipes/...` shape. The readiness contract (`imageStatus[key]` written by the resizer, composed into `processedAt`, gating publish) is unaffected.

## Why
Documentation hygiene as the **Images CDN — Phase 1** epic wraps up. Future readers landing on the older PRDs need a clear pointer to the current architecture; the architecture bullet in `CLAUDE.md` keeps the canonical stack list accurate so future agents don't propose contradictory designs.

## How to verify
Read each diff — pure prose, no code paths affected.

## AC coverage
- ✅ `CLAUDE.md` Architecture section adds an `ImagesStack` bullet (`CLAUDE.md:24`).
- ✅ `recipe-api-infrastructure.md` Image URLs (`docs/prds/recipe-api-infrastructure.md:101`) and CloudFront/API Stack Changes (`docs/prds/recipe-api-infrastructure.md:178`) each get a Superseded-by note.
- ✅ `image-processing-readiness.md` preamble (`docs/prds/image-processing-readiness.md:7`) gets a URL-pattern note clarifying the readiness contract still holds.