### PR TITLE
Generic createCachePolicy factory subsuming image + API + SSR (#134)

### DIFF
--- a/lib/akli-infrastructure-stack.ts
+++ b/lib/akli-infrastructure-stack.ts
@@ -12,7 +12,7 @@ import * as targets from 'aws-cdk-lib/aws-route53-targets'
 import * as s3 from 'aws-cdk-lib/aws-s3'
 import * as secretsmanager from 'aws-cdk-lib/aws-secretsmanager'
 import type { Construct } from 'constructs'
-import { createImageCachePolicy, createSecurityHeadersPolicy } from './cdn-policies'
+import { createCachePolicy, createImageCachePolicy, createSecurityHeadersPolicy } from './cdn-policies'
 
 interface AkliInfrastructureStackProps extends StackProps {
   hostedZone: route53.IHostedZone
@@ -92,14 +92,9 @@ export class AkliInfrastructureStack extends Stack {
       invokeMode: lambda.InvokeMode.RESPONSE_STREAM,
     })
 
-    const ssrCachePolicy = new cloudfront.CachePolicy(this, 'SsrCachePolicy', {
+    const ssrCachePolicy = createCachePolicy(this, 'SsrCachePolicy', {
       cachePolicyName: 'SsrCachePolicy',
       defaultTtl: Duration.seconds(60),
-      maxTtl: Duration.seconds(60),
-      minTtl: Duration.seconds(0),
-      queryStringBehavior: cloudfront.CacheQueryStringBehavior.all(),
-      headerBehavior: cloudfront.CacheHeaderBehavior.none(),
-      cookieBehavior: cloudfront.CacheCookieBehavior.none(),
     })
 
     const s3Origin = origins.S3BucketOrigin.withOriginAccessControl(siteBucket, {

--- a/lib/api-stack.ts
+++ b/lib/api-stack.ts
@@ -6,7 +6,7 @@ import * as origins from 'aws-cdk-lib/aws-cloudfront-origins'
 import * as route53 from 'aws-cdk-lib/aws-route53'
 import * as targets from 'aws-cdk-lib/aws-route53-targets'
 import type { Construct } from 'constructs'
-import { createSecurityHeadersPolicy } from './cdn-policies'
+import { createCachePolicy, createSecurityHeadersPolicy } from './cdn-policies'
 import { applyStackTags } from './utils'
 
 const API_DOMAIN_NAME = 'api.akli.dev'
@@ -52,14 +52,9 @@ export class ApiStack extends Stack {
     })
 
     // Cache policy: 5-minute TTL, forward all query strings
-    const apiCachePolicy = new cloudfront.CachePolicy(this, 'ApiCachePolicy', {
+    const apiCachePolicy = createCachePolicy(this, 'ApiCachePolicy', {
       cachePolicyName: 'ApiCachePolicy',
       defaultTtl: Duration.minutes(5),
-      maxTtl: Duration.minutes(5),
-      minTtl: Duration.seconds(0),
-      queryStringBehavior: cloudfront.CacheQueryStringBehavior.all(),
-      headerBehavior: cloudfront.CacheHeaderBehavior.none(),
-      cookieBehavior: cloudfront.CacheCookieBehavior.none(),
     })
 
     // Origin request policy to forward Host header to API Gateway

--- a/lib/cdn-policies.ts
+++ b/lib/cdn-policies.ts
@@ -2,21 +2,53 @@ import { Duration } from 'aws-cdk-lib'
 import * as cloudfront from 'aws-cdk-lib/aws-cloudfront'
 import type { Construct } from 'constructs'
 
-// CloudFront cache policy names are account-globally unique, so the factory
+interface CachePolicyOptions {
+  /**
+   * Optional explicit cache policy name. CloudFront cache policy names are
+   * account-globally unique — set this only for singleton policies.
+   * Multi-stack factories (e.g. createImageCachePolicy) must leave it unset
+   * so CDK auto-generates a unique name per stack.
+   */
+  readonly cachePolicyName?: string
+  readonly defaultTtl: Duration
+  /** Maximum TTL. Defaults to defaultTtl. */
+  readonly maxTtl?: Duration
+  /** Headers to include in the cache key. Empty/undefined = none. */
+  readonly headers?: readonly string[]
+}
+
+export function createCachePolicy(
+  scope: Construct,
+  id: string,
+  opts: CachePolicyOptions,
+): cloudfront.CachePolicy {
+  const headerBehavior = opts.headers && opts.headers.length > 0
+    ? cloudfront.CacheHeaderBehavior.allowList(...opts.headers)
+    : cloudfront.CacheHeaderBehavior.none()
+
+  return new cloudfront.CachePolicy(scope, id, {
+    cachePolicyName: opts.cachePolicyName,
+    defaultTtl: opts.defaultTtl,
+    maxTtl: opts.maxTtl ?? opts.defaultTtl,
+    minTtl: Duration.seconds(0),
+    queryStringBehavior: cloudfront.CacheQueryStringBehavior.all(),
+    headerBehavior,
+    cookieBehavior: cloudfront.CacheCookieBehavior.none(),
+  })
+}
+
+// CloudFront cache policy names are account-globally unique, so this factory
 // must not set an explicit name — multiple stacks (AkliInfrastructureStack,
-// ImagesStack) each call this factory and would 409 on deploy if they shared
-// a name. CDK auto-generates a unique name per stack.
+// ImagesStack) each call it and would 409 on deploy if they shared a name.
+// CDK auto-generates a unique name per stack.
 export function createImageCachePolicy(
   scope: Construct,
   id: string = 'ImageCachePolicy',
 ): cloudfront.CachePolicy {
-  return new cloudfront.CachePolicy(scope, id, {
+  return createCachePolicy(scope, id, {
     defaultTtl: Duration.days(30),
     maxTtl: Duration.days(365),
-    minTtl: Duration.seconds(0),
-    queryStringBehavior: cloudfront.CacheQueryStringBehavior.all(),
-    headerBehavior: cloudfront.CacheHeaderBehavior.allowList('Accept', 'CloudFront-Viewer-Country'),
-    cookieBehavior: cloudfront.CacheCookieBehavior.none(),
+    headers: ['Accept', 'CloudFront-Viewer-Country'],
   })
 }
 

--- a/test/cdn-policies.test.ts
+++ b/test/cdn-policies.test.ts
@@ -2,6 +2,7 @@ import * as cdk from 'aws-cdk-lib'
 import { Match, Template } from 'aws-cdk-lib/assertions'
 import * as cloudfront from 'aws-cdk-lib/aws-cloudfront'
 import {
+  createCachePolicy,
   createImageCachePolicy,
   createSecurityHeadersPolicy,
 } from '../lib/cdn-policies'
@@ -51,6 +52,121 @@ describe('cdn-policies', () => {
           }),
         }),
       })
+    })
+  })
+
+  describe('createCachePolicy', () => {
+    it('defaults maxTtl to defaultTtl and minTtl to 0 when only defaultTtl is provided', () => {
+      const stack = harnessStack()
+      createCachePolicy(stack, 'DefaultsPolicy', {
+        defaultTtl: cdk.Duration.minutes(5),
+      })
+      const template = Template.fromStack(stack)
+      template.hasResourceProperties('AWS::CloudFront::CachePolicy', {
+        CachePolicyConfig: Match.objectLike({
+          DefaultTTL: 300,
+          MaxTTL: 300,
+          MinTTL: 0,
+        }),
+      })
+    })
+
+    it('honours an explicit maxTtl', () => {
+      const stack = harnessStack()
+      createCachePolicy(stack, 'ExplicitMaxTtlPolicy', {
+        defaultTtl: cdk.Duration.minutes(1),
+        maxTtl: cdk.Duration.hours(1),
+      })
+      const template = Template.fromStack(stack)
+      template.hasResourceProperties('AWS::CloudFront::CachePolicy', {
+        CachePolicyConfig: Match.objectLike({
+          DefaultTTL: 60,
+          MaxTTL: 3600,
+          MinTTL: 0,
+        }),
+      })
+    })
+
+    it('configures HeaderBehavior=none when no headers are provided', () => {
+      const stack = harnessStack()
+      createCachePolicy(stack, 'NoHeadersPolicy', {
+        defaultTtl: cdk.Duration.seconds(60),
+      })
+      const template = Template.fromStack(stack)
+      template.hasResourceProperties('AWS::CloudFront::CachePolicy', {
+        CachePolicyConfig: Match.objectLike({
+          ParametersInCacheKeyAndForwardedToOrigin: Match.objectLike({
+            HeadersConfig: { HeaderBehavior: 'none' },
+          }),
+        }),
+      })
+    })
+
+    it('whitelists provided headers in the cache key', () => {
+      const stack = harnessStack()
+      createCachePolicy(stack, 'WithHeadersPolicy', {
+        defaultTtl: cdk.Duration.seconds(60),
+        headers: ['Accept'],
+      })
+      const template = Template.fromStack(stack)
+      template.hasResourceProperties('AWS::CloudFront::CachePolicy', {
+        CachePolicyConfig: Match.objectLike({
+          ParametersInCacheKeyAndForwardedToOrigin: Match.objectLike({
+            HeadersConfig: {
+              HeaderBehavior: 'whitelist',
+              Headers: ['Accept'],
+            },
+          }),
+        }),
+      })
+    })
+
+    it('always sets QueryStringBehavior=all, CookieBehavior=none, MinTTL=0 regardless of opts', () => {
+      const stack = harnessStack()
+      createCachePolicy(stack, 'InvariantsPolicy', {
+        defaultTtl: cdk.Duration.days(7),
+        maxTtl: cdk.Duration.days(30),
+        headers: ['Accept', 'CloudFront-Viewer-Country'],
+      })
+      const template = Template.fromStack(stack)
+      template.hasResourceProperties('AWS::CloudFront::CachePolicy', {
+        CachePolicyConfig: Match.objectLike({
+          MinTTL: 0,
+          ParametersInCacheKeyAndForwardedToOrigin: Match.objectLike({
+            QueryStringsConfig: { QueryStringBehavior: 'all' },
+            CookiesConfig: { CookieBehavior: 'none' },
+          }),
+        }),
+      })
+    })
+
+    it('sets Name to the explicit cachePolicyName when provided, and lets CDK auto-generate it otherwise', () => {
+      const stack = harnessStack()
+      createCachePolicy(stack, 'NamedPolicy', {
+        cachePolicyName: 'MyExplicitName',
+        defaultTtl: cdk.Duration.minutes(5),
+      })
+      createCachePolicy(stack, 'UnnamedPolicy', {
+        defaultTtl: cdk.Duration.minutes(5),
+      })
+      const template = Template.fromStack(stack)
+      template.hasResourceProperties('AWS::CloudFront::CachePolicy', {
+        CachePolicyConfig: Match.objectLike({ Name: 'MyExplicitName' }),
+      })
+      // CDK always emits a Name on AWS::CloudFront::CachePolicy. When
+      // cachePolicyName is omitted, CDK derives it from the construct path
+      // (e.g. "PolicyHarnessStackUnnamedPolicyXXXXXX-<region>") rather than
+      // leaving it undefined.
+      const policies = template.findResources('AWS::CloudFront::CachePolicy')
+      const autoNamed = Object.values(policies).find(
+        (resource) => {
+          const name = resource.Properties?.CachePolicyConfig?.Name as string | undefined
+          return typeof name === 'string'
+            && name !== 'MyExplicitName'
+            && name.includes('UnnamedPolicy')
+        },
+      )
+      expect(autoNamed).toBeDefined()
     })
   })
 


### PR DESCRIPTION
Closes #134

## What changed
- New `createCachePolicy(scope, id, opts)` exported from `lib/cdn-policies.ts` — bakes in the project's de-facto conventions (`minTtl=0`, `queryStringBehavior=all`, `cookieBehavior=none`, `maxTtl` defaults to `defaultTtl`) and surfaces only the differing bits (TTLs, optional headers, optional explicit name).
- `createImageCachePolicy` rewritten as a 6-line thin wrapper.
- `apiCachePolicy` in `lib/api-stack.ts` and `ssrCachePolicy` in `lib/akli-infrastructure-stack.ts` each shrink from 9 lines to 4.
- 6 new tests in `test/cdn-policies.test.ts` cover the factory's default handling, optional `cachePolicyName`, header propagation, and invariants.

## Why
Surfaced during the `/simplify` review on #122. Three near-identical `new cloudfront.CachePolicy(...)` invocations across three stacks all repeated the same conventions in slightly-different forms. A trivial passthrough wrapper would have added no DRY value, but a factory that **bakes the conventions in** turns 9 lines per consumer into 4 and ensures future cache policies inherit the same conventions automatically.

## How to verify
- `pnpm test` — 378/378 pass (added 6 tests).
- `pnpm lint` — clean.
- `pnpm exec tsc --noEmit` — only the pre-existing unrelated `sharp` type warning.
- **Synthesised CFN is byte-identical to `main`** for all three cache policy resources — no behavioural drift. Verified by diffing `cdk synth` output for `AkliInfrastructureStack`, `ApiStack`, and `ImagesStack`.

## Decisions made
- **Defaults baked into the factory** rather than a passthrough wrapper. The issue body literally described a passthrough but a passthrough adds nothing over the L2 construct. Encoding conventions in the factory is where the real DRY win lives.
- **The four invariants (`queryStringBehavior=all`, `cookieBehavior=none`, `minTtl=0`, plus `headerBehavior=none` when no headers passed) are NOT overridable.** If a future consumer needs different cookie or query-string behaviour, the factory will need extension — by design.
- **`createImageCachePolicy` keeps its singleton-naming caveat comment** (no explicit `cachePolicyName` because two stacks call it). The new `createCachePolicy` accepts an optional `cachePolicyName`, with the JSDoc explaining the constraint.

## AC coverage
- ✅ `lib/cdn-policies.ts` exports `createCachePolicy(scope, id, opts)` with typed `opts`.
- ✅ `createImageCachePolicy` is a thin wrapper that calls `createCachePolicy`.
- ✅ `apiCachePolicy` in `lib/api-stack.ts` is a `createCachePolicy` call.
- ✅ `ssrCachePolicy` in `lib/akli-infrastructure-stack.ts` is a `createCachePolicy` call.
- ✅ Synthesised CloudFormation template is functionally identical (verified byte-identical CachePolicy resources).
- ✅ Tests cover the generic factory's option handling.
- ✅ All existing assertion tests still pass.
- ✅ `pnpm test` and `pnpm lint` pass.

## Closes the /simplify follow-up trio
This is the third and final follow-up from the `/simplify` reviews on the Images CDN Phase 1 epic:
- ~~#133 — security headers on ApiStack~~ ✅ shipped
- ~~#136 — collapse upload-key namespace~~ ✅ shipped
- **#134 — generic cache policy factory** (this PR)