### PR TITLE
Epic: Images CDN — Phase 1 (Recipe Images Subdomain)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,13 +14,14 @@ Before implementing any new feature, check `docs/prds/` for a relevant PRD. If o
 
 ## Architecture
 
-Six stacks deployed across regions:
+Seven stacks deployed across regions:
 
 - **CertificateStack** (us-east-1): Route 53 hosted zone + ACM certificates (CloudFront requires us-east-1)
 - **AkliInfrastructureStack** (eu-west-2): S3, CloudFront, Route 53 records, IAM users, Secrets Manager
 - **PokedexStack** (eu-west-2): DynamoDB table, HTTP API Gateway, Lambda handlers
 - **AuthStack** (eu-west-2): Cognito user pool, HTTP API Gateway, Lambda handlers, JWT authoriser, CloudWatch alarms
 - **RecipeStack** (eu-west-2): DynamoDB table, S3 image bucket, HTTP API Gateway, Lambda handlers (CRUD, image upload, image resizer), JWT authoriser
+- **ImagesStack** (eu-west-2): CloudFront distribution serving `images.akli.dev` with the recipe-images bucket as origin
 - **ApiStack** (eu-west-2): CloudFront distribution for api.akli.dev, routes to Pokedex, Auth, and Recipe APIs
 
 Cross-region references are enabled so the main stack can consume the certificate.

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ AWS CDK infrastructure for [akli.dev](https://akli.dev). Manages static site hos
 
 ## Architecture
 
-Six CDK stacks deployed across regions:
+Seven CDK stacks deployed across regions:
 
 | Stack | Region | Resources |
 |-------|--------|-----------|
@@ -13,6 +13,7 @@ Six CDK stacks deployed across regions:
 | PokedexStack | eu-west-2 | DynamoDB table, HTTP API Gateway, Lambda handlers |
 | AuthStack | eu-west-2 | Cognito user pool, HTTP API Gateway, Lambda handlers, JWT authoriser, CloudWatch alarms |
 | RecipeStack | eu-west-2 | DynamoDB table, S3 image bucket, HTTP API Gateway, Lambda handlers (CRUD, image upload, image resizer), JWT authoriser |
+| ImagesStack | eu-west-2 | CloudFront distribution for images.akli.dev, OAC, Route 53 records — serves recipe images from the recipe-images bucket under `recipes/*` |
 | ApiStack | eu-west-2 | CloudFront distribution for api.akli.dev, routes to Pokedex, Auth, and Recipe APIs |
 
 ```

--- a/bin/akli-infrastructure.ts
+++ b/bin/akli-infrastructure.ts
@@ -4,6 +4,7 @@ import { AkliInfrastructureStack } from '../lib/akli-infrastructure-stack';
 import { ApiStack } from '../lib/api-stack';
 import { AuthStack } from '../lib/auth-stack';
 import { CertificateStack } from '../lib/certificate-stack';
+import { ImagesStack } from '../lib/images-stack';
 import { PokedexStack } from '../lib/pokedex-stack';
 import { RecipeStack } from '../lib/recipe-stack';
 
@@ -69,6 +70,20 @@ const recipeStack = new RecipeStack(app, 'RecipeStack', {
   userPoolArn: authStack.userPoolArn,
   tags: {
     Project: 'recipes',
+    Environment: 'production',
+    ManagedBy: 'cdk',
+  },
+})
+
+new ImagesStack(app, 'ImagesStack', {
+  env: { account, region: 'eu-west-2' },
+  crossRegionReferences: true,
+  hostedZone: certStack.hostedZone,
+  imagesCertificate: certStack.imagesCertificate,
+  recipeImageBucket: recipeStack.imageBucket,
+  description: 'CloudFront distribution for images.akli.dev (recipe images origin)',
+  tags: {
+    Project: 'akli-images',
     Environment: 'production',
     ManagedBy: 'cdk',
   },

--- a/docs/prds/image-processing-readiness.md
+++ b/docs/prds/image-processing-readiness.md
@@ -3,6 +3,8 @@
 > **Sibling PRD:** [`personal-website/docs/prds/image-processing-readiness.md`](../../../personal-website/docs/prds/image-processing-readiness.md) — covers the editor polling hook, processing skeletons across all image surfaces, and client-side publish-guard mirroring.
 >
 > **Context:** Follow-up to [`draft-recipes.md`](./draft-recipes.md), which shipped the async upload contract without a readiness signal, causing processed-variant 404s on admin surfaces.
+>
+> **URL pattern note:** the `https://akli.dev/images/processed/recipes/...` URL referenced in the Problem Statement below is replaced by the new `https://images.akli.dev/recipes/...` shape introduced in [`images-cdn-phase-1.md`](./images-cdn-phase-1.md). The readiness contract — `imageStatus[key]` written by the resizer, composed into `processedAt` on the API response, gating publish — is unaffected; only the URL host and key prefix change.
 
 ## Overview
 The recipes DynamoDB item gains a per-image readiness signal written by the image-resizer Lambda after variant PUTs succeed. The recipe handler composes that signal into the API response, extends publish validation to require readiness on every image, and adds a lightweight admin single-recipe endpoint that the frontend uses for polling.

--- a/docs/prds/recipe-api-infrastructure.md
+++ b/docs/prds/recipe-api-infrastructure.md
@@ -100,6 +100,8 @@ All endpoints are under the existing `api.akli.dev` CloudFront distribution.
 
 ### Image URLs
 
+> **Superseded by:** [`images-cdn-phase-1.md`](./images-cdn-phase-1.md). The `images/recipes/*` behaviour on the site CloudFront distribution described here was never implemented. Recipe images are now served from a dedicated `images.akli.dev` subdomain with the recipe-images bucket as a first-class origin, and the S3 key shape was flattened (no `processed/` prefix) so URLs map 1:1 to S3 keys.
+
 Images are stored in S3 under the `processed/` prefix and served via the site CloudFront distribution. The image `key` in the data model references the processed path. Three variants are generated on upload:
 
 - `{key}-thumb.webp` — 400px wide (listing cards, thumbnails)
@@ -174,6 +176,8 @@ All Lambda functions use Node.js 22, following existing conventions:
 - CORS: Allow origin `https://akli.dev`, methods GET/POST/PUT/PATCH/DELETE, headers `Content-Type` and `Authorization`.
 
 ### CloudFront/API Stack Changes
+
+> **Superseded by:** [`images-cdn-phase-1.md`](./images-cdn-phase-1.md) for the image-serving bullets below. The `images/recipes/*` behaviour on the site distribution was never implemented; recipe images are served from a dedicated `images.akli.dev` distribution (`ImagesStack`) instead. The API-side bullets (`/recipes/*` on `api.akli.dev`) shipped as described.
 
 - The `ApiStack` receives the recipe API endpoint as a prop (`recipeApiUrl: string`).
 - New CloudFront behaviour: `/recipes/*` routed to the recipe API origin.

--- a/lambda/image-variants.ts
+++ b/lambda/image-variants.ts
@@ -2,15 +2,19 @@ export const VARIANT_SUFFIXES = ['thumb', 'medium', 'full'] as const
 
 export type VariantSuffix = (typeof VARIANT_SUFFIXES)[number]
 
-// S3 key prefixes for the image pipeline. Uploads land under UPLOAD_PREFIX
-// (what the resizer S3 trigger listens for); processed variants are written
-// under PROCESSED_PREFIX (where the site serves `<prefix><name>-<variant>.webp`).
 export const UPLOAD_PREFIX = 'uploads/'
-export const PROCESSED_PREFIX = 'processed/'
+export const PROCESSED_PREFIX = 'recipes/'
 
 export const toProcessedKey = (uploadKey: string): string => {
   if (!uploadKey.startsWith(UPLOAD_PREFIX)) {
     throw new Error(`Expected key to start with "${UPLOAD_PREFIX}", got "${uploadKey}"`)
   }
-  return PROCESSED_PREFIX + uploadKey.slice(UPLOAD_PREFIX.length)
+  const afterUpload = uploadKey.slice(UPLOAD_PREFIX.length)
+  if (afterUpload.length === 0) {
+    throw new Error(`Expected key to have content after "${UPLOAD_PREFIX}", got "${uploadKey}"`)
+  }
+  const stripped = afterUpload.startsWith(PROCESSED_PREFIX)
+    ? afterUpload.slice(PROCESSED_PREFIX.length)
+    : afterUpload
+  return PROCESSED_PREFIX + stripped
 }

--- a/lambda/recipe-handler.ts
+++ b/lambda/recipe-handler.ts
@@ -3,7 +3,7 @@ import { DynamoDBClient } from '@aws-sdk/client-dynamodb'
 import { S3Client, ListObjectsV2Command, DeleteObjectsCommand } from '@aws-sdk/client-s3'
 import { DynamoDBDocumentClient, QueryCommand, GetCommand, PutCommand, UpdateCommand, DeleteCommand, ScanCommand } from '@aws-sdk/lib-dynamodb'
 import type { APIGatewayProxyEventV2, APIGatewayProxyStructuredResultV2 } from 'aws-lambda'
-import { VARIANT_SUFFIXES } from './image-variants'
+import { VARIANT_SUFFIXES, PROCESSED_PREFIX } from './image-variants'
 
 const ddbClient = new DynamoDBClient({})
 const docClient = DynamoDBDocumentClient.from(ddbClient)
@@ -638,7 +638,7 @@ async function handleDeleteRecipe(event: APIGatewayProxyEventV2): Promise<APIGat
   const listResult = await s3Client.send(
     new ListObjectsV2Command({
       Bucket: IMAGE_BUCKET_NAME,
-      Prefix: `processed/recipes/${id}/`,
+      Prefix: `${PROCESSED_PREFIX}${id}/`,
     }),
   )
 

--- a/lib/akli-infrastructure-stack.ts
+++ b/lib/akli-infrastructure-stack.ts
@@ -12,6 +12,7 @@ import * as targets from 'aws-cdk-lib/aws-route53-targets'
 import * as s3 from 'aws-cdk-lib/aws-s3'
 import * as secretsmanager from 'aws-cdk-lib/aws-secretsmanager'
 import type { Construct } from 'constructs'
+import { createImageCachePolicy, createSecurityHeadersPolicy } from './cdn-policies'
 
 interface AkliInfrastructureStackProps extends StackProps {
   hostedZone: route53.IHostedZone
@@ -50,30 +51,9 @@ export class AkliInfrastructureStack extends Stack {
       description: `OAC for ${DOMAIN_NAME}`,
     })
 
-    const securityHeadersPolicy = new cloudfront.ResponseHeadersPolicy(this, 'SecurityHeaders', {
-      securityHeadersBehavior: {
-        contentTypeOptions: { override: true },
-        frameOptions: { frameOption: cloudfront.HeadersFrameOption.DENY, override: true },
-        referrerPolicy: { referrerPolicy: cloudfront.HeadersReferrerPolicy.STRICT_ORIGIN_WHEN_CROSS_ORIGIN, override: true },
-        strictTransportSecurity: {
-          accessControlMaxAge: Duration.seconds(31536000),
-          includeSubdomains: true,
-          preload: true,
-          override: true
-        },
-      },
-    })
+    const securityHeadersPolicy = createSecurityHeadersPolicy(this)
 
-    // Cache policy for images with query string support
-    const imageCachePolicy = new cloudfront.CachePolicy(this, 'ImageCachePolicy', {
-      cachePolicyName: 'ImageOptimizationPolicy',
-      defaultTtl: Duration.days(30),
-      maxTtl: Duration.days(365),
-      minTtl: Duration.seconds(0),
-      queryStringBehavior: cloudfront.CacheQueryStringBehavior.all(), // Allow all query params
-      headerBehavior: cloudfront.CacheHeaderBehavior.allowList('Accept', 'CloudFront-Viewer-Country'),
-      cookieBehavior: cloudfront.CacheCookieBehavior.none(),
-    })
+    const imageCachePolicy = createImageCachePolicy(this)
 
     const subdirectoryIndexHandler = new cloudfront.Function(this, 'SubfolderIndexRewrite', {
       code: cloudfront.FunctionCode.fromInline(`

--- a/lib/cdn-policies.ts
+++ b/lib/cdn-policies.ts
@@ -1,26 +1,52 @@
-import type * as cloudfront from 'aws-cdk-lib/aws-cloudfront'
+import { Duration } from 'aws-cdk-lib'
+import * as cloudfront from 'aws-cdk-lib/aws-cloudfront'
 import type { Construct } from 'constructs'
 
 /**
  * Creates the shared image cache policy used by CloudFront distributions
  * that serve optimised images. Stable name `AkliImageCachePolicy` lets
  * tests and other stacks reference the policy by name.
- *
- * Stub — replaced by the cdk-engineer in issue #122.
  */
-export function createImageCachePolicy(_scope: Construct, _id?: string): cloudfront.CachePolicy {
-  throw new Error('createImageCachePolicy: not implemented')
+export function createImageCachePolicy(
+  scope: Construct,
+  id: string = 'ImageCachePolicy',
+): cloudfront.CachePolicy {
+  return new cloudfront.CachePolicy(scope, id, {
+    cachePolicyName: 'AkliImageCachePolicy',
+    defaultTtl: Duration.days(30),
+    maxTtl: Duration.days(365),
+    minTtl: Duration.seconds(0),
+    queryStringBehavior: cloudfront.CacheQueryStringBehavior.all(),
+    headerBehavior: cloudfront.CacheHeaderBehavior.allowList('Accept', 'CloudFront-Viewer-Country'),
+    cookieBehavior: cloudfront.CacheCookieBehavior.none(),
+  })
 }
 
 /**
  * Creates the shared response headers policy applied to CloudFront viewer
  * responses (CSP-adjacent security headers, HSTS, frame options, etc.).
- *
- * Stub — replaced by the cdk-engineer in issue #122.
  */
 export function createSecurityHeadersPolicy(
-  _scope: Construct,
-  _id?: string,
+  scope: Construct,
+  id: string = 'SecurityHeaders',
 ): cloudfront.ResponseHeadersPolicy {
-  throw new Error('createSecurityHeadersPolicy: not implemented')
+  return new cloudfront.ResponseHeadersPolicy(scope, id, {
+    securityHeadersBehavior: {
+      contentTypeOptions: { override: true },
+      frameOptions: {
+        frameOption: cloudfront.HeadersFrameOption.DENY,
+        override: true,
+      },
+      referrerPolicy: {
+        referrerPolicy: cloudfront.HeadersReferrerPolicy.STRICT_ORIGIN_WHEN_CROSS_ORIGIN,
+        override: true,
+      },
+      strictTransportSecurity: {
+        accessControlMaxAge: Duration.seconds(31536000),
+        includeSubdomains: true,
+        preload: true,
+        override: true,
+      },
+    },
+  })
 }

--- a/lib/cdn-policies.ts
+++ b/lib/cdn-policies.ts
@@ -1,0 +1,26 @@
+import type * as cloudfront from 'aws-cdk-lib/aws-cloudfront'
+import type { Construct } from 'constructs'
+
+/**
+ * Creates the shared image cache policy used by CloudFront distributions
+ * that serve optimised images. Stable name `AkliImageCachePolicy` lets
+ * tests and other stacks reference the policy by name.
+ *
+ * Stub — replaced by the cdk-engineer in issue #122.
+ */
+export function createImageCachePolicy(_scope: Construct, _id?: string): cloudfront.CachePolicy {
+  throw new Error('createImageCachePolicy: not implemented')
+}
+
+/**
+ * Creates the shared response headers policy applied to CloudFront viewer
+ * responses (CSP-adjacent security headers, HSTS, frame options, etc.).
+ *
+ * Stub — replaced by the cdk-engineer in issue #122.
+ */
+export function createSecurityHeadersPolicy(
+  _scope: Construct,
+  _id?: string,
+): cloudfront.ResponseHeadersPolicy {
+  throw new Error('createSecurityHeadersPolicy: not implemented')
+}

--- a/lib/cdn-policies.ts
+++ b/lib/cdn-policies.ts
@@ -2,17 +2,14 @@ import { Duration } from 'aws-cdk-lib'
 import * as cloudfront from 'aws-cdk-lib/aws-cloudfront'
 import type { Construct } from 'constructs'
 
-/**
- * Creates the shared image cache policy used by CloudFront distributions
- * that serve optimised images. Stable name `AkliImageCachePolicy` lets
- * tests and other stacks reference the policy by name.
- */
+export const IMAGE_CACHE_POLICY_NAME = 'AkliImageCachePolicy'
+
 export function createImageCachePolicy(
   scope: Construct,
   id: string = 'ImageCachePolicy',
 ): cloudfront.CachePolicy {
   return new cloudfront.CachePolicy(scope, id, {
-    cachePolicyName: 'AkliImageCachePolicy',
+    cachePolicyName: IMAGE_CACHE_POLICY_NAME,
     defaultTtl: Duration.days(30),
     maxTtl: Duration.days(365),
     minTtl: Duration.seconds(0),
@@ -22,10 +19,6 @@ export function createImageCachePolicy(
   })
 }
 
-/**
- * Creates the shared response headers policy applied to CloudFront viewer
- * responses (CSP-adjacent security headers, HSTS, frame options, etc.).
- */
 export function createSecurityHeadersPolicy(
   scope: Construct,
   id: string = 'SecurityHeaders',
@@ -42,7 +35,7 @@ export function createSecurityHeadersPolicy(
         override: true,
       },
       strictTransportSecurity: {
-        accessControlMaxAge: Duration.seconds(31536000),
+        accessControlMaxAge: Duration.days(365),
         includeSubdomains: true,
         preload: true,
         override: true,

--- a/lib/certificate-stack.ts
+++ b/lib/certificate-stack.ts
@@ -1,5 +1,5 @@
 import type { StackProps } from 'aws-cdk-lib';
-import { Stack } from 'aws-cdk-lib'
+import { CfnOutput, Stack } from 'aws-cdk-lib'
 import * as certificatemanager from 'aws-cdk-lib/aws-certificatemanager'
 import * as route53 from 'aws-cdk-lib/aws-route53'
 import type { Construct } from 'constructs'
@@ -7,6 +7,7 @@ import type { Construct } from 'constructs'
 const DOMAIN_NAME = 'akli.dev'
 const WWW_DOMAIN_NAME = `www.${DOMAIN_NAME}`
 const API_DOMAIN_NAME = `api.${DOMAIN_NAME}`
+const IMAGES_DOMAIN_NAME = `images.${DOMAIN_NAME}`
 
 /**
  * Separate stack for ACM certificates and Route 53 hosted zone.
@@ -17,6 +18,7 @@ export class CertificateStack extends Stack {
   public readonly hostedZone: route53.HostedZone
   public readonly certificate: certificatemanager.Certificate
   public readonly apiCertificate: certificatemanager.Certificate
+  public readonly imagesCertificate: certificatemanager.Certificate
 
   constructor(scope: Construct, id: string, props?: StackProps) {
     super(scope, id, props)
@@ -36,6 +38,18 @@ export class CertificateStack extends Stack {
     this.apiCertificate = new certificatemanager.Certificate(this, 'ApiCert', {
       domainName: API_DOMAIN_NAME,
       validation: certificatemanager.CertificateValidation.fromDns(this.hostedZone),
+    })
+
+    // Dedicated certificate for images.akli.dev — separate cert avoids replacing SiteCert (which would
+    // break cross-region SSM exports consumed by AkliInfrastructureStack). See images-cdn-phase-1 PRD.
+    this.imagesCertificate = new certificatemanager.Certificate(this, 'ImagesCert', {
+      domainName: IMAGES_DOMAIN_NAME,
+      validation: certificatemanager.CertificateValidation.fromDns(this.hostedZone),
+    })
+
+    new CfnOutput(this, 'ImagesCertArn', {
+      value: this.imagesCertificate.certificateArn,
+      description: 'ACM certificate ARN for images.akli.dev (consumed cross-region by ImagesStack)',
     })
   }
 }

--- a/lib/certificate-stack.ts
+++ b/lib/certificate-stack.ts
@@ -1,5 +1,5 @@
 import type { StackProps } from 'aws-cdk-lib';
-import { CfnOutput, Stack } from 'aws-cdk-lib'
+import { Stack } from 'aws-cdk-lib'
 import * as certificatemanager from 'aws-cdk-lib/aws-certificatemanager'
 import * as route53 from 'aws-cdk-lib/aws-route53'
 import type { Construct } from 'constructs'
@@ -40,16 +40,10 @@ export class CertificateStack extends Stack {
       validation: certificatemanager.CertificateValidation.fromDns(this.hostedZone),
     })
 
-    // Dedicated certificate for images.akli.dev — separate cert avoids replacing SiteCert (which would
-    // break cross-region SSM exports consumed by AkliInfrastructureStack). See images-cdn-phase-1 PRD.
+    // Separate certificate for images.akli.dev — avoids replacing the site cert which would break cross-stack exports
     this.imagesCertificate = new certificatemanager.Certificate(this, 'ImagesCert', {
       domainName: IMAGES_DOMAIN_NAME,
       validation: certificatemanager.CertificateValidation.fromDns(this.hostedZone),
-    })
-
-    new CfnOutput(this, 'ImagesCertArn', {
-      value: this.imagesCertificate.certificateArn,
-      description: 'ACM certificate ARN for images.akli.dev (consumed cross-region by ImagesStack)',
     })
   }
 }

--- a/lib/images-stack.ts
+++ b/lib/images-stack.ts
@@ -1,0 +1,28 @@
+import type { StackProps } from 'aws-cdk-lib'
+import { Stack } from 'aws-cdk-lib'
+import type * as certificatemanager from 'aws-cdk-lib/aws-certificatemanager'
+import type * as route53 from 'aws-cdk-lib/aws-route53'
+import type * as s3 from 'aws-cdk-lib/aws-s3'
+import type { Construct } from 'constructs'
+
+interface ImagesStackProps extends StackProps {
+  hostedZone: route53.IHostedZone
+  imagesCertificate: certificatemanager.ICertificate
+  recipeImageBucket: s3.IBucket
+}
+
+/**
+ * CloudFront distribution for images.akli.dev.
+ *
+ * Phase 1: serves the recipe-images S3 bucket via OAC under `recipes/*`.
+ * Default behaviour returns a synthetic 404 via a viewer-request CloudFront
+ * Function so non-routed paths never hit the origin.
+ *
+ * Stub — implementation to follow in cdk-engineer pass.
+ */
+export class ImagesStack extends Stack {
+  constructor(scope: Construct, id: string, props: ImagesStackProps) {
+    super(scope, id, props)
+    // not implemented — cdk-engineer fills this in
+  }
+}

--- a/lib/images-stack.ts
+++ b/lib/images-stack.ts
@@ -5,6 +5,7 @@ import * as cloudfront from 'aws-cdk-lib/aws-cloudfront'
 import * as origins from 'aws-cdk-lib/aws-cloudfront-origins'
 import * as iam from 'aws-cdk-lib/aws-iam'
 import * as route53 from 'aws-cdk-lib/aws-route53'
+import * as targets from 'aws-cdk-lib/aws-route53-targets'
 import * as s3 from 'aws-cdk-lib/aws-s3'
 import type { Construct } from 'constructs'
 import { createImageCachePolicy, createSecurityHeadersPolicy } from './cdn-policies'
@@ -18,34 +19,20 @@ interface ImagesStackProps extends StackProps {
   recipeImageBucket: s3.IBucket
 }
 
-/**
- * CloudFront distribution for images.akli.dev.
- *
- * Phase 1: serves the recipe-images S3 bucket via OAC under `recipes/*`.
- * Default behaviour returns a synthetic 404 via a viewer-request CloudFront
- * Function so non-routed paths never hit the origin.
- */
 export class ImagesStack extends Stack {
   constructor(scope: Construct, id: string, props: ImagesStackProps) {
     super(scope, id, props)
 
     const { hostedZone, imagesCertificate, recipeImageBucket } = props
 
-    // Origin Access Control for the recipe-images bucket.
     const originAccessControl = new cloudfront.S3OriginAccessControl(this, 'ImagesOAC')
 
-    // Re-import the cross-stack bucket as an IBucket reference within this
-    // stack. This is important: `S3BucketOrigin.withOriginAccessControl`
-    // tries to auto-attach a bucket policy that scopes `aws:SourceArn` to
-    // the distribution's ID. With a "real" cross-stack bucket, that auto-
-    // attach succeeds and creates a cyclic dependency (RecipeStack policy
-    // refers to ImagesStack distribution; ImagesStack origin refers to
-    // RecipeStack bucket). Importing via `fromBucketAttributes` makes the
-    // bucket reference behave like an imported bucket — `addToResourcePolicy`
-    // is a no-op on the imported view, so the auto-attach is skipped (CDK
-    // emits a warning instead). We then explicitly attach a policy below
-    // using the original cross-stack bucket reference, with a wildcard
-    // SourceArn to avoid the same cycle.
+    // Re-import the cross-stack bucket so `S3BucketOrigin.withOriginAccessControl`
+    // treats it as imported and skips its auto-attached bucket policy. Auto-attach
+    // would scope `aws:SourceArn` to `distribution.distributionId` and create a
+    // cycle: RecipeStack policy → ImagesStack distribution while ImagesStack
+    // origin already → RecipeStack bucket. Policy is re-attached below with a
+    // wildcard SourceArn to keep the cycle broken.
     const importedBucket = s3.Bucket.fromBucketAttributes(this, 'ImportedRecipeImageBucket', {
       bucketArn: recipeImageBucket.bucketArn,
       region: recipeImageBucket.env.region,
@@ -56,11 +43,6 @@ export class ImagesStack extends Stack {
       { originAccessControl },
     )
 
-    // CloudFront Function: viewer-request handler that returns a synthetic
-    // 404 for any path that hits the default behaviour. CloudFront requires
-    // every behaviour (including the default) to declare an origin, so the
-    // origin reference is a formality — the function ensures the origin is
-    // never queried for default-behaviour requests.
     const defaultDeny404 = new cloudfront.Function(this, 'DefaultDeny404Function', {
       code: cloudfront.FunctionCode.fromInline(
         `function handler(event) {
@@ -69,17 +51,15 @@ export class ImagesStack extends Stack {
       ),
     })
 
-    // Shared cache + headers policies (also used by AkliInfrastructureStack).
     const imageCachePolicy = createImageCachePolicy(this)
     const securityHeadersPolicy = createSecurityHeadersPolicy(this)
 
-    // CloudFront distribution for images.akli.dev.
     const distribution = new cloudfront.Distribution(this, 'ImagesDistribution', {
       domainNames: [IMAGES_DOMAIN_NAME],
       certificate: imagesCertificate,
       defaultBehavior: {
-        // Origin is a formality — function below returns 404 before the
-        // origin is queried.
+        // Origin is a formality; the function below returns 404 first so the
+        // origin is never queried for default-behaviour requests.
         origin: recipeImageOrigin,
         viewerProtocolPolicy: cloudfront.ViewerProtocolPolicy.REDIRECT_TO_HTTPS,
         cachePolicy: cloudfront.CachePolicy.CACHING_DISABLED,
@@ -102,19 +82,10 @@ export class ImagesStack extends Stack {
       },
     })
 
-    // Bucket policy: grant s3:GetObject to the CloudFront service principal,
-    // scoped via aws:SourceArn. Required because the bucket is owned by
-    // RecipeStack — CDK does not auto-attach the policy for cross-stack
-    // origins.
-    //
-    // SourceArn caveat: the bucket lives in RecipeStack and the distribution
-    // lives here in ImagesStack. Referencing `distribution.distributionId`
-    // directly would create a cyclic stack dependency (RecipeStack would
-    // depend on ImagesStack via the policy, while ImagesStack already
-    // depends on RecipeStack via the bucket origin). A wildcard scoped to
-    // this account preserves the same security boundary in practice (only
-    // CloudFront distributions in this account can invoke S3 with this
-    // SourceArn) without creating a cycle.
+    // Wildcard SourceArn (account-scoped) avoids a cyclic dependency between
+    // RecipeStack (policy) and ImagesStack (distribution). The OAC association
+    // on the distribution side still gates which CloudFront principals reach
+    // the bucket; the wildcard limits the grant to this account's CloudFront.
     recipeImageBucket.addToResourcePolicy(new iam.PolicyStatement({
       effect: iam.Effect.ALLOW,
       principals: [new iam.ServicePrincipal('cloudfront.amazonaws.com')],
@@ -127,28 +98,18 @@ export class ImagesStack extends Stack {
       },
     }))
 
-    // Route 53 alias records: images.akli.dev → CloudFront distribution.
-    // Use the literal global CloudFront alias hosted-zone ID (Z2FDTNDATAQYW2)
-    // rather than the Fn::FindInMap that route53-targets.CloudFrontTarget
-    // emits — this keeps the synthesised template compact and predictable
-    // (and matches the AC, which asserts the literal value).
-    const cloudFrontAliasTarget: route53.IAliasRecordTarget = {
-      bind: () => ({
-        dnsName: distribution.distributionDomainName,
-        hostedZoneId: 'Z2FDTNDATAQYW2',
-      }),
-    }
+    const aliasTarget = route53.RecordTarget.fromAlias(new targets.CloudFrontTarget(distribution))
 
     new route53.ARecord(this, 'ImagesAliasRecord', {
       zone: hostedZone,
       recordName: 'images',
-      target: route53.RecordTarget.fromAlias(cloudFrontAliasTarget),
+      target: aliasTarget,
     })
 
     new route53.AaaaRecord(this, 'ImagesAaaaAliasRecord', {
       zone: hostedZone,
       recordName: 'images',
-      target: route53.RecordTarget.fromAlias(cloudFrontAliasTarget),
+      target: aliasTarget,
     })
 
     applyStackTags(this, props)

--- a/lib/images-stack.ts
+++ b/lib/images-stack.ts
@@ -1,9 +1,16 @@
 import type { StackProps } from 'aws-cdk-lib'
 import { Stack } from 'aws-cdk-lib'
 import type * as certificatemanager from 'aws-cdk-lib/aws-certificatemanager'
-import type * as route53 from 'aws-cdk-lib/aws-route53'
-import type * as s3 from 'aws-cdk-lib/aws-s3'
+import * as cloudfront from 'aws-cdk-lib/aws-cloudfront'
+import * as origins from 'aws-cdk-lib/aws-cloudfront-origins'
+import * as iam from 'aws-cdk-lib/aws-iam'
+import * as route53 from 'aws-cdk-lib/aws-route53'
+import * as s3 from 'aws-cdk-lib/aws-s3'
 import type { Construct } from 'constructs'
+import { createImageCachePolicy, createSecurityHeadersPolicy } from './cdn-policies'
+import { applyStackTags } from './utils'
+
+const IMAGES_DOMAIN_NAME = 'images.akli.dev'
 
 interface ImagesStackProps extends StackProps {
   hostedZone: route53.IHostedZone
@@ -17,12 +24,133 @@ interface ImagesStackProps extends StackProps {
  * Phase 1: serves the recipe-images S3 bucket via OAC under `recipes/*`.
  * Default behaviour returns a synthetic 404 via a viewer-request CloudFront
  * Function so non-routed paths never hit the origin.
- *
- * Stub — implementation to follow in cdk-engineer pass.
  */
 export class ImagesStack extends Stack {
   constructor(scope: Construct, id: string, props: ImagesStackProps) {
     super(scope, id, props)
-    // not implemented — cdk-engineer fills this in
+
+    const { hostedZone, imagesCertificate, recipeImageBucket } = props
+
+    // Origin Access Control for the recipe-images bucket.
+    const originAccessControl = new cloudfront.S3OriginAccessControl(this, 'ImagesOAC')
+
+    // Re-import the cross-stack bucket as an IBucket reference within this
+    // stack. This is important: `S3BucketOrigin.withOriginAccessControl`
+    // tries to auto-attach a bucket policy that scopes `aws:SourceArn` to
+    // the distribution's ID. With a "real" cross-stack bucket, that auto-
+    // attach succeeds and creates a cyclic dependency (RecipeStack policy
+    // refers to ImagesStack distribution; ImagesStack origin refers to
+    // RecipeStack bucket). Importing via `fromBucketAttributes` makes the
+    // bucket reference behave like an imported bucket — `addToResourcePolicy`
+    // is a no-op on the imported view, so the auto-attach is skipped (CDK
+    // emits a warning instead). We then explicitly attach a policy below
+    // using the original cross-stack bucket reference, with a wildcard
+    // SourceArn to avoid the same cycle.
+    const importedBucket = s3.Bucket.fromBucketAttributes(this, 'ImportedRecipeImageBucket', {
+      bucketArn: recipeImageBucket.bucketArn,
+      region: recipeImageBucket.env.region,
+    })
+
+    const recipeImageOrigin = origins.S3BucketOrigin.withOriginAccessControl(
+      importedBucket,
+      { originAccessControl },
+    )
+
+    // CloudFront Function: viewer-request handler that returns a synthetic
+    // 404 for any path that hits the default behaviour. CloudFront requires
+    // every behaviour (including the default) to declare an origin, so the
+    // origin reference is a formality — the function ensures the origin is
+    // never queried for default-behaviour requests.
+    const defaultDeny404 = new cloudfront.Function(this, 'DefaultDeny404Function', {
+      code: cloudfront.FunctionCode.fromInline(
+        `function handler(event) {
+  return { statusCode: 404, statusDescription: 'Not Found' };
+}`,
+      ),
+    })
+
+    // Shared cache + headers policies (also used by AkliInfrastructureStack).
+    const imageCachePolicy = createImageCachePolicy(this)
+    const securityHeadersPolicy = createSecurityHeadersPolicy(this)
+
+    // CloudFront distribution for images.akli.dev.
+    const distribution = new cloudfront.Distribution(this, 'ImagesDistribution', {
+      domainNames: [IMAGES_DOMAIN_NAME],
+      certificate: imagesCertificate,
+      defaultBehavior: {
+        // Origin is a formality — function below returns 404 before the
+        // origin is queried.
+        origin: recipeImageOrigin,
+        viewerProtocolPolicy: cloudfront.ViewerProtocolPolicy.REDIRECT_TO_HTTPS,
+        cachePolicy: cloudfront.CachePolicy.CACHING_DISABLED,
+        responseHeadersPolicy: securityHeadersPolicy,
+        allowedMethods: cloudfront.AllowedMethods.ALLOW_GET_HEAD,
+        functionAssociations: [{
+          function: defaultDeny404,
+          eventType: cloudfront.FunctionEventType.VIEWER_REQUEST,
+        }],
+      },
+      additionalBehaviors: {
+        'recipes/*': {
+          origin: recipeImageOrigin,
+          viewerProtocolPolicy: cloudfront.ViewerProtocolPolicy.REDIRECT_TO_HTTPS,
+          cachePolicy: imageCachePolicy,
+          responseHeadersPolicy: securityHeadersPolicy,
+          allowedMethods: cloudfront.AllowedMethods.ALLOW_GET_HEAD,
+          compress: true,
+        },
+      },
+    })
+
+    // Bucket policy: grant s3:GetObject to the CloudFront service principal,
+    // scoped via aws:SourceArn. Required because the bucket is owned by
+    // RecipeStack — CDK does not auto-attach the policy for cross-stack
+    // origins.
+    //
+    // SourceArn caveat: the bucket lives in RecipeStack and the distribution
+    // lives here in ImagesStack. Referencing `distribution.distributionId`
+    // directly would create a cyclic stack dependency (RecipeStack would
+    // depend on ImagesStack via the policy, while ImagesStack already
+    // depends on RecipeStack via the bucket origin). A wildcard scoped to
+    // this account preserves the same security boundary in practice (only
+    // CloudFront distributions in this account can invoke S3 with this
+    // SourceArn) without creating a cycle.
+    recipeImageBucket.addToResourcePolicy(new iam.PolicyStatement({
+      effect: iam.Effect.ALLOW,
+      principals: [new iam.ServicePrincipal('cloudfront.amazonaws.com')],
+      actions: ['s3:GetObject'],
+      resources: [`${recipeImageBucket.bucketArn}/*`],
+      conditions: {
+        StringEquals: {
+          'aws:SourceArn': `arn:aws:cloudfront::${this.account}:distribution/*`,
+        },
+      },
+    }))
+
+    // Route 53 alias records: images.akli.dev → CloudFront distribution.
+    // Use the literal global CloudFront alias hosted-zone ID (Z2FDTNDATAQYW2)
+    // rather than the Fn::FindInMap that route53-targets.CloudFrontTarget
+    // emits — this keeps the synthesised template compact and predictable
+    // (and matches the AC, which asserts the literal value).
+    const cloudFrontAliasTarget: route53.IAliasRecordTarget = {
+      bind: () => ({
+        dnsName: distribution.distributionDomainName,
+        hostedZoneId: 'Z2FDTNDATAQYW2',
+      }),
+    }
+
+    new route53.ARecord(this, 'ImagesAliasRecord', {
+      zone: hostedZone,
+      recordName: 'images',
+      target: route53.RecordTarget.fromAlias(cloudFrontAliasTarget),
+    })
+
+    new route53.AaaaRecord(this, 'ImagesAaaaAliasRecord', {
+      zone: hostedZone,
+      recordName: 'images',
+      target: route53.RecordTarget.fromAlias(cloudFrontAliasTarget),
+    })
+
+    applyStackTags(this, props)
   }
 }

--- a/lib/recipe-stack.ts
+++ b/lib/recipe-stack.ts
@@ -20,6 +20,7 @@ interface RecipeStackProps extends StackProps {
 
 export class RecipeStack extends Stack {
   public readonly httpApi: HttpApi
+  public readonly imageBucket: s3.IBucket
 
   constructor(scope: Construct, id: string, props: RecipeStackProps) {
     super(scope, id, props)
@@ -69,6 +70,7 @@ export class RecipeStack extends Stack {
         },
       ],
     })
+    this.imageBucket = imageBucket
 
     // HTTP API with CORS
     this.httpApi = new HttpApi(this, 'RecipeHttpApi', {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "akli-infrastructure",
   "description": "Infrastructure as Code for akli.dev",
-  "version": "1.7.0",
+  "version": "1.8.0",
   "bin": {
     "akli-cdk": "bin/akli-cdk.js"
   },

--- a/test/akli-infrastructure.test.ts
+++ b/test/akli-infrastructure.test.ts
@@ -213,6 +213,16 @@ describe('AkliInfrastructureStack', () => {
     })
   })
 
+  describe('Image cache policy', () => {
+    it('uses the stable name AkliImageCachePolicy so other stacks can reference it', () => {
+      template.hasResourceProperties('AWS::CloudFront::CachePolicy', {
+        CachePolicyConfig: Match.objectLike({
+          Name: 'AkliImageCachePolicy',
+        }),
+      })
+    })
+  })
+
   describe('IAM deploy policy', () => {
     it('grants lambda:UpdateFunctionCode and lambda:GetFunction scoped to the SSR function', () => {
       template.hasResourceProperties('AWS::IAM::Policy', {

--- a/test/cdn-policies.test.ts
+++ b/test/cdn-policies.test.ts
@@ -1,7 +1,11 @@
 import * as cdk from 'aws-cdk-lib'
 import { Match, Template } from 'aws-cdk-lib/assertions'
 import * as cloudfront from 'aws-cdk-lib/aws-cloudfront'
-import { createImageCachePolicy, createSecurityHeadersPolicy } from '../lib/cdn-policies'
+import {
+  createImageCachePolicy,
+  createSecurityHeadersPolicy,
+  IMAGE_CACHE_POLICY_NAME,
+} from '../lib/cdn-policies'
 
 function harnessStack(): cdk.Stack {
   const app = new cdk.App()
@@ -12,31 +16,28 @@ function harnessStack(): cdk.Stack {
 
 describe('cdn-policies', () => {
   describe('createImageCachePolicy', () => {
-    it('returns a cloudfront.CachePolicy construct', () => {
+    let policy: cloudfront.CachePolicy
+    let template: Template
+
+    beforeAll(() => {
       const stack = harnessStack()
+      policy = createImageCachePolicy(stack, 'TestImageCachePolicy')
+      template = Template.fromStack(stack)
+    })
 
-      const policy = createImageCachePolicy(stack, 'TestImageCachePolicy')
-
+    it('returns a cloudfront.CachePolicy construct', () => {
       expect(policy).toBeInstanceOf(cloudfront.CachePolicy)
     })
 
-    it('synthesises with the stable name AkliImageCachePolicy', () => {
-      const stack = harnessStack()
-      createImageCachePolicy(stack, 'TestImageCachePolicy')
-
-      const template = Template.fromStack(stack)
+    it('synthesises with the stable name from IMAGE_CACHE_POLICY_NAME', () => {
       template.hasResourceProperties('AWS::CloudFront::CachePolicy', {
         CachePolicyConfig: Match.objectLike({
-          Name: 'AkliImageCachePolicy',
+          Name: IMAGE_CACHE_POLICY_NAME,
         }),
       })
     })
 
     it('configures default 30-day, max 365-day, min 0-second TTLs', () => {
-      const stack = harnessStack()
-      createImageCachePolicy(stack, 'TestImageCachePolicy')
-
-      const template = Template.fromStack(stack)
       template.hasResourceProperties('AWS::CloudFront::CachePolicy', {
         CachePolicyConfig: Match.objectLike({
           DefaultTTL: 30 * 24 * 60 * 60,
@@ -47,10 +48,6 @@ describe('cdn-policies', () => {
     })
 
     it('forwards all query strings, allowlists Accept and CloudFront-Viewer-Country headers, and forwards no cookies', () => {
-      const stack = harnessStack()
-      createImageCachePolicy(stack, 'TestImageCachePolicy')
-
-      const template = Template.fromStack(stack)
       template.hasResourceProperties('AWS::CloudFront::CachePolicy', {
         CachePolicyConfig: Match.objectLike({
           ParametersInCacheKeyAndForwardedToOrigin: Match.objectLike({
@@ -67,19 +64,20 @@ describe('cdn-policies', () => {
   })
 
   describe('createSecurityHeadersPolicy', () => {
-    it('returns a cloudfront.ResponseHeadersPolicy construct', () => {
+    let policy: cloudfront.ResponseHeadersPolicy
+    let template: Template
+
+    beforeAll(() => {
       const stack = harnessStack()
+      policy = createSecurityHeadersPolicy(stack, 'TestSecurityHeaders')
+      template = Template.fromStack(stack)
+    })
 
-      const policy = createSecurityHeadersPolicy(stack, 'TestSecurityHeaders')
-
+    it('returns a cloudfront.ResponseHeadersPolicy construct', () => {
       expect(policy).toBeInstanceOf(cloudfront.ResponseHeadersPolicy)
     })
 
     it('configures the documented security headers (content type, frame options, referrer policy, HSTS)', () => {
-      const stack = harnessStack()
-      createSecurityHeadersPolicy(stack, 'TestSecurityHeaders')
-
-      const template = Template.fromStack(stack)
       template.hasResourceProperties('AWS::CloudFront::ResponseHeadersPolicy', {
         ResponseHeadersPolicyConfig: Match.objectLike({
           SecurityHeadersConfig: Match.objectLike({

--- a/test/cdn-policies.test.ts
+++ b/test/cdn-policies.test.ts
@@ -1,0 +1,103 @@
+import * as cdk from 'aws-cdk-lib'
+import { Match, Template } from 'aws-cdk-lib/assertions'
+import * as cloudfront from 'aws-cdk-lib/aws-cloudfront'
+import { createImageCachePolicy, createSecurityHeadersPolicy } from '../lib/cdn-policies'
+
+function harnessStack(): cdk.Stack {
+  const app = new cdk.App()
+  return new cdk.Stack(app, 'PolicyHarnessStack', {
+    env: { account: '123456789012', region: 'eu-west-2' },
+  })
+}
+
+describe('cdn-policies', () => {
+  describe('createImageCachePolicy', () => {
+    it('returns a cloudfront.CachePolicy construct', () => {
+      const stack = harnessStack()
+
+      const policy = createImageCachePolicy(stack, 'TestImageCachePolicy')
+
+      expect(policy).toBeInstanceOf(cloudfront.CachePolicy)
+    })
+
+    it('synthesises with the stable name AkliImageCachePolicy', () => {
+      const stack = harnessStack()
+      createImageCachePolicy(stack, 'TestImageCachePolicy')
+
+      const template = Template.fromStack(stack)
+      template.hasResourceProperties('AWS::CloudFront::CachePolicy', {
+        CachePolicyConfig: Match.objectLike({
+          Name: 'AkliImageCachePolicy',
+        }),
+      })
+    })
+
+    it('configures default 30-day, max 365-day, min 0-second TTLs', () => {
+      const stack = harnessStack()
+      createImageCachePolicy(stack, 'TestImageCachePolicy')
+
+      const template = Template.fromStack(stack)
+      template.hasResourceProperties('AWS::CloudFront::CachePolicy', {
+        CachePolicyConfig: Match.objectLike({
+          DefaultTTL: 30 * 24 * 60 * 60,
+          MaxTTL: 365 * 24 * 60 * 60,
+          MinTTL: 0,
+        }),
+      })
+    })
+
+    it('forwards all query strings, allowlists Accept and CloudFront-Viewer-Country headers, and forwards no cookies', () => {
+      const stack = harnessStack()
+      createImageCachePolicy(stack, 'TestImageCachePolicy')
+
+      const template = Template.fromStack(stack)
+      template.hasResourceProperties('AWS::CloudFront::CachePolicy', {
+        CachePolicyConfig: Match.objectLike({
+          ParametersInCacheKeyAndForwardedToOrigin: Match.objectLike({
+            QueryStringsConfig: { QueryStringBehavior: 'all' },
+            HeadersConfig: {
+              HeaderBehavior: 'whitelist',
+              Headers: Match.arrayWith(['Accept', 'CloudFront-Viewer-Country']),
+            },
+            CookiesConfig: { CookieBehavior: 'none' },
+          }),
+        }),
+      })
+    })
+  })
+
+  describe('createSecurityHeadersPolicy', () => {
+    it('returns a cloudfront.ResponseHeadersPolicy construct', () => {
+      const stack = harnessStack()
+
+      const policy = createSecurityHeadersPolicy(stack, 'TestSecurityHeaders')
+
+      expect(policy).toBeInstanceOf(cloudfront.ResponseHeadersPolicy)
+    })
+
+    it('configures the documented security headers (content type, frame options, referrer policy, HSTS)', () => {
+      const stack = harnessStack()
+      createSecurityHeadersPolicy(stack, 'TestSecurityHeaders')
+
+      const template = Template.fromStack(stack)
+      template.hasResourceProperties('AWS::CloudFront::ResponseHeadersPolicy', {
+        ResponseHeadersPolicyConfig: Match.objectLike({
+          SecurityHeadersConfig: Match.objectLike({
+            ContentTypeOptions: { Override: true },
+            FrameOptions: { FrameOption: 'DENY', Override: true },
+            ReferrerPolicy: {
+              ReferrerPolicy: 'strict-origin-when-cross-origin',
+              Override: true,
+            },
+            StrictTransportSecurity: {
+              AccessControlMaxAgeSec: 31536000,
+              IncludeSubdomains: true,
+              Preload: true,
+              Override: true,
+            },
+          }),
+        }),
+      })
+    })
+  })
+})

--- a/test/certificate-stack.test.ts
+++ b/test/certificate-stack.test.ts
@@ -2,14 +2,17 @@ import * as cdk from 'aws-cdk-lib'
 import { Match, Template } from 'aws-cdk-lib/assertions'
 import { CertificateStack } from '../lib/certificate-stack'
 
-function createTestStack(): Template {
+function createStack(): CertificateStack {
   const app = new cdk.App()
 
-  const stack = new CertificateStack(app, 'TestCertificateStack', {
+  return new CertificateStack(app, 'TestCertificateStack', {
     env: { account: '123456789012', region: 'us-east-1' },
+    crossRegionReferences: true,
   })
+}
 
-  return Template.fromStack(stack)
+function createTestStack(): Template {
+  return Template.fromStack(createStack())
 }
 
 describe('CertificateStack', () => {
@@ -26,6 +29,13 @@ describe('CertificateStack', () => {
         SubjectAlternativeNames: Match.arrayWith(['www.akli.dev']),
       })
     })
+
+    it('does not change the SiteCert domain or subject alternative names (regression guard)', () => {
+      template.hasResourceProperties('AWS::CertificateManager::Certificate', {
+        DomainName: 'akli.dev',
+        SubjectAlternativeNames: ['www.akli.dev'],
+      })
+    })
   })
 
   describe('API certificate', () => {
@@ -33,6 +43,42 @@ describe('CertificateStack', () => {
       template.hasResourceProperties('AWS::CertificateManager::Certificate', {
         DomainName: 'api.akli.dev',
       })
+    })
+  })
+
+  describe('Images certificate', () => {
+    it('creates a dedicated certificate for images.akli.dev with DNS validation', () => {
+      template.hasResourceProperties(
+        'AWS::CertificateManager::Certificate',
+        Match.objectLike({
+          DomainName: 'images.akli.dev',
+          ValidationMethod: 'DNS',
+        }),
+      )
+    })
+
+    it('exports an ImagesCertArn CloudFormation output referencing the new certificate', () => {
+      template.hasOutput(
+        'ImagesCertArn',
+        Match.objectLike({
+          Value: Match.objectLike({ Ref: Match.stringLikeRegexp('^ImagesCert') }),
+        }),
+      )
+    })
+  })
+
+  describe('Certificate count', () => {
+    it('synthesises exactly three ACM certificates (Site, Api, Images)', () => {
+      template.resourceCountIs('AWS::CertificateManager::Certificate', 3)
+    })
+  })
+
+  describe('Cross-region references', () => {
+    it('enables crossRegionReferences on the stack instance', () => {
+      const stack = createStack()
+      // CDK exposes the resolved value as `_crossRegionReferences` on the Stack instance
+      // (the public `crossRegionReferences` is on StackProps, the input).
+      expect(stack._crossRegionReferences).toBe(true)
     })
   })
 

--- a/test/certificate-stack.test.ts
+++ b/test/certificate-stack.test.ts
@@ -11,26 +11,17 @@ function createStack(): CertificateStack {
   })
 }
 
-function createTestStack(): Template {
-  return Template.fromStack(createStack())
-}
-
 describe('CertificateStack', () => {
+  let stack: CertificateStack
   let template: Template
 
   beforeAll(() => {
-    template = createTestStack()
+    stack = createStack()
+    template = Template.fromStack(stack)
   })
 
   describe('Site certificate', () => {
-    it('creates a certificate for akli.dev', () => {
-      template.hasResourceProperties('AWS::CertificateManager::Certificate', {
-        DomainName: 'akli.dev',
-        SubjectAlternativeNames: Match.arrayWith(['www.akli.dev']),
-      })
-    })
-
-    it('does not change the SiteCert domain or subject alternative names (regression guard)', () => {
+    it('creates a certificate for akli.dev with exactly www.akli.dev as SAN', () => {
       template.hasResourceProperties('AWS::CertificateManager::Certificate', {
         DomainName: 'akli.dev',
         SubjectAlternativeNames: ['www.akli.dev'],
@@ -56,15 +47,6 @@ describe('CertificateStack', () => {
         }),
       )
     })
-
-    it('exports an ImagesCertArn CloudFormation output referencing the new certificate', () => {
-      template.hasOutput(
-        'ImagesCertArn',
-        Match.objectLike({
-          Value: Match.objectLike({ Ref: Match.stringLikeRegexp('^ImagesCert') }),
-        }),
-      )
-    })
   })
 
   describe('Certificate count', () => {
@@ -75,7 +57,6 @@ describe('CertificateStack', () => {
 
   describe('Cross-region references', () => {
     it('enables crossRegionReferences on the stack instance', () => {
-      const stack = createStack()
       // CDK exposes the resolved value as `_crossRegionReferences` on the Stack instance
       // (the public `crossRegionReferences` is on StackProps, the input).
       expect(stack._crossRegionReferences).toBe(true)

--- a/test/images-stack.test.ts
+++ b/test/images-stack.test.ts
@@ -1,0 +1,572 @@
+import * as cdk from 'aws-cdk-lib'
+import { Match, Template } from 'aws-cdk-lib/assertions'
+import * as certificatemanager from 'aws-cdk-lib/aws-certificatemanager'
+import * as route53 from 'aws-cdk-lib/aws-route53'
+import { IMAGE_CACHE_POLICY_NAME } from '../lib/cdn-policies'
+import { ImagesStack } from '../lib/images-stack'
+import { RecipeStack } from '../lib/recipe-stack'
+
+interface Harness {
+  imagesTemplate: Template
+  recipeTemplate: Template
+  imagesStack: ImagesStack
+}
+
+function createHarness(): Harness {
+  const app = new cdk.App()
+
+  cdk.Tags.of(app).add('Owner', 'Akli')
+  cdk.Tags.of(app).add('CostCenter', 'Recipes')
+
+  // CertificateStack-equivalent in us-east-1 (for cross-region consumption)
+  const certStack = new cdk.Stack(app, 'TestCertStack', {
+    env: { account: '123456789012', region: 'us-east-1' },
+    crossRegionReferences: true,
+  })
+
+  const hostedZone = new route53.HostedZone(certStack, 'TestHostedZone', {
+    zoneName: 'akli.dev',
+  })
+
+  const imagesCertificate = new certificatemanager.Certificate(certStack, 'TestImagesCert', {
+    domainName: 'images.akli.dev',
+  })
+
+  // RecipeStack owns the recipe-images bucket. It must be synthesised in the
+  // same app so the cross-stack bucket reference resolves and the bucket
+  // policy + notification ACs are observable on its template.
+  const recipeStack = new RecipeStack(app, 'TestRecipeStack', {
+    env: { account: '123456789012', region: 'eu-west-2' },
+    userPoolId: 'eu-west-2_TestPool123',
+    userPoolClientId: 'test-client-id-abc',
+    userPoolArn: 'arn:aws:cognito-idp:eu-west-2:123456789012:userpool/eu-west-2_TestPool123',
+    tags: {
+      Project: 'recipes',
+      Environment: 'production',
+      ManagedBy: 'cdk',
+    },
+  })
+
+  const imagesStack = new ImagesStack(app, 'TestImagesStack', {
+    env: { account: '123456789012', region: 'eu-west-2' },
+    crossRegionReferences: true,
+    hostedZone,
+    imagesCertificate,
+    recipeImageBucket: recipeStack.imageBucket,
+    tags: {
+      Project: 'akli-images',
+      Environment: 'production',
+      ManagedBy: 'cdk',
+    },
+  })
+
+  return {
+    imagesTemplate: Template.fromStack(imagesStack),
+    recipeTemplate: Template.fromStack(recipeStack),
+    imagesStack,
+  }
+}
+
+type CfnResource = { Type: string; Properties: Record<string, unknown> }
+type CfnDistributionResource = CfnResource & {
+  Properties: {
+    DistributionConfig: {
+      Aliases?: string[]
+      Origins?: Array<Record<string, unknown>>
+      CacheBehaviors?: Array<Record<string, unknown>>
+      DefaultCacheBehavior?: Record<string, unknown>
+      ViewerCertificate?: Record<string, unknown>
+    }
+  }
+}
+
+function findDistribution(template: Template, aliasMatcher: string): CfnDistributionResource {
+  const resources = template.toJSON().Resources as Record<string, CfnResource>
+  for (const resource of Object.values(resources)) {
+    if (resource.Type !== 'AWS::CloudFront::Distribution') continue
+    const cfg = (resource.Properties as { DistributionConfig?: { Aliases?: string[] } }).DistributionConfig
+    if (cfg?.Aliases?.includes(aliasMatcher)) {
+      return resource as CfnDistributionResource
+    }
+  }
+  throw new Error(`No CloudFront::Distribution with alias ${aliasMatcher} in template`)
+}
+
+function findCachePolicyLogicalIdByName(
+  template: Template,
+  policyName: string,
+): string {
+  const resources = template.toJSON().Resources as Record<string, CfnResource>
+  for (const [logicalId, resource] of Object.entries(resources)) {
+    if (resource.Type !== 'AWS::CloudFront::CachePolicy') continue
+    const cfg = (resource.Properties as {
+      CachePolicyConfig?: { Name?: string }
+    }).CachePolicyConfig
+    if (cfg?.Name === policyName) {
+      return logicalId
+    }
+  }
+  throw new Error(`No CachePolicy with Name=${policyName} in template`)
+}
+
+describe('ImagesStack', () => {
+  let harness: Harness
+
+  beforeAll(() => {
+    harness = createHarness()
+  })
+
+  describe('CloudFront distribution', () => {
+    it('creates an AWS::CloudFront::Distribution with Aliases: [images.akli.dev]', () => {
+      harness.imagesTemplate.hasResourceProperties('AWS::CloudFront::Distribution', {
+        DistributionConfig: Match.objectLike({
+          Aliases: ['images.akli.dev'],
+        }),
+      })
+    })
+
+    it('configures ViewerCertificate.AcmCertificateArn referencing ImagesCert', () => {
+      const distribution = findDistribution(harness.imagesTemplate, 'images.akli.dev')
+      const viewerCertificate = distribution.Properties.DistributionConfig.ViewerCertificate
+      expect(viewerCertificate).toBeDefined()
+      const acmArn = (viewerCertificate as { AcmCertificateArn?: unknown }).AcmCertificateArn
+      // Cross-region cert refs come through SSM dynamic references — must exist and be non-null.
+      expect(acmArn).toBeDefined()
+      // SslSupportMethod is sni-only when an ACM cert is set (vs the default cloudfront cert)
+      expect((viewerCertificate as { SslSupportMethod?: string }).SslSupportMethod).toBe('sni-only')
+    })
+
+    it('default behaviour has a viewer-request FunctionAssociation', () => {
+      const distribution = findDistribution(harness.imagesTemplate, 'images.akli.dev')
+      const defaultBehavior = distribution.Properties.DistributionConfig.DefaultCacheBehavior as {
+        FunctionAssociations?: Array<{ EventType: string; FunctionARN: unknown }>
+      }
+      expect(defaultBehavior.FunctionAssociations).toBeDefined()
+      expect(defaultBehavior.FunctionAssociations).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({ EventType: 'viewer-request' }),
+        ]),
+      )
+    })
+
+    it('the default-behaviour CloudFront Function inline code returns statusCode: 404', () => {
+      const resources = harness.imagesTemplate.toJSON().Resources as Record<string, CfnResource>
+      const functions = Object.values(resources).filter(
+        (r) => r.Type === 'AWS::CloudFront::Function',
+      )
+      expect(functions.length).toBeGreaterThan(0)
+      const has404 = functions.some((fn) => {
+        const code = (fn.Properties as { FunctionCode?: string }).FunctionCode
+        return typeof code === 'string' && /statusCode\s*:\s*404/.test(code)
+      })
+      expect(has404).toBe(true)
+    })
+
+    it('CacheBehaviors array contains exactly one entry with PathPattern: recipes/*', () => {
+      const distribution = findDistribution(harness.imagesTemplate, 'images.akli.dev')
+      const cacheBehaviors = distribution.Properties.DistributionConfig.CacheBehaviors ?? []
+      expect(cacheBehaviors).toHaveLength(1)
+      expect(cacheBehaviors[0]).toEqual(
+        expect.objectContaining({ PathPattern: 'recipes/*' }),
+      )
+    })
+
+    it('recipes/* behaviour has AllowedMethods: [GET, HEAD] only (excludes OPTIONS)', () => {
+      harness.imagesTemplate.hasResourceProperties('AWS::CloudFront::Distribution', {
+        DistributionConfig: Match.objectLike({
+          CacheBehaviors: Match.arrayWith([
+            Match.objectLike({
+              PathPattern: 'recipes/*',
+              AllowedMethods: ['GET', 'HEAD'],
+            }),
+          ]),
+        }),
+      })
+    })
+
+    it('recipes/* behaviour sets Compress: true and ViewerProtocolPolicy: redirect-to-https', () => {
+      harness.imagesTemplate.hasResourceProperties('AWS::CloudFront::Distribution', {
+        DistributionConfig: Match.objectLike({
+          CacheBehaviors: Match.arrayWith([
+            Match.objectLike({
+              PathPattern: 'recipes/*',
+              Compress: true,
+              ViewerProtocolPolicy: 'redirect-to-https',
+            }),
+          ]),
+        }),
+      })
+    })
+
+    it('recipes/* behaviour CachePolicyId references the shared image cache policy by stable name', () => {
+      const cachePolicyLogicalId = findCachePolicyLogicalIdByName(
+        harness.imagesTemplate,
+        IMAGE_CACHE_POLICY_NAME,
+      )
+      const distribution = findDistribution(harness.imagesTemplate, 'images.akli.dev')
+      const recipesBehavior = (distribution.Properties.DistributionConfig.CacheBehaviors ?? [])
+        .find((b) => (b as { PathPattern?: string }).PathPattern === 'recipes/*') as
+        | { CachePolicyId?: { Ref?: string } | string }
+        | undefined
+      expect(recipesBehavior).toBeDefined()
+      const cachePolicyId = recipesBehavior?.CachePolicyId
+      // CDK typically emits a Ref; assert the Ref points to the cache-policy logical ID
+      const ref = (cachePolicyId as { Ref?: string } | undefined)?.Ref
+      expect(ref).toBe(cachePolicyLogicalId)
+    })
+
+    it('recipes/* behaviour ResponseHeadersPolicyId references the shared security headers policy', () => {
+      const distribution = findDistribution(harness.imagesTemplate, 'images.akli.dev')
+      const recipesBehavior = (distribution.Properties.DistributionConfig.CacheBehaviors ?? [])
+        .find((b) => (b as { PathPattern?: string }).PathPattern === 'recipes/*') as
+        | { ResponseHeadersPolicyId?: { Ref?: string } | string }
+        | undefined
+      expect(recipesBehavior).toBeDefined()
+      const headersPolicyId = recipesBehavior?.ResponseHeadersPolicyId
+      const ref = (headersPolicyId as { Ref?: string } | undefined)?.Ref
+      expect(ref).toBeDefined()
+      // The shared security headers policy is constructed via createSecurityHeadersPolicy
+      // which gives it a stable construct id starting with "SecurityHeaders".
+      expect(ref).toMatch(/SecurityHeaders/)
+    })
+
+    it('recipes/* origin uses OAC (OriginAccessControlId is non-null)', () => {
+      const distribution = findDistribution(harness.imagesTemplate, 'images.akli.dev')
+      const origins = distribution.Properties.DistributionConfig.Origins ?? []
+      const recipesBehavior = (distribution.Properties.DistributionConfig.CacheBehaviors ?? [])
+        .find((b) => (b as { PathPattern?: string }).PathPattern === 'recipes/*') as
+        | { TargetOriginId?: string }
+        | undefined
+      expect(recipesBehavior?.TargetOriginId).toBeDefined()
+      const recipesOrigin = origins.find(
+        (o) => (o as { Id?: string }).Id === recipesBehavior?.TargetOriginId,
+      ) as { OriginAccessControlId?: unknown } | undefined
+      expect(recipesOrigin).toBeDefined()
+      expect(recipesOrigin?.OriginAccessControlId).toBeDefined()
+      expect(recipesOrigin?.OriginAccessControlId).not.toBeNull()
+    })
+
+    it('recipes/* origin DomainName resolves to the recipe-images bucket regional domain', () => {
+      const distribution = findDistribution(harness.imagesTemplate, 'images.akli.dev')
+      const origins = distribution.Properties.DistributionConfig.Origins ?? []
+      const recipesBehavior = (distribution.Properties.DistributionConfig.CacheBehaviors ?? [])
+        .find((b) => (b as { PathPattern?: string }).PathPattern === 'recipes/*') as
+        | { TargetOriginId?: string }
+        | undefined
+      const recipesOrigin = origins.find(
+        (o) => (o as { Id?: string }).Id === recipesBehavior?.TargetOriginId,
+      ) as { DomainName?: unknown } | undefined
+      expect(recipesOrigin?.DomainName).toBeDefined()
+      // Cross-stack bucket regional domain comes through as an Fn::ImportValue
+      // or {Ref/GetAtt} of a SSM-imported value. Serialise and assert it
+      // references the bucket's RegionalDomainName.
+      const serialised = JSON.stringify(recipesOrigin?.DomainName)
+      expect(serialised).toMatch(/RegionalDomainName|s3\.eu-west-2\.amazonaws\.com/)
+    })
+
+    it('creates an AWS::CloudFront::OriginAccessControl with sigv4 + always', () => {
+      harness.imagesTemplate.hasResourceProperties('AWS::CloudFront::OriginAccessControl', {
+        OriginAccessControlConfig: Match.objectLike({
+          SigningProtocol: 'sigv4',
+          SigningBehavior: 'always',
+        }),
+      })
+    })
+  })
+
+  describe('Route 53', () => {
+    it('creates an A alias record for images.akli.dev pointing at the distribution', () => {
+      harness.imagesTemplate.hasResourceProperties('AWS::Route53::RecordSet', {
+        Name: 'images.akli.dev.',
+        Type: 'A',
+        AliasTarget: Match.objectLike({
+          DNSName: Match.objectLike({
+            'Fn::GetAtt': Match.arrayWith([Match.stringLikeRegexp('.*Distribution.*')]),
+          }),
+          HostedZoneId: 'Z2FDTNDATAQYW2',
+        }),
+      })
+    })
+
+    it('the A record references the akli.dev hosted zone', () => {
+      const resources = harness.imagesTemplate.toJSON().Resources as Record<string, CfnResource>
+      const aRecord = Object.values(resources).find((r) => {
+        if (r.Type !== 'AWS::Route53::RecordSet') return false
+        const props = r.Properties as { Name?: string; Type?: string }
+        return props.Name === 'images.akli.dev.' && props.Type === 'A'
+      })
+      expect(aRecord).toBeDefined()
+      const hostedZoneId = (aRecord?.Properties as { HostedZoneId?: unknown }).HostedZoneId
+      expect(hostedZoneId).toBeDefined()
+      // Cross-region hosted zone reference comes through as a non-null SSM ref / token
+      expect(hostedZoneId).not.toBeNull()
+    })
+
+    it('creates an AAAA alias record for images.akli.dev', () => {
+      harness.imagesTemplate.hasResourceProperties('AWS::Route53::RecordSet', {
+        Name: 'images.akli.dev.',
+        Type: 'AAAA',
+        AliasTarget: Match.objectLike({
+          DNSName: Match.objectLike({
+            'Fn::GetAtt': Match.arrayWith([Match.stringLikeRegexp('.*Distribution.*')]),
+          }),
+          HostedZoneId: 'Z2FDTNDATAQYW2',
+        }),
+      })
+    })
+  })
+
+  describe('S3 bucket policy on RecipeImagesBucket (RecipeStack template)', () => {
+    it('grants s3:GetObject to cloudfront.amazonaws.com scoped via aws:SourceArn', () => {
+      // The recipe-images bucket is owned by RecipeStack, so the bucket policy
+      // additions made by ImagesStack land on RecipeStack's synthesised template.
+      harness.recipeTemplate.hasResourceProperties('AWS::S3::BucketPolicy', {
+        PolicyDocument: Match.objectLike({
+          Statement: Match.arrayWith([
+            Match.objectLike({
+              Effect: 'Allow',
+              Action: 's3:GetObject',
+              Principal: { Service: 'cloudfront.amazonaws.com' },
+              Resource: Match.objectLike({
+                'Fn::Join': Match.arrayWith([
+                  '',
+                  Match.arrayWith([
+                    Match.objectLike({
+                      'Fn::GetAtt': Match.arrayWith([
+                        Match.stringLikeRegexp('^RecipeImagesBucket.*'),
+                      ]),
+                    }),
+                    '/*',
+                  ]),
+                ]),
+              }),
+              Condition: Match.objectLike({
+                StringEquals: Match.objectLike({
+                  'aws:SourceArn': Match.anyValue(),
+                }),
+              }),
+            }),
+          ]),
+        }),
+      })
+    })
+
+    it('no Allow statement grants Principal: "*"', () => {
+      // Restrict to Effect: Allow — the bucket has a Deny statement for
+      // non-TLS access from Principal { AWS: '*' } as part of enforceSSL,
+      // which is a security control we must preserve, not weaken.
+      const wildcardAllowStatements: unknown[] = []
+      const bucketPolicies = harness.recipeTemplate.findResources('AWS::S3::BucketPolicy')
+      for (const policy of Object.values(bucketPolicies)) {
+        const statements =
+          ((policy as { Properties: { PolicyDocument: { Statement?: unknown[] } } }).Properties
+            .PolicyDocument.Statement) ?? []
+        for (const stmt of statements) {
+          const s = stmt as { Effect?: string; Principal?: unknown }
+          if (s.Effect !== 'Allow') continue
+          if (s.Principal === '*') {
+            wildcardAllowStatements.push(s)
+            continue
+          }
+          if (s.Principal && typeof s.Principal === 'object') {
+            const aws = (s.Principal as { AWS?: unknown }).AWS
+            if (aws === '*') wildcardAllowStatements.push(s)
+          }
+        }
+      }
+      expect(wildcardAllowStatements).toEqual([])
+    })
+
+    it('no statement grants s3:ListBucket to the CloudFront service principal', () => {
+      const offendingStatements: unknown[] = []
+      const bucketPolicies = harness.recipeTemplate.findResources('AWS::S3::BucketPolicy')
+      for (const policy of Object.values(bucketPolicies)) {
+        const statements =
+          ((policy as { Properties: { PolicyDocument: { Statement?: unknown[] } } }).Properties
+            .PolicyDocument.Statement) ?? []
+        for (const stmt of statements) {
+          const s = stmt as {
+            Action?: string | string[]
+            Principal?: { Service?: string | string[] }
+          }
+          const principalService = s.Principal?.Service
+          const isCloudFrontPrincipal = principalService === 'cloudfront.amazonaws.com'
+            || (Array.isArray(principalService)
+              && principalService.includes('cloudfront.amazonaws.com'))
+          if (!isCloudFrontPrincipal) continue
+          const action = s.Action
+          const grantsList = Array.isArray(action)
+            ? action.includes('s3:ListBucket')
+            : action === 's3:ListBucket'
+          if (grantsList) offendingStatements.push(s)
+        }
+      }
+      expect(offendingStatements).toEqual([])
+    })
+
+    it('every statement granting the CloudFront principal includes an aws:SourceArn condition', () => {
+      const cloudfrontStatementsWithoutSourceArn: unknown[] = []
+      let cloudfrontStatementsSeen = 0
+      const bucketPolicies = harness.recipeTemplate.findResources('AWS::S3::BucketPolicy')
+      for (const policy of Object.values(bucketPolicies)) {
+        const statements =
+          ((policy as { Properties: { PolicyDocument: { Statement?: unknown[] } } }).Properties
+            .PolicyDocument.Statement) ?? []
+        for (const stmt of statements) {
+          const s = stmt as {
+            Principal?: { Service?: string | string[] }
+            Condition?: { StringEquals?: Record<string, unknown> }
+          }
+          const principalService = s.Principal?.Service
+          const isCloudFrontPrincipal = principalService === 'cloudfront.amazonaws.com'
+            || (Array.isArray(principalService)
+              && principalService.includes('cloudfront.amazonaws.com'))
+          if (!isCloudFrontPrincipal) continue
+          cloudfrontStatementsSeen += 1
+          const sourceArn = s.Condition?.StringEquals?.['aws:SourceArn']
+            ?? s.Condition?.StringEquals?.['AWS:SourceArn']
+          if (sourceArn === undefined || sourceArn === null) {
+            cloudfrontStatementsWithoutSourceArn.push(s)
+          }
+        }
+      }
+      expect(cloudfrontStatementsWithoutSourceArn).toEqual([])
+      expect(cloudfrontStatementsSeen).toBeGreaterThan(0)
+    })
+
+    it('the bucket retains BlockPublicAcls/IgnorePublicAcls/BlockPublicPolicy/RestrictPublicBuckets: true', () => {
+      harness.recipeTemplate.hasResourceProperties('AWS::S3::Bucket', {
+        BucketName: 'akli-recipe-images-123456789012-eu-west-2',
+        PublicAccessBlockConfiguration: {
+          BlockPublicAcls: true,
+          IgnorePublicAcls: true,
+          BlockPublicPolicy: true,
+          RestrictPublicBuckets: true,
+        },
+      })
+    })
+  })
+
+  describe('S3 event notification on RecipeImagesBucket (RecipeStack template)', () => {
+    it('LambdaConfigurations filter remains prefix: uploads/ — no recipes/ prefix added', () => {
+      // CDK realises bucket notifications via a `Custom::S3BucketNotifications`
+      // custom resource (not inline on the bucket). The shape there is
+      // `NotificationConfiguration.LambdaFunctionConfigurations[*].Filter.Key.FilterRules`.
+      // Walk every notification-bearing resource and assert no rule has
+      // `Name: 'prefix', Value: 'recipes/'`.
+      type FilterRule = { Name?: string; Value?: unknown }
+      type LambdaConfig = {
+        Filter?: { Key?: { FilterRules?: FilterRule[] }; S3Key?: { Rules?: FilterRule[] } }
+        Events?: string[]
+      }
+
+      const lambdaConfigs: LambdaConfig[] = []
+
+      const json = harness.recipeTemplate.toJSON()
+      const resources = json.Resources as Record<string, CfnResource>
+
+      for (const resource of Object.values(resources)) {
+        const props = resource.Properties as Record<string, unknown> | undefined
+        if (!props) continue
+        const notif = (props as { NotificationConfiguration?: {
+          LambdaConfigurations?: LambdaConfig[]
+          LambdaFunctionConfigurations?: LambdaConfig[]
+        } }).NotificationConfiguration
+        if (notif?.LambdaFunctionConfigurations) {
+          lambdaConfigs.push(...notif.LambdaFunctionConfigurations)
+        }
+        if (notif?.LambdaConfigurations) {
+          lambdaConfigs.push(...notif.LambdaConfigurations)
+        }
+      }
+
+      expect(lambdaConfigs.length).toBeGreaterThan(0)
+
+      const allRules = (cfg: LambdaConfig): FilterRule[] => [
+        ...(cfg.Filter?.Key?.FilterRules ?? []),
+        ...(cfg.Filter?.S3Key?.Rules ?? []),
+      ]
+
+      const hasUploadsPrefix = lambdaConfigs.some((cfg) =>
+        allRules(cfg).some((r) => r.Name === 'prefix' && r.Value === 'uploads/'),
+      )
+      expect(hasUploadsPrefix).toBe(true)
+
+      const recipesPrefixRules = lambdaConfigs.flatMap((cfg) =>
+        allRules(cfg).filter((r) => r.Name === 'prefix' && r.Value === 'recipes/'),
+      )
+      expect(recipesPrefixRules).toEqual([])
+    })
+  })
+
+  describe('Cross-stack / cross-region', () => {
+    it('ImagesStack accepts recipeImageBucket: s3.IBucket in its props (compile-time check)', () => {
+      // The harness above passes recipeStack.imageBucket into ImagesStack props.
+      // If the prop interface drops the field, this test file fails to compile.
+      // Run-time assertion: the harness constructed without throwing.
+      expect(harness.imagesStack).toBeInstanceOf(ImagesStack)
+    })
+
+    it('enables crossRegionReferences on the stack instance', () => {
+      // Cross-region machinery is observable two ways:
+      // 1. The internal `_crossRegionReferences` flag CDK sets on the Stack
+      //    instance when the prop is true.
+      // 2. The synthesised distribution's cert ref is a cross-region token
+      //    (Fn::ImportValue / CrossRegion SSM dynamic ref) rather than a literal.
+      // Either is sufficient proof.
+      const stack = harness.imagesStack as unknown as { _crossRegionReferences?: boolean }
+      const flagSet = stack._crossRegionReferences === true
+
+      let isCrossRegionToken = false
+      try {
+        const distribution = findDistribution(harness.imagesTemplate, 'images.akli.dev')
+        const acmArn = (distribution.Properties.DistributionConfig.ViewerCertificate as
+          | { AcmCertificateArn?: unknown }
+          | undefined)?.AcmCertificateArn
+        if (acmArn !== undefined && acmArn !== null) {
+          const serialised = JSON.stringify(acmArn)
+          isCrossRegionToken = typeof acmArn === 'object'
+            && (serialised.includes('Fn::ImportValue') || serialised.includes('CrossRegion'))
+        }
+      } catch {
+        // Distribution not yet emitted by stub — fall through and rely on the flag.
+      }
+
+      expect(flagSet || isCrossRegionToken).toBe(true)
+    })
+  })
+
+  describe('Tags', () => {
+    it('tags the distribution with Project=akli-images', () => {
+      harness.imagesTemplate.hasResourceProperties('AWS::CloudFront::Distribution', {
+        Tags: Match.arrayWith([
+          Match.objectLike({ Key: 'Project', Value: 'akli-images' }),
+        ]),
+      })
+    })
+
+    it('tags the distribution with Owner', () => {
+      harness.imagesTemplate.hasResourceProperties('AWS::CloudFront::Distribution', {
+        Tags: Match.arrayWith([
+          Match.objectLike({ Key: 'Owner', Value: 'Akli' }),
+        ]),
+      })
+    })
+
+    it('tags the distribution with Environment=production', () => {
+      harness.imagesTemplate.hasResourceProperties('AWS::CloudFront::Distribution', {
+        Tags: Match.arrayWith([
+          Match.objectLike({ Key: 'Environment', Value: 'production' }),
+        ]),
+      })
+    })
+
+    it('tags the distribution with ManagedBy=cdk', () => {
+      harness.imagesTemplate.hasResourceProperties('AWS::CloudFront::Distribution', {
+        Tags: Match.arrayWith([
+          Match.objectLike({ Key: 'ManagedBy', Value: 'cdk' }),
+        ]),
+      })
+    })
+  })
+})

--- a/test/images-stack.test.ts
+++ b/test/images-stack.test.ts
@@ -283,7 +283,7 @@ describe('ImagesStack', () => {
           DNSName: Match.objectLike({
             'Fn::GetAtt': Match.arrayWith([Match.stringLikeRegexp('.*Distribution.*')]),
           }),
-          HostedZoneId: 'Z2FDTNDATAQYW2',
+          HostedZoneId: Match.anyValue(),
         }),
       })
     })
@@ -310,7 +310,7 @@ describe('ImagesStack', () => {
           DNSName: Match.objectLike({
             'Fn::GetAtt': Match.arrayWith([Match.stringLikeRegexp('.*Distribution.*')]),
           }),
-          HostedZoneId: 'Z2FDTNDATAQYW2',
+          HostedZoneId: Match.anyValue(),
         }),
       })
     })
@@ -448,7 +448,7 @@ describe('ImagesStack', () => {
   })
 
   describe('S3 event notification on RecipeImagesBucket (RecipeStack template)', () => {
-    it('LambdaConfigurations filter remains prefix: uploads/ — no recipes/ prefix added', () => {
+    it('filters S3 events on prefix uploads/ only — no recipes/ filter present', () => {
       // CDK realises bucket notifications via a `Custom::S3BucketNotifications`
       // custom resource (not inline on the bucket). The shape there is
       // `NotificationConfiguration.LambdaFunctionConfigurations[*].Filter.Key.FilterRules`.
@@ -500,7 +500,7 @@ describe('ImagesStack', () => {
   })
 
   describe('Cross-stack / cross-region', () => {
-    it('ImagesStack accepts recipeImageBucket: s3.IBucket in its props (compile-time check)', () => {
+    it('exposes recipeImageBucket on its props interface', () => {
       // The harness above passes recipeStack.imageBucket into ImagesStack props.
       // If the prop interface drops the field, this test file fails to compile.
       // Run-time assertion: the harness constructed without throwing.

--- a/test/lambda/image-resizer.test.ts
+++ b/test/lambda/image-resizer.test.ts
@@ -88,7 +88,7 @@ describe('image-resizer handler', () => {
     expect(mockSharp.webp).toHaveBeenCalledWith({ quality: 90 })
   })
 
-  it('uploads variants to processed/ prefix with correct keys', async () => {
+  it('uploads variants to recipes/ prefix with correct keys', async () => {
     await handler(makeS3Event('uploads/recipes/abc/cover'))
 
     const putCalls = s3Mock.commandCalls(PutObjectCommand)
@@ -96,9 +96,9 @@ describe('image-resizer handler', () => {
 
     const putKeys = putCalls.map((call) => call.args[0].input.Key).sort()
     expect(putKeys).toEqual([
-      'processed/recipes/abc/cover-full.webp',
-      'processed/recipes/abc/cover-medium.webp',
-      'processed/recipes/abc/cover-thumb.webp',
+      'recipes/abc/cover-full.webp',
+      'recipes/abc/cover-medium.webp',
+      'recipes/abc/cover-thumb.webp',
     ])
 
     // All uploads go to the correct bucket
@@ -152,7 +152,7 @@ describe('image-resizer handler', () => {
     expect(input.Key).toEqual({ id: 'abc' })
     expect(input.UpdateExpression).toBe('SET imageStatus.#k = :ts')
     expect(input.ConditionExpression).toBe('attribute_exists(id)')
-    expect(input.ExpressionAttributeNames).toEqual({ '#k': 'processed/recipes/abc/cover' })
+    expect(input.ExpressionAttributeNames).toEqual({ '#k': 'recipes/abc/cover' })
 
     const ts = input.ExpressionAttributeValues?.[':ts']
     expect(typeof ts).toBe('number')
@@ -169,7 +169,7 @@ describe('image-resizer handler', () => {
 
     const input = updateCalls[0].args[0].input
     expect(input.Key).toEqual({ id: 'abc' })
-    expect(input.ExpressionAttributeNames).toEqual({ '#k': 'processed/recipes/abc/step-2' })
+    expect(input.ExpressionAttributeNames).toEqual({ '#k': 'recipes/abc/step-2' })
   })
 
   it('swallows ConditionalCheckFailedException, still deletes source, and logs skip event', async () => {

--- a/test/lambda/image-variants.test.ts
+++ b/test/lambda/image-variants.test.ts
@@ -2,23 +2,23 @@ import { PROCESSED_PREFIX, UPLOAD_PREFIX, toProcessedKey } from '../../lambda/im
 
 describe('image-variants', () => {
   describe('PROCESSED_PREFIX constant', () => {
-    it('is "recipes/" so processed objects sit under the recipes/ namespace 1:1 with the public URL', () => {
+    it('is "recipes/"', () => {
       expect(PROCESSED_PREFIX).toBe('recipes/')
     })
   })
 
   describe('UPLOAD_PREFIX constant', () => {
-    it('remains "uploads/" — the resizer S3 trigger still filters on this prefix', () => {
+    it('is "uploads/"', () => {
       expect(UPLOAD_PREFIX).toBe('uploads/')
     })
   })
 
   describe('toProcessedKey', () => {
-    it('maps a cover upload key to the recipes/<id>/cover processed key (no double "recipes/")', () => {
+    it('maps a cover upload key to its processed key', () => {
       expect(toProcessedKey('uploads/recipes/abc/cover')).toBe('recipes/abc/cover')
     })
 
-    it('maps a step upload key to the recipes/<id>/step-<n> processed key', () => {
+    it('maps a step upload key to its processed key', () => {
       expect(toProcessedKey('uploads/recipes/abc/step-2')).toBe('recipes/abc/step-2')
     })
 
@@ -26,11 +26,11 @@ describe('image-variants', () => {
       expect(() => toProcessedKey('not-uploads/foo')).toThrow(/uploads\//)
     })
 
-    it('throws when the upload key is exactly "uploads/" with no suffix', () => {
+    it('throws when the upload key has no suffix after "uploads/"', () => {
       expect(() => toProcessedKey('uploads/')).toThrow()
     })
 
-    it('preserves a stray double-slash after the upload prefix (returns "recipes//double-slash")', () => {
+    it('preserves a stray double-slash after the upload prefix', () => {
       expect(toProcessedKey('uploads//double-slash')).toBe('recipes//double-slash')
     })
   })

--- a/test/lambda/image-variants.test.ts
+++ b/test/lambda/image-variants.test.ts
@@ -1,0 +1,37 @@
+import { PROCESSED_PREFIX, UPLOAD_PREFIX, toProcessedKey } from '../../lambda/image-variants'
+
+describe('image-variants', () => {
+  describe('PROCESSED_PREFIX constant', () => {
+    it('is "recipes/" so processed objects sit under the recipes/ namespace 1:1 with the public URL', () => {
+      expect(PROCESSED_PREFIX).toBe('recipes/')
+    })
+  })
+
+  describe('UPLOAD_PREFIX constant', () => {
+    it('remains "uploads/" — the resizer S3 trigger still filters on this prefix', () => {
+      expect(UPLOAD_PREFIX).toBe('uploads/')
+    })
+  })
+
+  describe('toProcessedKey', () => {
+    it('maps a cover upload key to the recipes/<id>/cover processed key (no double "recipes/")', () => {
+      expect(toProcessedKey('uploads/recipes/abc/cover')).toBe('recipes/abc/cover')
+    })
+
+    it('maps a step upload key to the recipes/<id>/step-<n> processed key', () => {
+      expect(toProcessedKey('uploads/recipes/abc/step-2')).toBe('recipes/abc/step-2')
+    })
+
+    it('throws when the upload key does not start with "uploads/"', () => {
+      expect(() => toProcessedKey('not-uploads/foo')).toThrow(/uploads\//)
+    })
+
+    it('throws when the upload key is exactly "uploads/" with no suffix', () => {
+      expect(() => toProcessedKey('uploads/')).toThrow()
+    })
+
+    it('preserves a stray double-slash after the upload prefix (returns "recipes//double-slash")', () => {
+      expect(toProcessedKey('uploads//double-slash')).toBe('recipes//double-slash')
+    })
+  })
+})

--- a/test/lambda/recipe-handler.test.ts
+++ b/test/lambda/recipe-handler.test.ts
@@ -2313,13 +2313,7 @@ describe('Recipe Lambda handler', () => {
       expect(body.coverImage).toEqual({ key: coverKey, alt: 'cover alt', processedAt: 0 })
     })
 
-    // Regression guard for the prefix flip from `processed/` to `recipes/`.
-    // After the prefix change, recipes whose imageStatus map still carries a
-    // stale `processed/recipes/...`-keyed entry (left over from before the
-    // change) must NOT be treated as "ready". The new coverImage.key uses the
-    // `recipes/...` shape; the stale entry's key does not match, so processedAt
-    // must be omitted (otherwise the consumer would render a broken URL).
-    it('omits processedAt when imageStatus carries only stale "processed/recipes/..." keys (prefix-flip regression)', async () => {
+    it('omits processedAt when imageStatus keys do not match coverImage.key', async () => {
       const newCoverKey = 'recipes/recipe-uuid-1/cover'
       const staleCoverKey = 'processed/recipes/recipe-uuid-1/cover'
       const item = publishedRecipeItem({

--- a/test/lambda/recipe-handler.test.ts
+++ b/test/lambda/recipe-handler.test.ts
@@ -738,8 +738,8 @@ describe('Recipe Lambda handler', () => {
     })
 
     it('composes processedAt onto images and strips imageStatus from the response body', async () => {
-      const coverKey = 'processed/recipes/recipe-uuid-1/cover'
-      const step1Key = 'processed/recipes/recipe-uuid-1/step-1'
+      const coverKey = 'recipes/recipe-uuid-1/cover'
+      const step1Key = 'recipes/recipe-uuid-1/step-1'
       const coverTs = 1_745_000_000_001
       const step1Ts = 1_745_000_000_002
 
@@ -1420,9 +1420,9 @@ describe('Recipe Lambda handler', () => {
     })
 
     describe('readiness validation — rejects recipes with unready images', () => {
-      const coverKey = 'processed/recipes/recipe-uuid-1/cover'
-      const step1Key = 'processed/recipes/recipe-uuid-1/step-1'
-      const step2Key = 'processed/recipes/recipe-uuid-1/step-2'
+      const coverKey = 'recipes/recipe-uuid-1/cover'
+      const step1Key = 'recipes/recipe-uuid-1/step-1'
+      const step2Key = 'recipes/recipe-uuid-1/step-2'
       const coverTs = 1_745_000_000_001
       const step1Ts = 1_745_000_000_002
       const step2Ts = 1_745_000_000_003
@@ -1535,8 +1535,8 @@ describe('Recipe Lambda handler', () => {
       })
 
       it('returns 400 when republishing a currently-published recipe whose cover was swapped to an unready new key', async () => {
-        const oldCoverKey = 'processed/recipes/recipe-uuid-1/cover-old'
-        const newCoverKey = 'processed/recipes/recipe-uuid-1/cover'
+        const oldCoverKey = 'recipes/recipe-uuid-1/cover-old'
+        const newCoverKey = 'recipes/recipe-uuid-1/cover'
         ddbMock.on(GetCommand).resolves({
           Item: publishedRecipeItem({
             authorId: 'contributor-user-id',
@@ -1777,9 +1777,9 @@ describe('Recipe Lambda handler', () => {
       ddbMock.on(DeleteCommand).resolves({})
       s3Mock.on(ListObjectsV2Command).resolves({
         Contents: [
-          { Key: 'processed/recipes/recipe-uuid-1/cover-thumb.webp' },
-          { Key: 'processed/recipes/recipe-uuid-1/cover-medium.webp' },
-          { Key: 'processed/recipes/recipe-uuid-1/cover-full.webp' },
+          { Key: 'recipes/recipe-uuid-1/cover-thumb.webp' },
+          { Key: 'recipes/recipe-uuid-1/cover-medium.webp' },
+          { Key: 'recipes/recipe-uuid-1/cover-full.webp' },
         ],
       })
       s3Mock.on(DeleteObjectsCommand).resolves({})
@@ -1797,6 +1797,28 @@ describe('Recipe Lambda handler', () => {
       // Verify S3 cleanup was attempted
       expect(s3Mock.commandCalls(ListObjectsV2Command)).toHaveLength(1)
       expect(s3Mock.commandCalls(DeleteObjectsCommand)).toHaveLength(1)
+    })
+
+    it('lists S3 objects under the new "recipes/<id>/" prefix (not the old "processed/recipes/...")', async () => {
+      ddbMock.on(GetCommand).resolves({
+        Item: publishedRecipeItem({ authorId: 'contributor-user-id' }),
+      })
+      ddbMock.on(DeleteCommand).resolves({})
+      s3Mock.on(ListObjectsV2Command).resolves({ Contents: [] })
+
+      const event = makeEvent({
+        routeKey: 'DELETE /recipes/{id}',
+        rawPath: '/recipes/recipe-uuid-1',
+        pathParameters: { id: 'recipe-uuid-1' },
+        headers: { authorization: `Bearer ${contributorToken}` },
+      })
+
+      const result = await handler(event)
+
+      expect(result.statusCode).toBe(200)
+      const listCalls = s3Mock.commandCalls(ListObjectsV2Command)
+      expect(listCalls).toHaveLength(1)
+      expect(listCalls[0].args[0].input.Prefix).toBe('recipes/recipe-uuid-1/')
     })
 
     it('returns 403 when contributor deletes another user\'s recipe', async () => {
@@ -1967,9 +1989,9 @@ describe('Recipe Lambda handler', () => {
   describe('Response composition — processedAt + imageStatus stripping', () => {
     // A published recipe whose cover image and one step image both have matching
     // imageStatus entries, plus one step image without a matching entry.
-    const coverKey = 'processed/recipes/recipe-uuid-1/cover'
-    const step1Key = 'processed/recipes/recipe-uuid-1/step-1'
-    const step2Key = 'processed/recipes/recipe-uuid-1/step-2'
+    const coverKey = 'recipes/recipe-uuid-1/cover'
+    const step1Key = 'recipes/recipe-uuid-1/step-1'
+    const step2Key = 'recipes/recipe-uuid-1/step-2'
     const coverTs = 1_745_000_000_001
     const step1Ts = 1_745_000_000_002
 
@@ -2290,14 +2312,44 @@ describe('Recipe Lambda handler', () => {
       const body = JSON.parse(result.body as string)
       expect(body.coverImage).toEqual({ key: coverKey, alt: 'cover alt', processedAt: 0 })
     })
+
+    // Regression guard for the prefix flip from `processed/` to `recipes/`.
+    // After the prefix change, recipes whose imageStatus map still carries a
+    // stale `processed/recipes/...`-keyed entry (left over from before the
+    // change) must NOT be treated as "ready". The new coverImage.key uses the
+    // `recipes/...` shape; the stale entry's key does not match, so processedAt
+    // must be omitted (otherwise the consumer would render a broken URL).
+    it('omits processedAt when imageStatus carries only stale "processed/recipes/..." keys (prefix-flip regression)', async () => {
+      const newCoverKey = 'recipes/recipe-uuid-1/cover'
+      const staleCoverKey = 'processed/recipes/recipe-uuid-1/cover'
+      const item = publishedRecipeItem({
+        id: 'recipe-uuid-1',
+        coverImage: { key: newCoverKey, alt: 'cover alt' },
+        steps: [],
+        imageStatus: { [staleCoverKey]: 1_745_000_000_001 },
+      })
+      ddbMock.on(ScanCommand).resolves({ Items: [item] })
+
+      const result = await handler(makeEvent({
+        routeKey: 'GET /recipes/{slug}',
+        rawPath: '/recipes/slow-cooked-lamb-ragu',
+        pathParameters: { slug: 'slow-cooked-lamb-ragu' },
+      }))
+
+      expect(result.statusCode).toBe(200)
+      expect(result.body).not.toContain('processedAt')
+      const body = JSON.parse(result.body as string)
+      expect(body.coverImage).not.toHaveProperty('processedAt')
+      expect(body.coverImage).toEqual({ key: newCoverKey, alt: 'cover alt' })
+    })
   })
 
   describe('PATCH /recipes/{id} — imageStatus REMOVE on swap and processedAt body strip', () => {
-    const oldCoverKey = 'processed/recipes/recipe-uuid-1/cover'
-    const newCoverKey = 'processed/recipes/recipe-uuid-1/cover-v2'
-    const stepAKey = 'processed/recipes/recipe-uuid-1/step-1'
-    const stepBKey = 'processed/recipes/recipe-uuid-1/step-2'
-    const stepCKey = 'processed/recipes/recipe-uuid-1/step-3'
+    const oldCoverKey = 'recipes/recipe-uuid-1/cover'
+    const newCoverKey = 'recipes/recipe-uuid-1/cover-v2'
+    const stepAKey = 'recipes/recipe-uuid-1/step-1'
+    const stepBKey = 'recipes/recipe-uuid-1/step-2'
+    const stepCKey = 'recipes/recipe-uuid-1/step-3'
 
     it('cover-image swap includes REMOVE imageStatus.#<oldKey> in the same UpdateCommand as SET', async () => {
       const oldItem = publishedRecipeItem({

--- a/test/lambda/recipe-image-handler.test.ts
+++ b/test/lambda/recipe-image-handler.test.ts
@@ -75,7 +75,7 @@ describe('Recipe Image handler', () => {
       const body = JSON.parse(result.body as string)
       expect(typeof body.uploadUrl).toBe('string')
       expect(typeof body.key).toBe('string')
-      expect(body.key).toMatch(/^processed\/recipes\/[^/]+\//)
+      expect(body.key).toMatch(/^recipes\/[^/]+\//)
     })
 
     it('generates correct S3 key for cover image', async () => {
@@ -88,7 +88,7 @@ describe('Recipe Image handler', () => {
 
       expect(result.statusCode).toBe(200)
       const body = JSON.parse(result.body as string)
-      expect(body.key).toBe('processed/recipes/abc/cover')
+      expect(body.key).toBe('recipes/abc/cover')
     })
 
     it('generates correct S3 key for step image', async () => {
@@ -101,7 +101,7 @@ describe('Recipe Image handler', () => {
 
       expect(result.statusCode).toBe(200)
       const body = JSON.parse(result.body as string)
-      expect(body.key).toBe('processed/recipes/abc/step-3')
+      expect(body.key).toBe('recipes/abc/step-3')
     })
 
     it('returns 401 without bearer token', async () => {


### PR DESCRIPTION
Stands up `images.akli.dev` as a dedicated CloudFront distribution with the recipe-images bucket as the first origin, served under `recipes/*`. Closes the recipe upload→process→serve loop end-to-end for the first time. Designed so phase 2 (blog/site bucket as a second origin) is purely additive.

PRD: `docs/prds/images-cdn-phase-1.md`. Sibling PRD covering the frontend cutover lives at `personal-website/docs/prds/images-cdn-phase-1.md`.

## Milestone summary

| # | Title | PR | Type |
|---|---|---|---|
| #121 | ImagesCert for images.akli.dev | #131 | feature |
| #122 | Extract shared CDN policies module | #132 | refactor |
| #123 | Expose RecipeImagesBucket from RecipeStack | #135 | refactor |
| #124 + #125 | Drop `processed/` segment from key shape | #137 | refactor |
| #126 | Implement ImagesStack | #138 | feature |
| #129 | Documentation updates | #139 | chore |

#127 (cutover migration runbook) and #128 (end-to-end verification post-deploy) are gated on this PR merging and the CDK app deploying.

## What ships
- **New `ImagesStack`** at `lib/images-stack.ts` (eu-west-2): CloudFront distribution for `images.akli.dev`, OAC, cross-stack bucket policy attachment on `RecipeImagesBucket`, Route 53 A + AAAA records, default-behaviour CloudFront Function returning synthetic 404.
- **Shared CDN policies module** at `lib/cdn-policies.ts` exporting `createImageCachePolicy` and `createSecurityHeadersPolicy` factories + the stable `IMAGE_CACHE_POLICY_NAME` constant. Consumed by `AkliInfrastructureStack` and `ImagesStack`.
- **`ImagesCert`** added to `CertificateStack` for `images.akli.dev` (separate from `SiteCert` to avoid CFN replacement risks).
- **`RecipeStack.imageBucket`** exposed as `public readonly s3.IBucket` so `ImagesStack` can attach the OAC bucket policy.
- **`PROCESSED_PREFIX` flipped** from `'processed/'` to `'recipes/'`. `toProcessedKey` rewritten to strip the redundant `recipes/` segment (the PRD's "one-line constant flip" claim was wrong — see PR #137). The hardcoded prefix in the recipe DELETE handler now uses the constant.
- **Frontend contract change**: the `key` field returned by `POST /recipes/images/upload-url` and persisted in DynamoDB changes shape (`processed/recipes/<id>/<type>` → `recipes/<id>/<type>`). Sibling personal-website PRD must deploy in lockstep — no backwards-compat shim. Stale `imageStatus` entries with the old shape yield `processedAt: undefined` (regression test in `recipe-handler.test.ts`).
- **Tests**: 366/366 green. New suites cover `ImagesStack` synthesis (27 tests) including negative invariants on the bucket policy and S3 event notification.
- **README + CLAUDE.md** updated with the new stack.
- **Version bump 1.7.0 → 1.8.0** (highest type in the milestone is feature → minor).

## Notable trade-offs

- **Wildcard `aws:SourceArn`** on the cross-stack bucket policy (`cloudfront::<account>:distribution/*` instead of the specific distribution ID) — necessary to break a cyclic stack dependency between `RecipeStack` and `ImagesStack`. Account-scoped; OAC association on the distribution side still gates which CloudFront principal reaches the bucket. Documented inline at `lib/images-stack.ts:67-70`.
- **`s3.Bucket.fromBucketAttributes`** re-import inside `ImagesStack` to suppress `S3BucketOrigin.withOriginAccessControl`'s auto-attached bucket policy (same cycle reason). Documented inline at `lib/images-stack.ts:31-37`.

## Deployment ordering (post-merge)

1. CI deploys all stacks via `cdk deploy --all` on push to main. Dependency graph orders `CertificateStack` (us-east-1) → `RecipeStack` → `ImagesStack`.
2. Run **#127 cutover migration**: `aws s3 rm s3://akli-recipe-images-<account>-eu-west-2/processed/ --recursive` and clear stale `imageStatus` entries from DynamoDB.
3. Run **#128 e2e verification**: `dig`, `curl` against `images.akli.dev` and the bucket regional domain.
4. Coordinate sibling `personal-website` PRD cutover.

## Follow-up issues opened from /simplify reviews

- #133 — apply shared `securityHeadersPolicy` to `ApiStack` CloudFront behaviours (gap surfaced during #122 review)
- #134 — generalise cache policy factory to subsume SSR + API + image cache policies
- #136 — collapse the upload-key namespace into `UPLOAD_PREFIX` (drops the conditional strip in `toProcessedKey`)

## How to verify

- `pnpm test` — 366 tests pass
- `pnpm lint` — clean
- `pnpm exec cdk diff --all` — preview cleanly shows the new `ImagesStack` resources