### PR TITLE
Collapse upload-key namespace into UPLOAD_PREFIX (#136)

### DIFF
--- a/lambda/image-resizer.ts
+++ b/lambda/image-resizer.ts
@@ -25,15 +25,12 @@ const VARIANTS: readonly ImageVariant[] = VARIANT_SUFFIXES.map((suffix) => ({
   ...VARIANT_SIZING[suffix],
 }))
 
-const RECIPES_SEGMENT = 'recipes'
-
 // Accepts exactly `uploads/recipes/<id>/<type>` — extra trailing segments are rejected.
 function parseRecipeId(uploadKey: string): string | undefined {
   if (!uploadKey.startsWith(UPLOAD_PREFIX)) return undefined
   const segments = uploadKey.slice(UPLOAD_PREFIX.length).split('/')
-  if (segments.length !== 3) return undefined
-  if (segments[0] !== RECIPES_SEGMENT) return undefined
-  const id = segments[1]
+  if (segments.length !== 2) return undefined
+  const id = segments[0]
   if (!id) return undefined
   return id
 }

--- a/lambda/image-variants.ts
+++ b/lambda/image-variants.ts
@@ -2,19 +2,16 @@ export const VARIANT_SUFFIXES = ['thumb', 'medium', 'full'] as const
 
 export type VariantSuffix = (typeof VARIANT_SUFFIXES)[number]
 
-export const UPLOAD_PREFIX = 'uploads/'
+export const UPLOAD_PREFIX = 'uploads/recipes/'
 export const PROCESSED_PREFIX = 'recipes/'
 
 export const toProcessedKey = (uploadKey: string): string => {
   if (!uploadKey.startsWith(UPLOAD_PREFIX)) {
     throw new Error(`Expected key to start with "${UPLOAD_PREFIX}", got "${uploadKey}"`)
   }
-  const afterUpload = uploadKey.slice(UPLOAD_PREFIX.length)
-  if (afterUpload.length === 0) {
+  const suffix = uploadKey.slice(UPLOAD_PREFIX.length)
+  if (suffix.length === 0) {
     throw new Error(`Expected key to have content after "${UPLOAD_PREFIX}", got "${uploadKey}"`)
   }
-  const stripped = afterUpload.startsWith(PROCESSED_PREFIX)
-    ? afterUpload.slice(PROCESSED_PREFIX.length)
-    : afterUpload
-  return PROCESSED_PREFIX + stripped
+  return PROCESSED_PREFIX + suffix
 }

--- a/lambda/recipe-image-handler.ts
+++ b/lambda/recipe-image-handler.ts
@@ -54,8 +54,8 @@ async function handleUploadUrl(event: APIGatewayProxyEventV2): Promise<APIGatewa
   if (imageType !== 'cover' && !stepOrder) return json(400, { error: 'stepOrder is required for step images' })
 
   const uploadKey = imageType === 'cover'
-    ? `${UPLOAD_PREFIX}recipes/${recipeId}/cover`
-    : `${UPLOAD_PREFIX}recipes/${recipeId}/step-${stepOrder}`
+    ? `${UPLOAD_PREFIX}${recipeId}/cover`
+    : `${UPLOAD_PREFIX}${recipeId}/step-${stepOrder}`
 
   const uploadUrl = await getSignedUrl(
     s3,

--- a/test/lambda/image-resizer.test.ts
+++ b/test/lambda/image-resizer.test.ts
@@ -208,15 +208,14 @@ describe('image-resizer handler', () => {
     await expect(handler(makeS3Event('uploads/recipes/abc/cover'))).rejects.toThrow('boom')
   })
 
-  it('skips the DDB write for a malformed key that does not match uploads/recipes/<id>/...', async () => {
-    // This key passes the toProcessedKey prefix guard but isn't the recipes shape.
-    await handler(makeS3Event('uploads/not-recipes/x'))
+  it('throws and writes nothing for a malformed key that does not match uploads/recipes/<id>/...', async () => {
+    // With UPLOAD_PREFIX = 'uploads/recipes/', this key fails the prefix guard
+    // inside toProcessedKey and the handler now refuses to process it.
+    await expect(handler(makeS3Event('uploads/not-recipes/x'))).rejects.toThrow(/uploads\/recipes\//)
 
     expect(ddbMock.commandCalls(UpdateCommand)).toHaveLength(0)
-
-    // Variant writes and source-delete still happen.
-    expect(s3Mock.commandCalls(PutObjectCommand)).toHaveLength(3)
-    expect(s3Mock.commandCalls(DeleteObjectCommand)).toHaveLength(1)
+    expect(s3Mock.commandCalls(PutObjectCommand)).toHaveLength(0)
+    expect(s3Mock.commandCalls(DeleteObjectCommand)).toHaveLength(0)
   })
 
   it('invokes DDB UpdateCommand before the source DeleteObjectCommand', async () => {

--- a/test/lambda/image-variants.test.ts
+++ b/test/lambda/image-variants.test.ts
@@ -8,8 +8,8 @@ describe('image-variants', () => {
   })
 
   describe('UPLOAD_PREFIX constant', () => {
-    it('is "uploads/"', () => {
-      expect(UPLOAD_PREFIX).toBe('uploads/')
+    it('is "uploads/recipes/"', () => {
+      expect(UPLOAD_PREFIX).toBe('uploads/recipes/')
     })
   })
 
@@ -22,16 +22,16 @@ describe('image-variants', () => {
       expect(toProcessedKey('uploads/recipes/abc/step-2')).toBe('recipes/abc/step-2')
     })
 
-    it('throws when the upload key does not start with "uploads/"', () => {
-      expect(() => toProcessedKey('not-uploads/foo')).toThrow(/uploads\//)
+    it('throws when the upload key does not start with "uploads/recipes/"', () => {
+      expect(() => toProcessedKey('not-uploads/foo')).toThrow(/uploads\/recipes\//)
     })
 
-    it('throws when the upload key has no suffix after "uploads/"', () => {
-      expect(() => toProcessedKey('uploads/')).toThrow()
+    it('throws when the upload key has no suffix after "uploads/recipes/"', () => {
+      expect(() => toProcessedKey('uploads/recipes/')).toThrow(/content after/)
     })
 
     it('preserves a stray double-slash after the upload prefix', () => {
-      expect(toProcessedKey('uploads//double-slash')).toBe('recipes//double-slash')
+      expect(toProcessedKey('uploads/recipes//double-slash')).toBe('recipes//double-slash')
     })
   })
 })


### PR DESCRIPTION
Closes #136

## What changed
- `UPLOAD_PREFIX` in `lambda/image-variants.ts` is now `'uploads/recipes/'` (was `'uploads/'`).
- `toProcessedKey` is now a clean prefix swap — drops the conditional strip introduced in #137 because the redundancy no longer exists.
- `lambda/recipe-image-handler.ts` upload-key construction drops the inline `recipes/` literal: `\`${UPLOAD_PREFIX}${recipeId}/cover\`` instead of `\`${UPLOAD_PREFIX}recipes/${recipeId}/cover\``.
- `lambda/image-resizer.ts` drops the private `RECIPES_SEGMENT` constant and `parseRecipeId` is simplified to expect 2 segments (id, type) since `UPLOAD_PREFIX` already absorbs `recipes/`.
- Two existing tests updated for the new malformed-input behaviour (see "Decisions").

## Why
Surfaced during the `/simplify` review on #124+#125. The literal `recipes/` segment lived as three separate copies — a private constant in the resizer, a hardcoded string in the upload-URL handler, and a conditional inside `toProcessedKey`. Single source of truth eliminates drift risk and makes the function a clean prefix swap again.

## How to verify
- `pnpm test` — 372/372 pass.
- `pnpm lint` — clean.
- `pnpm exec tsc --noEmit` — only the pre-existing unrelated `sharp` type warning.
- `cdk synth` — no template changes (pure Lambda code refactor).

## Decisions made
- **On-the-wire contract is unchanged.** Upload key value is still `uploads/recipes/<id>/<type>` and processed key value is still `recipes/<id>/<type>`. Frontend and DynamoDB shape unaffected.
- **One observable behaviour change** at the malformed-input boundary: `toProcessedKey('uploads/not-recipes/foo')` previously returned `'recipes/not-recipes/foo'`, now throws. Two tests updated to pin the new behaviour:
  - `test/lambda/image-variants.test.ts` — empty-suffix case migrated from `'uploads/'` to `'uploads/recipes/'`; double-slash case migrated from `'uploads//double-slash'` to `'uploads/recipes//double-slash'`.
  - `test/lambda/image-resizer.test.ts` — the malformed-key test now asserts the handler rejects rather than silently producing variants. Defensive narrowing — the resizer should not be processing keys it doesn't understand.
- **CDK side untouched.** S3 event notification at `lib/recipe-stack.ts:164` still filters on `prefix: 'uploads/'`. `uploads/recipes/` is a sub-prefix so this still matches; tightening the filter would be a CFN replacement, out of scope.

## AC coverage
- ✅ `UPLOAD_PREFIX` equals `'uploads/recipes/'` — `lambda/image-variants.ts:5`.
- ✅ `toProcessedKey` is a clean prefix swap with no conditional strip — `lambda/image-variants.ts:8-17`.
- ✅ `lambda/recipe-image-handler.ts` no longer hardcodes the `recipes/` segment.
- ✅ `lambda/image-resizer.ts` no longer defines `RECIPES_SEGMENT`; `parseRecipeId` expects 2 segments.
- ✅ Existing `test/lambda/image-variants.test.ts` empty-suffix throw test updated for `'uploads/recipes/'`.
- ✅ Existing `test/lambda/image-resizer.test.ts` malformed-key test updated to assert it now throws.
- ✅ All other tests still pass.
- ✅ `pnpm test` and `pnpm lint` pass.