### PR TITLE
Hotfix: drop explicit cachePolicyName so two stacks can share the factory

### DIFF
--- a/lib/cdn-policies.ts
+++ b/lib/cdn-policies.ts
@@ -2,14 +2,15 @@ import { Duration } from 'aws-cdk-lib'
 import * as cloudfront from 'aws-cdk-lib/aws-cloudfront'
 import type { Construct } from 'constructs'
 
-export const IMAGE_CACHE_POLICY_NAME = 'AkliImageCachePolicy'
-
+// CloudFront cache policy names are account-globally unique, so the factory
+// must not set an explicit name — multiple stacks (AkliInfrastructureStack,
+// ImagesStack) each call this factory and would 409 on deploy if they shared
+// a name. CDK auto-generates a unique name per stack.
 export function createImageCachePolicy(
   scope: Construct,
   id: string = 'ImageCachePolicy',
 ): cloudfront.CachePolicy {
   return new cloudfront.CachePolicy(scope, id, {
-    cachePolicyName: IMAGE_CACHE_POLICY_NAME,
     defaultTtl: Duration.days(30),
     maxTtl: Duration.days(365),
     minTtl: Duration.seconds(0),

--- a/test/akli-infrastructure.test.ts
+++ b/test/akli-infrastructure.test.ts
@@ -214,10 +214,19 @@ describe('AkliInfrastructureStack', () => {
   })
 
   describe('Image cache policy', () => {
-    it('uses the stable name AkliImageCachePolicy so other stacks can reference it', () => {
+    it('configures 30-day default / 365-day max TTL with all-query / Accept+Country header allowlist', () => {
       template.hasResourceProperties('AWS::CloudFront::CachePolicy', {
         CachePolicyConfig: Match.objectLike({
-          Name: 'AkliImageCachePolicy',
+          DefaultTTL: 30 * 24 * 60 * 60,
+          MaxTTL: 365 * 24 * 60 * 60,
+          ParametersInCacheKeyAndForwardedToOrigin: Match.objectLike({
+            QueryStringsConfig: { QueryStringBehavior: 'all' },
+            HeadersConfig: {
+              HeaderBehavior: 'whitelist',
+              Headers: Match.arrayWith(['Accept', 'CloudFront-Viewer-Country']),
+            },
+            CookiesConfig: { CookieBehavior: 'none' },
+          }),
         }),
       })
     })

--- a/test/cdn-policies.test.ts
+++ b/test/cdn-policies.test.ts
@@ -4,7 +4,6 @@ import * as cloudfront from 'aws-cdk-lib/aws-cloudfront'
 import {
   createImageCachePolicy,
   createSecurityHeadersPolicy,
-  IMAGE_CACHE_POLICY_NAME,
 } from '../lib/cdn-policies'
 
 function harnessStack(): cdk.Stack {
@@ -27,14 +26,6 @@ describe('cdn-policies', () => {
 
     it('returns a cloudfront.CachePolicy construct', () => {
       expect(policy).toBeInstanceOf(cloudfront.CachePolicy)
-    })
-
-    it('synthesises with the stable name from IMAGE_CACHE_POLICY_NAME', () => {
-      template.hasResourceProperties('AWS::CloudFront::CachePolicy', {
-        CachePolicyConfig: Match.objectLike({
-          Name: IMAGE_CACHE_POLICY_NAME,
-        }),
-      })
     })
 
     it('configures default 30-day, max 365-day, min 0-second TTLs', () => {

--- a/test/images-stack.test.ts
+++ b/test/images-stack.test.ts
@@ -2,7 +2,6 @@ import * as cdk from 'aws-cdk-lib'
 import { Match, Template } from 'aws-cdk-lib/assertions'
 import * as certificatemanager from 'aws-cdk-lib/aws-certificatemanager'
 import * as route53 from 'aws-cdk-lib/aws-route53'
-import { IMAGE_CACHE_POLICY_NAME } from '../lib/cdn-policies'
 import { ImagesStack } from '../lib/images-stack'
 import { RecipeStack } from '../lib/recipe-stack'
 
@@ -92,21 +91,26 @@ function findDistribution(template: Template, aliasMatcher: string): CfnDistribu
   throw new Error(`No CloudFront::Distribution with alias ${aliasMatcher} in template`)
 }
 
-function findCachePolicyLogicalIdByName(
-  template: Template,
-  policyName: string,
-): string {
+// Identify the image cache policy by its unique TTLs (30d default / 365d max);
+// other CachePolicy resources in the template have different TTLs (e.g. SSR's
+// 60s default). Cannot match by Name because cache policy names are
+// account-globally unique, so the factory deliberately leaves the name unset
+// and lets CDK auto-generate per-stack.
+const IMAGE_CACHE_DEFAULT_TTL_SEC = 30 * 24 * 60 * 60
+const IMAGE_CACHE_MAX_TTL_SEC = 365 * 24 * 60 * 60
+
+function findImageCachePolicyLogicalId(template: Template): string {
   const resources = template.toJSON().Resources as Record<string, CfnResource>
   for (const [logicalId, resource] of Object.entries(resources)) {
     if (resource.Type !== 'AWS::CloudFront::CachePolicy') continue
     const cfg = (resource.Properties as {
-      CachePolicyConfig?: { Name?: string }
+      CachePolicyConfig?: { DefaultTTL?: number; MaxTTL?: number }
     }).CachePolicyConfig
-    if (cfg?.Name === policyName) {
+    if (cfg?.DefaultTTL === IMAGE_CACHE_DEFAULT_TTL_SEC && cfg?.MaxTTL === IMAGE_CACHE_MAX_TTL_SEC) {
       return logicalId
     }
   }
-  throw new Error(`No CachePolicy with Name=${policyName} in template`)
+  throw new Error('No image cache policy (30d/365d TTL) found in template')
 }
 
 describe('ImagesStack', () => {
@@ -198,11 +202,8 @@ describe('ImagesStack', () => {
       })
     })
 
-    it('recipes/* behaviour CachePolicyId references the shared image cache policy by stable name', () => {
-      const cachePolicyLogicalId = findCachePolicyLogicalIdByName(
-        harness.imagesTemplate,
-        IMAGE_CACHE_POLICY_NAME,
-      )
+    it('recipes/* behaviour CachePolicyId references the shared image cache policy', () => {
+      const cachePolicyLogicalId = findImageCachePolicyLogicalId(harness.imagesTemplate)
       const distribution = findDistribution(harness.imagesTemplate, 'images.akli.dev')
       const recipesBehavior = (distribution.Properties.DistributionConfig.CacheBehaviors ?? [])
         .find((b) => (b as { PathPattern?: string }).PathPattern === 'recipes/*') as
@@ -210,7 +211,6 @@ describe('ImagesStack', () => {
         | undefined
       expect(recipesBehavior).toBeDefined()
       const cachePolicyId = recipesBehavior?.CachePolicyId
-      // CDK typically emits a Ref; assert the Ref points to the cache-policy logical ID
       const ref = (cachePolicyId as { Ref?: string } | undefined)?.Ref
       expect(ref).toBe(cachePolicyLogicalId)
     })


### PR DESCRIPTION
Fixes the deploy failure that surfaced after #140 merged:

```
ImagesStack failed: Resource of type 'AWS::CloudFront::CachePolicy' with identifier 'AkliImageCachePolicy' already exists. (Service: CloudFront, Status Code: 409)
```

## Root cause
CloudFront cache policy names are **account-globally unique**. The factory in `lib/cdn-policies.ts` hardcoded `cachePolicyName: 'AkliImageCachePolicy'`. Both `AkliInfrastructureStack` and `ImagesStack` call the factory; the first stack succeeded, the second 409'd.

Tests passed locally because each test synthesises a single stack against a mock CDK app — no real AWS API to validate name uniqueness. The bug was structural, not in any individual test.

The `securityHeadersPolicy` factory does not have this issue because it doesn't set an explicit `responseHeadersPolicyName` — CDK auto-generates a unique name per stack. This hotfix aligns the cache policy with that pattern.

## Fix
- Drop `cachePolicyName: IMAGE_CACHE_POLICY_NAME` from `createImageCachePolicy`.
- Drop the `IMAGE_CACHE_POLICY_NAME` export (no longer load-bearing).
- Inline comment in `lib/cdn-policies.ts` documents the constraint.
- Tests previously matching by name (`test/cdn-policies.test.ts`, `test/akli-infrastructure.test.ts`, `test/images-stack.test.ts`) now match by structural shape — the image cache policy is the unique `CachePolicy` resource with default 30-day / max 365-day TTLs.

## Why structural matching is fine
CloudFront cache keys are computed per-distribution-behaviour. Two distributions referencing the same cache policy and two distributions each having an identical-config cache policy are functionally equivalent. The name was purely a test-side affordance — and a misguided one, given the deploy constraint.

## How to verify
- `pnpm test` — 365/365 pass (was 366 before; the now-bogus "synthesises with stable name" test was deleted).
- `pnpm lint` — clean.
- `pnpm exec cdk synth ImagesStack` — produces a clean template; cache policy resources have auto-generated names.

## Pre-merge step (you)
The failed `ImagesStack` is stuck in `ROLLBACK_COMPLETE` state and CFN won't recreate without it being deleted first:
```
aws cloudformation delete-stack --stack-name ImagesStack --region eu-west-2
```
Resources were already rolled back when the deploy failed; this just removes the empty stack metadata. Then merge this PR — CI will redeploy from a clean slate.