### PR TITLE
Apply shared securityHeadersPolicy to ApiStack CloudFront behaviours (#133)

### DIFF
--- a/lib/api-stack.ts
+++ b/lib/api-stack.ts
@@ -6,6 +6,7 @@ import * as origins from 'aws-cdk-lib/aws-cloudfront-origins'
 import * as route53 from 'aws-cdk-lib/aws-route53'
 import * as targets from 'aws-cdk-lib/aws-route53-targets'
 import type { Construct } from 'constructs'
+import { createSecurityHeadersPolicy } from './cdn-policies'
 import { applyStackTags } from './utils'
 
 const API_DOMAIN_NAME = 'api.akli.dev'
@@ -69,6 +70,8 @@ export class ApiStack extends Stack {
       cookieBehavior: cloudfront.OriginRequestCookieBehavior.none(),
     })
 
+    const securityHeadersPolicy = createSecurityHeadersPolicy(this)
+
     // CloudFront distribution for api.akli.dev
     const distribution = new cloudfront.Distribution(this, 'ApiDistribution', {
       domainNames: [API_DOMAIN_NAME],
@@ -80,6 +83,7 @@ export class ApiStack extends Stack {
         viewerProtocolPolicy: cloudfront.ViewerProtocolPolicy.REDIRECT_TO_HTTPS,
         cachePolicy: cloudfront.CachePolicy.CACHING_DISABLED,
         allowedMethods: cloudfront.AllowedMethods.ALLOW_GET_HEAD,
+        responseHeadersPolicy: securityHeadersPolicy,
       },
       additionalBehaviors: {
         '/pokedex/*': {
@@ -87,6 +91,7 @@ export class ApiStack extends Stack {
           viewerProtocolPolicy: cloudfront.ViewerProtocolPolicy.REDIRECT_TO_HTTPS,
           cachePolicy: apiCachePolicy,
           originRequestPolicy: apiOriginRequestPolicy,
+          responseHeadersPolicy: securityHeadersPolicy,
           allowedMethods: cloudfront.AllowedMethods.ALLOW_GET_HEAD,
           compress: true,
         },
@@ -96,6 +101,7 @@ export class ApiStack extends Stack {
           cachePolicy: cloudfront.CachePolicy.CACHING_DISABLED,
           // AllViewerExceptHostHeader forwards all viewer headers (including Authorization) except Host
           originRequestPolicy: cloudfront.OriginRequestPolicy.ALL_VIEWER_EXCEPT_HOST_HEADER,
+          responseHeadersPolicy: securityHeadersPolicy,
           allowedMethods: cloudfront.AllowedMethods.ALLOW_ALL,
           compress: true,
         },
@@ -104,6 +110,7 @@ export class ApiStack extends Stack {
           viewerProtocolPolicy: cloudfront.ViewerProtocolPolicy.REDIRECT_TO_HTTPS,
           cachePolicy: cloudfront.CachePolicy.CACHING_DISABLED,
           originRequestPolicy: cloudfront.OriginRequestPolicy.ALL_VIEWER_EXCEPT_HOST_HEADER,
+          responseHeadersPolicy: securityHeadersPolicy,
           allowedMethods: cloudfront.AllowedMethods.ALLOW_ALL,
           compress: true,
         },
@@ -112,6 +119,7 @@ export class ApiStack extends Stack {
           viewerProtocolPolicy: cloudfront.ViewerProtocolPolicy.REDIRECT_TO_HTTPS,
           cachePolicy: cloudfront.CachePolicy.CACHING_DISABLED,
           originRequestPolicy: cloudfront.OriginRequestPolicy.ALL_VIEWER_EXCEPT_HOST_HEADER,
+          responseHeadersPolicy: securityHeadersPolicy,
           allowedMethods: cloudfront.AllowedMethods.ALLOW_ALL,
           compress: true,
         },
@@ -120,6 +128,7 @@ export class ApiStack extends Stack {
           viewerProtocolPolicy: cloudfront.ViewerProtocolPolicy.REDIRECT_TO_HTTPS,
           cachePolicy: cloudfront.CachePolicy.CACHING_DISABLED,
           originRequestPolicy: cloudfront.OriginRequestPolicy.ALL_VIEWER_EXCEPT_HOST_HEADER,
+          responseHeadersPolicy: securityHeadersPolicy,
           allowedMethods: cloudfront.AllowedMethods.ALLOW_ALL,
           compress: true,
         },

--- a/test/api-stack.test.ts
+++ b/test/api-stack.test.ts
@@ -266,6 +266,104 @@ describe('ApiStack', () => {
     })
   })
 
+  describe('Security headers (response headers policy)', () => {
+    it('creates a ResponseHeadersPolicy with HSTS, frame-options, content-type-options, and referrer-policy', () => {
+      template.hasResourceProperties('AWS::CloudFront::ResponseHeadersPolicy', {
+        ResponseHeadersPolicyConfig: {
+          SecurityHeadersConfig: {
+            ContentTypeOptions: { Override: true },
+            FrameOptions: { FrameOption: 'DENY', Override: true },
+            ReferrerPolicy: Match.objectLike({
+              ReferrerPolicy: 'strict-origin-when-cross-origin',
+              Override: true,
+            }),
+            StrictTransportSecurity: Match.objectLike({
+              AccessControlMaxAgeSec: 31536000,
+              IncludeSubdomains: true,
+              Preload: true,
+              Override: true,
+            }),
+          },
+        },
+      })
+    })
+
+    it('attaches a ResponseHeadersPolicyId to the default behaviour', () => {
+      template.hasResourceProperties('AWS::CloudFront::Distribution', {
+        DistributionConfig: Match.objectLike({
+          DefaultCacheBehavior: Match.objectLike({
+            ResponseHeadersPolicyId: Match.anyValue(),
+          }),
+        }),
+      })
+    })
+
+    it('attaches a ResponseHeadersPolicyId to the /pokedex/* behaviour', () => {
+      template.hasResourceProperties('AWS::CloudFront::Distribution', {
+        DistributionConfig: Match.objectLike({
+          CacheBehaviors: Match.arrayWith([
+            Match.objectLike({
+              PathPattern: '/pokedex/*',
+              ResponseHeadersPolicyId: Match.anyValue(),
+            }),
+          ]),
+        }),
+      })
+    })
+
+    it('attaches a ResponseHeadersPolicyId to the /auth/* behaviour', () => {
+      template.hasResourceProperties('AWS::CloudFront::Distribution', {
+        DistributionConfig: Match.objectLike({
+          CacheBehaviors: Match.arrayWith([
+            Match.objectLike({
+              PathPattern: '/auth/*',
+              ResponseHeadersPolicyId: Match.anyValue(),
+            }),
+          ]),
+        }),
+      })
+    })
+
+    it('attaches a ResponseHeadersPolicyId to the /me/* behaviour', () => {
+      template.hasResourceProperties('AWS::CloudFront::Distribution', {
+        DistributionConfig: Match.objectLike({
+          CacheBehaviors: Match.arrayWith([
+            Match.objectLike({
+              PathPattern: '/me/*',
+              ResponseHeadersPolicyId: Match.anyValue(),
+            }),
+          ]),
+        }),
+      })
+    })
+
+    it('attaches a ResponseHeadersPolicyId to the /recipes behaviour', () => {
+      template.hasResourceProperties('AWS::CloudFront::Distribution', {
+        DistributionConfig: Match.objectLike({
+          CacheBehaviors: Match.arrayWith([
+            Match.objectLike({
+              PathPattern: '/recipes',
+              ResponseHeadersPolicyId: Match.anyValue(),
+            }),
+          ]),
+        }),
+      })
+    })
+
+    it('attaches a ResponseHeadersPolicyId to the /recipes/* behaviour', () => {
+      template.hasResourceProperties('AWS::CloudFront::Distribution', {
+        DistributionConfig: Match.objectLike({
+          CacheBehaviors: Match.arrayWith([
+            Match.objectLike({
+              PathPattern: '/recipes/*',
+              ResponseHeadersPolicyId: Match.anyValue(),
+            }),
+          ]),
+        }),
+      })
+    })
+  })
+
   describe('Route 53 record', () => {
     it('creates an A record for api.akli.dev', () => {
       template.hasResourceProperties('AWS::Route53::RecordSet', {


### PR DESCRIPTION
Closes #133

## What changed
- `ApiStack` (`lib/api-stack.ts`) now imports `createSecurityHeadersPolicy` from `lib/cdn-policies.ts` and attaches the policy to the distribution's default behaviour and every additional behaviour (`/pokedex/*`, `/auth/*`, `/me/*`, `/recipes`, `/recipes/*`).
- 7 new assertion tests in `test/api-stack.test.ts` cover the new policy resource (HSTS, frame-options, content-type-options, referrer-policy) plus per-behaviour `ResponseHeadersPolicyId` attachment.

## Why
Defence-in-depth gap surfaced during the `/simplify` review on #122. `api.akli.dev` responses previously went out without HSTS, X-Frame-Options, X-Content-Type-Options, or Referrer-Policy — now consistent with `akli.dev` and `images.akli.dev`. The shared factory means future stacks pick up identical headers for free.

## How to verify
- `pnpm test` — 372/372 pass (added 7 tests).
- `pnpm lint` — clean.
- `pnpm exec cdk diff ApiStack` — preview should show six behaviours each gaining a `ResponseHeadersPolicyId` reference plus one new `AWS::CloudFront::ResponseHeadersPolicy` resource. No other drift.
- After deploy: `curl -I https://api.akli.dev/pokedex/health` → response should carry `strict-transport-security`, `x-frame-options: DENY`, `x-content-type-options: nosniff`, `referrer-policy: strict-origin-when-cross-origin`.

## Decisions made
- **Reused the existing factory** rather than inlining or extracting a new helper. Three stacks now consume the same shared headers config.
- **TDD** — `3295de2` test commit before `ce30554` implementation commit.
- **No `responseHeadersPolicyName` set** — the factory deliberately leaves it unset so CDK auto-generates a unique name per stack (cache policy lessons from hotfix #141 apply equally to response headers policies, which are also account-globally unique).

## AC coverage
- ✅ `ApiStack` imports `createSecurityHeadersPolicy` from `lib/cdn-policies.ts`.
- ✅ `responseHeadersPolicy` attached to default behaviour + 5 additional behaviours.
- ✅ Assertion tests verify policy resource shape + per-behaviour `ResponseHeadersPolicyId`.
- ✅ TDD sequence followed.
- ✅ `pnpm test` and `pnpm lint` pass locally.