### PR TITLE
Add slug-index GSI + IAM grants for resizer and image-handler

### DIFF
--- a/lib/recipe-stack.ts
+++ b/lib/recipe-stack.ts
@@ -49,6 +49,12 @@ export class RecipeStack extends Stack {
       sortKey: { name: 'createdAt', type: dynamodb.AttributeType.STRING },
     })
 
+    table.addGlobalSecondaryIndex({
+      indexName: 'slug-index',
+      partitionKey: { name: 'slug', type: dynamodb.AttributeType.STRING },
+      projectionType: dynamodb.ProjectionType.KEYS_ONLY,
+    })
+
     // S3 image bucket
     const imageBucket = new s3.Bucket(this, 'RecipeImagesBucket', {
       bucketName: `akli-recipe-images-${this.account}-${this.region}`,
@@ -115,10 +121,15 @@ export class RecipeStack extends Stack {
       functionName: 'akli-recipe-image-handler',
       environment: {
         IMAGE_BUCKET_NAME: imageBucket.bucketName,
+        TABLE_NAME: table.tableName,
       },
     })
 
     imageBucket.grantPut(recipeImageHandler)
+    recipeImageHandler.addToRolePolicy(new iam.PolicyStatement({
+      actions: ['dynamodb:GetItem'],
+      resources: [table.tableArn],
+    }))
 
     const imageResizer = new NodejsFunction(this, 'ImageResizer', {
       runtime: lambda.Runtime.NODEJS_22_X,
@@ -157,6 +168,10 @@ export class RecipeStack extends Stack {
     imageResizer.addToRolePolicy(new iam.PolicyStatement({
       actions: ['dynamodb:UpdateItem'],
       resources: [table.tableArn],
+    }))
+    imageResizer.addToRolePolicy(new iam.PolicyStatement({
+      actions: ['dynamodb:Query'],
+      resources: [`${table.tableArn}/index/slug-index`],
     }))
 
     // S3 event notification for image uploads

--- a/test/recipe-stack.test.ts
+++ b/test/recipe-stack.test.ts
@@ -172,6 +172,45 @@ describe('RecipeStack', () => {
     })
   })
 
+  describe('GSI slug-index', () => {
+    it('creates GSI with name slug-index', () => {
+      template.hasResourceProperties('AWS::DynamoDB::Table', {
+        GlobalSecondaryIndexes: Match.arrayWith([
+          Match.objectLike({
+            IndexName: 'slug-index',
+          }),
+        ]),
+      })
+    })
+
+    it('has partition key slug (String)', () => {
+      template.hasResourceProperties('AWS::DynamoDB::Table', {
+        GlobalSecondaryIndexes: Match.arrayWith([
+          Match.objectLike({
+            IndexName: 'slug-index',
+            KeySchema: [
+              { AttributeName: 'slug', KeyType: 'HASH' },
+            ],
+          }),
+        ]),
+        AttributeDefinitions: Match.arrayWith([
+          { AttributeName: 'slug', AttributeType: 'S' },
+        ]),
+      })
+    })
+
+    it('uses KEYS_ONLY projection', () => {
+      template.hasResourceProperties('AWS::DynamoDB::Table', {
+        GlobalSecondaryIndexes: Match.arrayWith([
+          Match.objectLike({
+            IndexName: 'slug-index',
+            Projection: { ProjectionType: 'KEYS_ONLY' },
+          }),
+        ]),
+      })
+    })
+  })
+
   describe('S3 image bucket', () => {
     it('creates an S3 bucket named akli-recipe-images-{account-id}-eu-west-2', () => {
       template.hasResourceProperties('AWS::S3::Bucket', {
@@ -421,6 +460,27 @@ describe('RecipeStack', () => {
       })
     })
 
+    it('grants dynamodb:Query on the slug-index GSI ARN', () => {
+      template.hasResourceProperties('AWS::IAM::Policy', {
+        Roles: Match.arrayWith([
+          { Ref: Match.stringLikeRegexp('^ImageResizerServiceRole.*') },
+        ]),
+        PolicyDocument: Match.objectLike({
+          Statement: Match.arrayWith([
+            Match.objectLike({
+              Action: 'dynamodb:Query',
+              Effect: 'Allow',
+              Resource: Match.objectLike({
+                'Fn::Join': Match.arrayWith([
+                  Match.arrayWith([Match.stringLikeRegexp('/index/slug-index$')]),
+                ]),
+              }),
+            }),
+          ]),
+        }),
+      })
+    })
+
     it('does not grant dynamodb:PutItem, dynamodb:DeleteItem, or dynamodb:Scan on the image-resizer role', () => {
       const assertResizerLacks = (action: string) => {
         // CDK consolidates actions into either a string or string[] — assert both forms.
@@ -441,6 +501,36 @@ describe('RecipeStack', () => {
       for (const action of ['dynamodb:PutItem', 'dynamodb:DeleteItem', 'dynamodb:Scan']) {
         assertResizerLacks(action)
       }
+    })
+  })
+
+  describe('IAM — recipe-image-handler role', () => {
+    it('recipe-image-handler Lambda environment includes TABLE_NAME set to the recipes table name', () => {
+      template.hasResourceProperties('AWS::Lambda::Function', Match.objectLike({
+        FunctionName: 'akli-recipe-image-handler',
+        Environment: {
+          Variables: Match.objectLike({
+            TABLE_NAME: { Ref: Match.stringLikeRegexp('^RecipesTable.*') },
+          }),
+        },
+      }))
+    })
+
+    it('grants dynamodb:GetItem on the recipes table ARN (table-level, not GSI)', () => {
+      template.hasResourceProperties('AWS::IAM::Policy', {
+        Roles: Match.arrayWith([
+          { Ref: Match.stringLikeRegexp('^RecipeImageHandlerServiceRole.*') },
+        ]),
+        PolicyDocument: Match.objectLike({
+          Statement: Match.arrayWith([
+            Match.objectLike({
+              Action: 'dynamodb:GetItem',
+              Effect: 'Allow',
+              Resource: { 'Fn::GetAtt': [Match.stringLikeRegexp('^RecipesTable.*'), 'Arn'] },
+            }),
+          ]),
+        }),
+      })
     })
   })
 


### PR DESCRIPTION
Closes #146

## What changed

- **`lib/recipe-stack.ts`** — added a third GSI to the Recipes table: `slug-index`, partitioned on `slug` (String), `KEYS_ONLY` projection. Granted `dynamodb:Query` on the new GSI ARN to the image-resizer Lambda. Granted `dynamodb:GetItem` on the table-level Recipes ARN to the recipe-image-handler Lambda, and added `TABLE_NAME` to its environment.
- **`test/recipe-stack.test.ts`** — six new TDD assertions covering each of the above. Written first, committed separately from the implementation so the TDD progression is visible in git history.

## Why

Foundation for the **Editable Recipe Slugs (Backend)** milestone (PRD: `docs/prds/editable-recipe-slugs.md`). Subsequent issues need:

- The `slug-index` GSI so the image-resizer can resolve `slug → id` in O(1), replacing the existing `Scan`-based `findUniqueSlug` helper, and so `recipe-handler` can do TOCTOU-safe slug uniqueness checks via `Query`.
- `dynamodb:GetItem` + `TABLE_NAME` on the recipe-image-handler so it can look up a recipe's slug to build the upload S3 key (`uploads/recipes/<slug>/...`) — replacing the current UUID-based key shape.

Blocks every other issue in this milestone.

## How to verify

- `pnpm test -- recipe-stack.test.ts` → 54/54 (the 6 new + 48 existing).
- `pnpm test` → 384/384.
- `pnpm lint` → clean.
- `pnpm exec tsc --noEmit` → only the pre-existing, unrelated `Cannot find type definition file for 'sharp'` baseline error; 0 new errors.
- `cdk synth` should show one new GSI on the Recipes table and two new IAM `PolicyStatement`s — no other changes.

## Decisions made

- **Explicit `addToRolePolicy` over `table.grantReadData()`** for both Lambdas. Matches the existing narrow-scoping pattern at `lib/recipe-stack.ts:157` (the resizer's `dynamodb:UpdateItem` grant). Mandated by the issue ACs — `grantReadData` would also grant `Query`/`Scan`/`BatchGetItem` table-wide, which is broader than required.
- **`KEYS_ONLY` projection** on the GSI. Per the PRD: only the recipe `id` is needed to resolve the slug; `KEYS_ONLY` is the cheapest correct option.
- **GSI name `'slug-index'` left as inline literals** (one in the GSI definition, one in the IAM resource ARN). Consistent with the two existing GSIs in this file; drift between the two references is already caught by the test asserting `/index/slug-index$`.

## Out of scope (handled by sibling issues in this milestone)

- Lambda code changes — `lambda/recipe-image-handler.ts` (#149), `lambda/image-resizer.ts` (#150), `lambda/recipe-handler.ts` (#147, #148, #151).