### PR TITLE
Hotfix: bucket policy aws:SourceArn must use StringLike for wildcard

### DIFF
--- a/lib/images-stack.ts
+++ b/lib/images-stack.ts
@@ -92,7 +92,11 @@ export class ImagesStack extends Stack {
       actions: ['s3:GetObject'],
       resources: [`${recipeImageBucket.bucketArn}/*`],
       conditions: {
-        StringEquals: {
+        // StringLike (not StringEquals) is required for the trailing `*` to be
+        // treated as a wildcard. CloudFront sends the specific distribution
+        // ARN as aws:SourceArn; StringEquals would require exact match against
+        // the literal `…/distribution/*` string and the Allow would never fire.
+        StringLike: {
           'aws:SourceArn': `arn:aws:cloudfront::${this.account}:distribution/*`,
         },
       },

--- a/test/images-stack.test.ts
+++ b/test/images-stack.test.ts
@@ -341,7 +341,7 @@ describe('ImagesStack', () => {
                 ]),
               }),
               Condition: Match.objectLike({
-                StringEquals: Match.objectLike({
+                StringLike: Match.objectLike({
                   'aws:SourceArn': Match.anyValue(),
                 }),
               }),
@@ -415,7 +415,10 @@ describe('ImagesStack', () => {
         for (const stmt of statements) {
           const s = stmt as {
             Principal?: { Service?: string | string[] }
-            Condition?: { StringEquals?: Record<string, unknown> }
+            Condition?: {
+              StringEquals?: Record<string, unknown>
+              StringLike?: Record<string, unknown>
+            }
           }
           const principalService = s.Principal?.Service
           const isCloudFrontPrincipal = principalService === 'cloudfront.amazonaws.com'
@@ -425,6 +428,8 @@ describe('ImagesStack', () => {
           cloudfrontStatementsSeen += 1
           const sourceArn = s.Condition?.StringEquals?.['aws:SourceArn']
             ?? s.Condition?.StringEquals?.['AWS:SourceArn']
+            ?? s.Condition?.StringLike?.['aws:SourceArn']
+            ?? s.Condition?.StringLike?.['AWS:SourceArn']
           if (sourceArn === undefined || sourceArn === null) {
             cloudfrontStatementsWithoutSourceArn.push(s)
           }


### PR DESCRIPTION
Fixes the 403 surfaced during personal-website manual QA (#187):

\`\`\`
HTTP/2 403
content-type: application/xml
server: AmazonS3
x-cache: Error from cloudfront
\`\`\`

## Root cause
The bucket policy created by ImagesStack uses a wildcard `aws:SourceArn`:
\`\`\`json
"Condition": {
  "StringEquals": {
    "aws:SourceArn": "arn:aws:cloudfront::<account>:distribution/*"
  }
}
\`\`\`

**`StringEquals` does not expand `*` as a wildcard** — it requires literal exact-string match. CloudFront sends the specific distribution ARN (e.g. `…/E1234ABCDEF`) as `aws:SourceArn`, which never equals the literal string ending in `*`. The Allow statement therefore never fired and S3 fell through to default-Deny → 403 on every CloudFront request.

The wildcard was deliberately introduced in #126 to break the cyclic stack dependency between RecipeStack (bucket policy) and ImagesStack (distribution); the workaround was sound, but `StringEquals` should have been `StringLike`.

## Fix
- `lib/images-stack.ts:91-95` — change `StringEquals` to `StringLike`. Inline comment documents why.
- `test/images-stack.test.ts` — two test sites updated to either pin the new condition shape or accept both `StringEquals` and `StringLike` (the latter for the negative-assertion that walks all CloudFront-principal statements).

## Diagnosis evidence
- `aws s3 ls s3://akli-recipe-images-…/recipes/<id>/` → all three variant files present (resizer worked).
- `aws dynamodb get-item …` → `imageStatus['recipes/<id>/cover']` is set with a timestamp.
- `curl -I https://images.akli.dev/recipes/<id>/cover-medium.webp` → `HTTP/2 403`, `server: AmazonS3`, `x-cache: Error from cloudfront`.
- `aws s3api get-bucket-policy …` → confirms the StringEquals-with-wildcard bug.

## Pre-merge step
The fix is a CloudFormation-update of the existing bucket policy on RecipeStack — no manual stack deletion needed this time. CI will redeploy on merge.

## Verification post-merge
After redeploy, the same `curl -I` should return `HTTP/2 200` and the personal-website manual QA flow can complete.