### PR TITLE
Add slug validation + accept slug on POST /recipes/drafts

### DIFF
--- a/lambda/recipe-handler.ts
+++ b/lambda/recipe-handler.ts
@@ -60,16 +60,14 @@ function tagsToArray(tags: unknown): string[] {
   return []
 }
 
-// ── Slug validation (issue #147) ────────────────────────────────────────────
-export const RESERVED_SLUGS = ['new', 'admin', 'drafts', 'images'] as const
+export const RESERVED_SLUGS: readonly string[] = ['new', 'admin', 'drafts', 'images']
 
 const SLUG_REGEX = /^[a-z0-9](?:[a-z0-9-]*[a-z0-9])?$/
 
 export function isValidSlug(slug: string): boolean {
-  if (typeof slug !== 'string') return false
   if (slug.length < 1 || slug.length > 100) return false
   if (!SLUG_REGEX.test(slug)) return false
-  if ((RESERVED_SLUGS as readonly string[]).includes(slug)) return false
+  if (RESERVED_SLUGS.includes(slug)) return false
   return true
 }
 

--- a/lambda/recipe-handler.ts
+++ b/lambda/recipe-handler.ts
@@ -60,42 +60,31 @@ function tagsToArray(tags: unknown): string[] {
   return []
 }
 
-function generateSlug(title: string): string {
-  return title
-    .toLowerCase()
-    .replace(/[^a-z0-9]+/g, '-')
-    .replace(/^-+|-+$/g, '')
-}
-
-async function findUniqueSlug(baseSlug: string): Promise<string> {
-  let candidate = baseSlug
-  let suffix = 2
-
-  while (true) {
-    const result = await docClient.send(
-      new ScanCommand({
-        TableName: TABLE_NAME,
-        FilterExpression: 'slug = :slug',
-        ExpressionAttributeValues: { ':slug': candidate },
-      }),
-    )
-
-    if (!result.Items || result.Items.length === 0) return candidate
-    candidate = `${baseSlug}-${suffix}`
-    suffix += 1
-  }
-}
-
 // ── Slug validation (issue #147) ────────────────────────────────────────────
-// Stubs: deliberately unimplemented so TDD tests fail at runtime, not compile.
-export const RESERVED_SLUGS: readonly string[] = []
+export const RESERVED_SLUGS = ['new', 'admin', 'drafts', 'images'] as const
 
-export function isValidSlug(_slug: string): boolean {
-  throw new Error('isValidSlug not implemented')
+const SLUG_REGEX = /^[a-z0-9](?:[a-z0-9-]*[a-z0-9])?$/
+
+export function isValidSlug(slug: string): boolean {
+  if (typeof slug !== 'string') return false
+  if (slug.length < 1 || slug.length > 100) return false
+  if (!SLUG_REGEX.test(slug)) return false
+  if ((RESERVED_SLUGS as readonly string[]).includes(slug)) return false
+  return true
 }
 
-export async function slugExists(_slug: string, _excludeId?: string): Promise<boolean> {
-  throw new Error('slugExists not implemented')
+export async function slugExists(slug: string, excludeId?: string): Promise<boolean> {
+  const result = await docClient.send(
+    new QueryCommand({
+      TableName: TABLE_NAME,
+      IndexName: 'slug-index',
+      KeyConditionExpression: 'slug = :slug',
+      ExpressionAttributeValues: { ':slug': slug },
+    }),
+  )
+  if (!result.Items || result.Items.length === 0) return false
+  if (excludeId) return result.Items.some((i) => (i as { id: string }).id !== excludeId)
+  return true
 }
 
 function imageStatusOf(item: Record<string, unknown>): Record<string, number> {
@@ -309,11 +298,21 @@ async function handleCreateDraft(event: APIGatewayProxyEventV2): Promise<APIGate
   if (!payload) return json(401, { error: 'Unauthorised' })
   if (!isAdmin(event)) return json(403, { error: 'Forbidden' })
 
-  const input = JSON.parse(event.body ?? '{}') as { title?: string }
-  const title = typeof input.title === 'string' ? input.title : ''
-
+  const input = JSON.parse(event.body ?? '{}') as { slug?: unknown }
   const id = randomUUID()
-  const slug = title.length > 0 ? await findUniqueSlug(generateSlug(title)) : `draft-${id}`
+  const requestedSlug = typeof input.slug === 'string' ? input.slug : undefined
+
+  let slug: string
+  if (requestedSlug !== undefined) {
+    if (!isValidSlug(requestedSlug)) return json(400, { error: 'invalid_slug' })
+    if (await slugExists(requestedSlug)) {
+      return json(409, { error: 'slug_taken', message: `Slug "${requestedSlug}" is already in use.` })
+    }
+    slug = requestedSlug
+  } else {
+    slug = `draft-${id.slice(0, 8)}`
+  }
+
   const ttl = Math.floor(Date.now() / 1000) + DRAFT_TTL_SECONDS
   const now = new Date().toISOString()
 
@@ -322,7 +321,7 @@ async function handleCreateDraft(event: APIGatewayProxyEventV2): Promise<APIGate
     slug,
     status: DRAFT,
     ttl,
-    title,
+    title: '',
     intro: '',
     ingredients: [],
     steps: [],

--- a/lambda/recipe-handler.ts
+++ b/lambda/recipe-handler.ts
@@ -86,6 +86,18 @@ async function findUniqueSlug(baseSlug: string): Promise<string> {
   }
 }
 
+// ── Slug validation (issue #147) ────────────────────────────────────────────
+// Stubs: deliberately unimplemented so TDD tests fail at runtime, not compile.
+export const RESERVED_SLUGS: readonly string[] = []
+
+export function isValidSlug(_slug: string): boolean {
+  throw new Error('isValidSlug not implemented')
+}
+
+export async function slugExists(_slug: string, _excludeId?: string): Promise<boolean> {
+  throw new Error('slugExists not implemented')
+}
+
 function imageStatusOf(item: Record<string, unknown>): Record<string, number> {
   return (item.imageStatus as Record<string, number> | undefined) ?? {}
 }

--- a/test/lambda/recipe-handler.test.ts
+++ b/test/lambda/recipe-handler.test.ts
@@ -11,7 +11,7 @@ process.env.TABLE_NAME = 'test-recipes-table'
 process.env.IMAGE_BUCKET_NAME = 'test-recipe-images-bucket'
 
 // Import handler after mock setup
-import { handler } from '../../lambda/recipe-handler'
+import { handler, isValidSlug, RESERVED_SLUGS } from '../../lambda/recipe-handler'
 
 // Build a fake JWT with the given payload (header.payload.signature)
 function fakeJwt(payload: Record<string, unknown>): string {
@@ -335,6 +335,52 @@ describe('Recipe Lambda handler', () => {
     })
   })
 
+  // ─── isValidSlug helper (issue #147 AC1, AC2) ───────────────────────
+  describe('isValidSlug', () => {
+    it('accepts simple lowercase ASCII slugs', () => {
+      expect(isValidSlug('beans-on-toast')).toBe(true)
+      expect(isValidSlug('a')).toBe(true)
+      expect(isValidSlug('recipe-1')).toBe(true)
+      expect(isValidSlug('123')).toBe(true)
+    })
+
+    it('rejects uppercase letters', () => {
+      expect(isValidSlug('BEANS')).toBe(false)
+      expect(isValidSlug('Beans-On-Toast')).toBe(false)
+    })
+
+    it('rejects whitespace', () => {
+      expect(isValidSlug('  beans  ')).toBe(false)
+      expect(isValidSlug('beans on toast')).toBe(false)
+    })
+
+    it('rejects leading or trailing hyphens', () => {
+      expect(isValidSlug('-beans')).toBe(false)
+      expect(isValidSlug('beans-')).toBe(false)
+      expect(isValidSlug('-beans-')).toBe(false)
+    })
+
+    it('rejects non-ASCII characters and punctuation', () => {
+      expect(isValidSlug('beans!')).toBe(false)
+      expect(isValidSlug('beans/toast')).toBe(false)
+      expect(isValidSlug('café')).toBe(false)
+      expect(isValidSlug('beans_on_toast')).toBe(false)
+    })
+
+    it('rejects empty string and slugs longer than 100 characters', () => {
+      expect(isValidSlug('')).toBe(false)
+      expect(isValidSlug('a'.repeat(100))).toBe(true)
+      expect(isValidSlug('a'.repeat(101))).toBe(false)
+    })
+
+    it('rejects reserved slugs', () => {
+      expect(RESERVED_SLUGS).toEqual(expect.arrayContaining(['new', 'admin', 'drafts', 'images']))
+      for (const reserved of ['new', 'admin', 'drafts', 'images']) {
+        expect(isValidSlug(reserved)).toBe(false)
+      }
+    })
+  })
+
   // ─── POST /recipes/drafts — create draft ────────────────────────────
   describe('POST /recipes/drafts — create draft', () => {
     it('returns 401 without a valid token', async () => {
@@ -368,7 +414,7 @@ describe('Recipe Lambda handler', () => {
     })
 
     it('returns 201 with { id, slug } in the body on success', async () => {
-      ddbMock.on(ScanCommand).resolves({ Items: [] })
+      ddbMock.on(QueryCommand).resolves({ Items: [] })
       ddbMock.on(PutCommand).resolves({})
 
       const event = makeEvent({
@@ -390,7 +436,7 @@ describe('Recipe Lambda handler', () => {
     it('writes status=draft and ttl=now+30d to DynamoDB', async () => {
       jest.useFakeTimers().setSystemTime(new Date('2026-04-19T12:00:00Z'))
       try {
-        ddbMock.on(ScanCommand).resolves({ Items: [] })
+        ddbMock.on(QueryCommand).resolves({ Items: [] })
         ddbMock.on(PutCommand).resolves({})
 
         const event = makeEvent({
@@ -418,7 +464,7 @@ describe('Recipe Lambda handler', () => {
     })
 
     it('initialises imageStatus as an empty map on the new item', async () => {
-      ddbMock.on(ScanCommand).resolves({ Items: [] })
+      ddbMock.on(QueryCommand).resolves({ Items: [] })
       ddbMock.on(PutCommand).resolves({})
 
       const event = makeEvent({
@@ -439,8 +485,9 @@ describe('Recipe Lambda handler', () => {
       expect(item.imageStatus).toEqual({})
     })
 
-    it('defaults slug to draft-<uuid> when no title is provided', async () => {
-      ddbMock.on(ScanCommand).resolves({ Items: [] })
+    // AC4: server-generated default slug shape is `draft-<8 hex chars>`.
+    it('defaults slug to /^draft-[a-z0-9]{8}$/ when no slug is provided', async () => {
+      ddbMock.on(QueryCommand).resolves({ Items: [] })
       ddbMock.on(PutCommand).resolves({})
 
       const event = makeEvent({
@@ -454,25 +501,155 @@ describe('Recipe Lambda handler', () => {
 
       expect(result.statusCode).toBe(201)
       const body = JSON.parse(result.body as string)
-      expect(body.slug).toMatch(/^draft-/)
+      expect(body.slug).toMatch(/^draft-[a-z0-9]{8}$/)
+      // Default slug is derived from id.slice(0, 8) — first 8 chars of the UUID with hyphens stripped or sliced.
+      expect(typeof body.id).toBe('string')
+      expect(body.slug).toBe(`draft-${(body.id as string).slice(0, 8)}`)
     })
 
-    it('derives slug from the title when one is provided', async () => {
-      ddbMock.on(ScanCommand).resolves({ Items: [] })
+    // AC5: caller-supplied slug is echoed back when valid and unused.
+    it('returns 201 with the caller-supplied slug when it is valid and unused', async () => {
+      ddbMock.on(QueryCommand).resolves({ Items: [] })
       ddbMock.on(PutCommand).resolves({})
 
       const event = makeEvent({
         routeKey: 'POST /recipes/drafts',
         rawPath: '/recipes/drafts',
         headers: { authorization: `Bearer ${adminToken}` },
-        body: JSON.stringify({ title: 'My New Recipe' }),
+        body: JSON.stringify({ slug: 'beans-on-toast' }),
       })
 
       const result = await handler(event)
 
       expect(result.statusCode).toBe(201)
       const body = JSON.parse(result.body as string)
-      expect(body.slug).toBe('my-new-recipe')
+      expect(body.slug).toBe('beans-on-toast')
+
+      // Persisted item also has the caller-supplied slug
+      const putCalls = ddbMock.commandCalls(PutCommand)
+      expect(putCalls).toHaveLength(1)
+      const item = putCalls[0].args[0].input.Item as Record<string, unknown>
+      expect(item.slug).toBe('beans-on-toast')
+    })
+
+    // AC3: uniqueness lookup uses the slug-index GSI via QueryCommand (NOT ScanCommand).
+    it('checks slug uniqueness via QueryCommand against IndexName: slug-index', async () => {
+      ddbMock.on(QueryCommand).resolves({ Items: [] })
+      ddbMock.on(PutCommand).resolves({})
+
+      const event = makeEvent({
+        routeKey: 'POST /recipes/drafts',
+        rawPath: '/recipes/drafts',
+        headers: { authorization: `Bearer ${adminToken}` },
+        body: JSON.stringify({ slug: 'beans-on-toast' }),
+      })
+
+      const result = await handler(event)
+
+      expect(result.statusCode).toBe(201)
+
+      const queryCalls = ddbMock.commandCalls(QueryCommand)
+      expect(queryCalls).toHaveLength(1)
+      const input = queryCalls[0].args[0].input
+      expect(input.TableName).toBe('test-recipes-table')
+      expect(input.IndexName).toBe('slug-index')
+      expect(input.KeyConditionExpression).toBe('slug = :slug')
+      expect(input.ExpressionAttributeValues).toEqual({ ':slug': 'beans-on-toast' })
+
+      // Must NOT use a ScanCommand for uniqueness lookup.
+      expect(ddbMock.commandCalls(ScanCommand)).toHaveLength(0)
+    })
+
+    // AC6: lowercase enforcement via regex.
+    it('returns 400 for an uppercase slug', async () => {
+      const event = makeEvent({
+        routeKey: 'POST /recipes/drafts',
+        rawPath: '/recipes/drafts',
+        headers: { authorization: `Bearer ${adminToken}` },
+        body: JSON.stringify({ slug: 'BEANS' }),
+      })
+
+      const result = await handler(event)
+
+      expect(result.statusCode).toBe(400)
+      const body = JSON.parse(result.body as string)
+      expect(body).toHaveProperty('error')
+      // Must not have written the item.
+      expect(ddbMock.commandCalls(PutCommand)).toHaveLength(0)
+    })
+
+    // AC7: whitespace rejected by regex.
+    it('returns 400 for a slug containing whitespace', async () => {
+      const event = makeEvent({
+        routeKey: 'POST /recipes/drafts',
+        rawPath: '/recipes/drafts',
+        headers: { authorization: `Bearer ${adminToken}` },
+        body: JSON.stringify({ slug: '  beans  ' }),
+      })
+
+      const result = await handler(event)
+
+      expect(result.statusCode).toBe(400)
+      const body = JSON.parse(result.body as string)
+      expect(body).toHaveProperty('error')
+      expect(ddbMock.commandCalls(PutCommand)).toHaveLength(0)
+    })
+
+    // AC8: reserved word "admin" rejected.
+    it('returns 400 for the reserved slug "admin"', async () => {
+      const event = makeEvent({
+        routeKey: 'POST /recipes/drafts',
+        rawPath: '/recipes/drafts',
+        headers: { authorization: `Bearer ${adminToken}` },
+        body: JSON.stringify({ slug: 'admin' }),
+      })
+
+      const result = await handler(event)
+
+      expect(result.statusCode).toBe(400)
+      const body = JSON.parse(result.body as string)
+      expect(body).toHaveProperty('error')
+      expect(ddbMock.commandCalls(PutCommand)).toHaveLength(0)
+    })
+
+    // AC9: reserved word "drafts" rejected.
+    it('returns 400 for the reserved slug "drafts"', async () => {
+      const event = makeEvent({
+        routeKey: 'POST /recipes/drafts',
+        rawPath: '/recipes/drafts',
+        headers: { authorization: `Bearer ${adminToken}` },
+        body: JSON.stringify({ slug: 'drafts' }),
+      })
+
+      const result = await handler(event)
+
+      expect(result.statusCode).toBe(400)
+      const body = JSON.parse(result.body as string)
+      expect(body).toHaveProperty('error')
+      expect(ddbMock.commandCalls(PutCommand)).toHaveLength(0)
+    })
+
+    // AC10: collision returns 409 with the exact error body.
+    it('returns 409 slug_taken when the supplied slug is already in use', async () => {
+      ddbMock.on(QueryCommand).resolves({ Items: [{ id: 'some-other-recipe-id' }] })
+
+      const event = makeEvent({
+        routeKey: 'POST /recipes/drafts',
+        rawPath: '/recipes/drafts',
+        headers: { authorization: `Bearer ${adminToken}` },
+        body: JSON.stringify({ slug: 'beans-on-toast' }),
+      })
+
+      const result = await handler(event)
+
+      expect(result.statusCode).toBe(409)
+      const body = JSON.parse(result.body as string)
+      expect(body).toEqual({
+        error: 'slug_taken',
+        message: 'Slug "beans-on-toast" is already in use.',
+      })
+      // Must not persist the colliding draft.
+      expect(ddbMock.commandCalls(PutCommand)).toHaveLength(0)
     })
   })
 


### PR DESCRIPTION
Closes #147

## What changed

- **`lambda/recipe-handler.ts`** — added `isValidSlug` (regex + reserved-word check) and `slugExists` (Query against the new `slug-index` GSI). Replaced `findUniqueSlug` (Scan-based auto-suffix) with a strict-match-or-409 model. Rewrote `handleCreateDraft` so it accepts `{ slug? }` (instead of the old `{ title? }` derivation): unsupplied → `draft-${id.slice(0, 8)}`, supplied + valid + unused → echoed back, supplied + invalid → 400, supplied + taken → 409 with `{ error: 'slug_taken', message: 'Slug "<slug>" is already in use.' }`.
- Removed dead code: `findUniqueSlug` (Scan loop), `generateSlug` (title→slug helper, only used by the old flow).
- **`test/lambda/recipe-handler.test.ts`** — 15 new TDD assertions covering `isValidSlug`, `RESERVED_SLUGS`, the GSI-backed uniqueness check, the new default-slug shape, and every 400/409 branch. Three existing tests switched their mock from `ScanCommand` to `QueryCommand`. Two obsolete tests (title-based slug derivation, auto-suffix collision) deleted.

## Why

Required by the **Editable Recipe Slugs (Backend)** milestone (PRD: `docs/prds/editable-recipe-slugs.md`). The old behaviour silently auto-suffixed conflicting slugs (`spaghetti-bolognese-2`) instead of surfacing them, and made the slug effectively non-user-editable. The new contract gives the user explicit control with clear 409 conflicts. Builds on the `slug-index` GSI added by #146 — replaces the O(table-size) Scan with an O(matches) Query.

## How to verify

- `pnpm test -- recipe-handler.test.ts` → 114/114
- `pnpm test` → 397/397
- `pnpm lint` → clean
- `pnpm exec tsc --noEmit` → only the pre-existing `sharp` baseline error; 0 new
- Manual: `curl -X POST .../recipes/drafts -d '{}'` → `slug` matches `/^draft-[a-z0-9]{8}$/`. With `{"slug":"BEANS"}` → 400. With `{"slug":"beans-on-toast"}` against an existing recipe → 409 `slug_taken` with the templated message.

## Decisions made

- **Slug validation lives in `recipe-handler.ts`** rather than a shared utility. There is no existing util file for Lambda helpers; spinning one up for a single helper would be premature. Issue #148 will reuse `isValidSlug` + `slugExists` for PATCH — at that point the move-to-shared call is easier to make.
- **`slugExists` is exported** so #148 can call it directly with `excludeId` for the same-recipe-PATCH path.
- **`ScanCommand` import preserved** — still used by `handleGetBySlug` (`GET /recipes/{slug}`) and `handleListTags`. Migrating those to the GSI is beyond #147 scope.
- **The `excludeId` branch in `slugExists` is currently unreachable** from `handleCreateDraft` (always called without it). Wired in for #148 / PATCH; the test for the PATCH path will cover it. No `excludeId` test was added in this PR per scope.

## Out of scope (handled by sibling issues)

- PATCH `/recipes/{id}` slug acceptance and TOCTOU `ConditionExpression` — issue #148.
- `handleGetBySlug` Scan → Query migration — flagged by /simplify; not in this issue's ACs.

## Commits

This PR contains three logical stages, kept as separate commits for clarity:

1. `test(recipe-handler): add failing tests for slug validation on draft creation` — TDD failing tests
2. `feat(recipe-handler): accept slug on draft creation with validation` — implementation
3. `refactor(recipe-handler): tighten slug validation helper` — `/simplify` fixes (drop banner comment, drop redundant `typeof` guard, type `RESERVED_SLUGS` as `readonly string[]` to remove cast at call site)