### PR TITLE
PATCH /recipes/{id}: accept slug with TOCTOU-safe ConditionExpression

### DIFF
--- a/lambda/recipe-handler.ts
+++ b/lambda/recipe-handler.ts
@@ -62,6 +62,11 @@ function tagsToArray(tags: unknown): string[] {
 
 export const RESERVED_SLUGS: readonly string[] = ['new', 'admin', 'drafts', 'images']
 
+const SLUG_LOCKED_RESPONSE = {
+  error: 'slug_locked',
+  message: 'Cannot change slug after images have been uploaded. Delete uploaded images first.',
+} as const
+
 const SLUG_REGEX = /^[a-z0-9](?:[a-z0-9-]*[a-z0-9])?$/
 
 export function isValidSlug(slug: string): boolean {
@@ -421,20 +426,14 @@ async function handleUpdateRecipe(event: APIGatewayProxyEventV2): Promise<APIGat
   if (slugChanging) {
     if (!isValidSlug(requestedSlug)) return json(400, { error: 'invalid_slug' })
 
-    const imageStatusMap = (existing.imageStatus as Record<string, unknown> | undefined) ?? {}
-    if (Object.keys(imageStatusMap).length > 0) {
-      return json(409, {
-        error: 'slug_locked',
-        message: 'Cannot change slug after images have been uploaded. Delete uploaded images first.',
-      })
+    if (Object.keys(imageStatusOf(existing)).length > 0) {
+      return json(409, SLUG_LOCKED_RESPONSE)
     }
 
     if (await slugExists(requestedSlug, id)) {
       return json(409, { error: 'slug_taken', message: `Slug "${requestedSlug}" is already in use.` })
     }
-  }
-
-  if (!slugChanging) {
+  } else {
     delete updates.slug
   }
 
@@ -500,12 +499,8 @@ async function handleUpdateRecipe(event: APIGatewayProxyEventV2): Promise<APIGat
   } catch (err) {
     if (err instanceof ConditionalCheckFailedException || (err as { name?: string }).name === 'ConditionalCheckFailedException') {
       const reRead = await getRecipeById(id)
-      const reReadImageStatus = (reRead?.imageStatus as Record<string, unknown> | undefined) ?? {}
-      if (Object.keys(reReadImageStatus).length > 0) {
-        return json(409, {
-          error: 'slug_locked',
-          message: 'Cannot change slug after images have been uploaded. Delete uploaded images first.',
-        })
+      if (reRead && Object.keys(imageStatusOf(reRead)).length > 0) {
+        return json(409, SLUG_LOCKED_RESPONSE)
       }
       return json(409, { error: 'conflict', message: 'Recipe was modified by another request. Please retry.' })
     }

--- a/lambda/recipe-handler.ts
+++ b/lambda/recipe-handler.ts
@@ -1,5 +1,5 @@
 import { randomUUID } from 'node:crypto'
-import { DynamoDBClient } from '@aws-sdk/client-dynamodb'
+import { ConditionalCheckFailedException, DynamoDBClient } from '@aws-sdk/client-dynamodb'
 import { S3Client, ListObjectsV2Command, DeleteObjectsCommand } from '@aws-sdk/client-s3'
 import { DynamoDBDocumentClient, QueryCommand, GetCommand, PutCommand, UpdateCommand, DeleteCommand, ScanCommand } from '@aws-sdk/lib-dynamodb'
 import type { APIGatewayProxyEventV2, APIGatewayProxyStructuredResultV2 } from 'aws-lambda'
@@ -408,13 +408,35 @@ async function handleUpdateRecipe(event: APIGatewayProxyEventV2): Promise<APIGat
   }
 
   const updates = JSON.parse(event.body ?? '{}') as Record<string, unknown>
-  delete updates.slug
   delete updates.id
   delete updates.authorId
   delete updates.createdAt
   delete updates.status
   delete updates.ttl
   stripProcessedAtFromBody(updates)
+
+  const requestedSlug = typeof updates.slug === 'string' ? updates.slug : undefined
+  const slugChanging = requestedSlug !== undefined && requestedSlug !== existing.slug
+
+  if (slugChanging) {
+    if (!isValidSlug(requestedSlug)) return json(400, { error: 'invalid_slug' })
+
+    const imageStatusMap = (existing.imageStatus as Record<string, unknown> | undefined) ?? {}
+    if (Object.keys(imageStatusMap).length > 0) {
+      return json(409, {
+        error: 'slug_locked',
+        message: 'Cannot change slug after images have been uploaded. Delete uploaded images first.',
+      })
+    }
+
+    if (await slugExists(requestedSlug, id)) {
+      return json(409, { error: 'slug_taken', message: `Slug "${requestedSlug}" is already in use.` })
+    }
+  }
+
+  if (!slugChanging) {
+    delete updates.slug
+  }
 
   const now = new Date().toISOString()
   const setParts: string[] = []
@@ -453,16 +475,42 @@ async function handleUpdateRecipe(event: APIGatewayProxyEventV2): Promise<APIGat
     ? `SET ${setParts.join(', ')} REMOVE ${removeParts.join(', ')}`
     : `SET ${setParts.join(', ')}`
 
-  const updateResult = await docClient.send(
-    new UpdateCommand({
-      TableName: TABLE_NAME,
-      Key: { id },
-      UpdateExpression: updateExpression,
-      ExpressionAttributeNames: expressionNames,
-      ExpressionAttributeValues: expressionValues,
-      ReturnValues: 'ALL_OLD',
-    }),
-  )
+  const conditionExpression = slugChanging
+    ? 'attribute_exists(id) AND (attribute_not_exists(imageStatus) OR size(imageStatus) = :zero) AND slug = :expectedOldSlug'
+    : undefined
+
+  if (slugChanging) {
+    expressionValues[':zero'] = 0
+    expressionValues[':expectedOldSlug'] = existing.slug
+  }
+
+  let updateResult
+  try {
+    updateResult = await docClient.send(
+      new UpdateCommand({
+        TableName: TABLE_NAME,
+        Key: { id },
+        UpdateExpression: updateExpression,
+        ExpressionAttributeNames: expressionNames,
+        ExpressionAttributeValues: expressionValues,
+        ConditionExpression: conditionExpression,
+        ReturnValues: 'ALL_OLD',
+      }),
+    )
+  } catch (err) {
+    if (err instanceof ConditionalCheckFailedException || (err as { name?: string }).name === 'ConditionalCheckFailedException') {
+      const reRead = await getRecipeById(id)
+      const reReadImageStatus = (reRead?.imageStatus as Record<string, unknown> | undefined) ?? {}
+      if (Object.keys(reReadImageStatus).length > 0) {
+        return json(409, {
+          error: 'slug_locked',
+          message: 'Cannot change slug after images have been uploaded. Delete uploaded images first.',
+        })
+      }
+      return json(409, { error: 'conflict', message: 'Recipe was modified by another request. Please retry.' })
+    }
+    throw err
+  }
 
   const atomicOld = updateResult.Attributes as Record<string, unknown>
 

--- a/test/lambda/recipe-handler.test.ts
+++ b/test/lambda/recipe-handler.test.ts
@@ -1,3 +1,4 @@
+import { ConditionalCheckFailedException } from '@aws-sdk/client-dynamodb'
 import { S3Client, ListObjectsV2Command, DeleteObjectsCommand } from '@aws-sdk/client-s3'
 import { DynamoDBDocumentClient, QueryCommand, GetCommand, PutCommand, UpdateCommand, DeleteCommand, ScanCommand } from '@aws-sdk/lib-dynamodb'
 import type { APIGatewayProxyEventV2 } from 'aws-lambda'
@@ -1429,6 +1430,311 @@ describe('Recipe Lambda handler', () => {
       // The user-supplied ttl value must not be present
       expect((input.ExpressionAttributeNames as Record<string, string>)['#ttl']).toBeUndefined()
       expect((input.ExpressionAttributeValues as Record<string, unknown>)[':ttl']).toBe(undefined)
+    })
+  })
+
+  // ─── PATCH /recipes/{id} — slug acceptance and lock ─────────────────
+  describe('PATCH /recipes/{id} — slug acceptance and lock', () => {
+    it('returns 200 and updates the slug when imageStatus is empty and the new slug is unique', async () => {
+      const oldItem = publishedRecipeItem({
+        id: 'recipe-uuid-1',
+        slug: 'old-slug',
+        authorId: 'contributor-user-id',
+        imageStatus: {},
+      })
+      ddbMock.on(GetCommand).resolves({ Item: oldItem })
+      ddbMock.on(QueryCommand).resolves({ Items: [] })
+      // Mock returns the OLD item — so the new slug only ends up in the response if the
+      // handler actually puts it into `updates` (rather than stripping it).
+      ddbMock.on(UpdateCommand).resolves({ Attributes: oldItem })
+
+      const event = makeEvent({
+        routeKey: 'PATCH /recipes/{id}',
+        rawPath: '/recipes/recipe-uuid-1',
+        pathParameters: { id: 'recipe-uuid-1' },
+        headers: { authorization: `Bearer ${contributorToken}` },
+        body: JSON.stringify({ slug: 'new-slug' }),
+      })
+
+      const result = await handler(event)
+
+      expect(result.statusCode).toBe(200)
+      const body = JSON.parse(result.body as string)
+      expect(body.slug).toBe('new-slug')
+
+      // The UpdateCommand should be invoked exactly once and must actually carry the new slug.
+      const updateCalls = ddbMock.commandCalls(UpdateCommand)
+      expect(updateCalls).toHaveLength(1)
+      const values = updateCalls[0].args[0].input.ExpressionAttributeValues as Record<string, unknown>
+      expect(values[':slug']).toBe('new-slug')
+    })
+
+    it('returns 409 slug_locked when imageStatus has at least one entry', async () => {
+      const oldItem = publishedRecipeItem({
+        id: 'recipe-uuid-1',
+        slug: 'old-slug',
+        authorId: 'contributor-user-id',
+        imageStatus: { 'recipes/old-slug/cover': 1_745_000_000_000 },
+      })
+      ddbMock.on(GetCommand).resolves({ Item: oldItem })
+
+      const event = makeEvent({
+        routeKey: 'PATCH /recipes/{id}',
+        rawPath: '/recipes/recipe-uuid-1',
+        pathParameters: { id: 'recipe-uuid-1' },
+        headers: { authorization: `Bearer ${contributorToken}` },
+        body: JSON.stringify({ slug: 'new-slug' }),
+      })
+
+      const result = await handler(event)
+
+      expect(result.statusCode).toBe(409)
+      const body = JSON.parse(result.body as string)
+      expect(body).toEqual({
+        error: 'slug_locked',
+        message: 'Cannot change slug after images have been uploaded. Delete uploaded images first.',
+      })
+
+      // In-memory check fails first — no UpdateCommand should be issued.
+      expect(ddbMock.commandCalls(UpdateCommand)).toHaveLength(0)
+    })
+
+    it('returns 400 when the supplied slug is invalid', async () => {
+      const oldItem = publishedRecipeItem({
+        id: 'recipe-uuid-1',
+        slug: 'old-slug',
+        authorId: 'contributor-user-id',
+        imageStatus: {},
+      })
+      ddbMock.on(GetCommand).resolves({ Item: oldItem })
+
+      const event = makeEvent({
+        routeKey: 'PATCH /recipes/{id}',
+        rawPath: '/recipes/recipe-uuid-1',
+        pathParameters: { id: 'recipe-uuid-1' },
+        headers: { authorization: `Bearer ${contributorToken}` },
+        body: JSON.stringify({ slug: 'INVALID' }),
+      })
+
+      const result = await handler(event)
+
+      expect(result.statusCode).toBe(400)
+      // Validation must happen before any write.
+      expect(ddbMock.commandCalls(UpdateCommand)).toHaveLength(0)
+    })
+
+    it('returns 409 slug_taken when the new slug is already in use by another recipe', async () => {
+      const oldItem = publishedRecipeItem({
+        id: 'recipe-uuid-1',
+        slug: 'old-slug',
+        authorId: 'contributor-user-id',
+        imageStatus: {},
+      })
+      ddbMock.on(GetCommand).resolves({ Item: oldItem })
+      // Slug-index returns a different recipe owning the desired slug.
+      ddbMock.on(QueryCommand).resolves({ Items: [{ id: 'some-other-recipe-id' }] })
+
+      const event = makeEvent({
+        routeKey: 'PATCH /recipes/{id}',
+        rawPath: '/recipes/recipe-uuid-1',
+        pathParameters: { id: 'recipe-uuid-1' },
+        headers: { authorization: `Bearer ${contributorToken}` },
+        body: JSON.stringify({ slug: 'taken-slug' }),
+      })
+
+      const result = await handler(event)
+
+      expect(result.statusCode).toBe(409)
+      const body = JSON.parse(result.body as string)
+      expect(body).toEqual({
+        error: 'slug_taken',
+        message: 'Slug "taken-slug" is already in use.',
+      })
+      expect(ddbMock.commandCalls(UpdateCommand)).toHaveLength(0)
+    })
+
+    it('returns 200 when the slug-index returns the recipe being patched (excludeId ignores self)', async () => {
+      const oldItem = publishedRecipeItem({
+        id: 'recipe-uuid-1',
+        slug: 'old-slug',
+        authorId: 'contributor-user-id',
+        imageStatus: {},
+      })
+      ddbMock.on(GetCommand).resolves({ Item: oldItem })
+      // Slug-index returns ONLY the recipe being patched — must not be treated as a collision.
+      ddbMock.on(QueryCommand).resolves({ Items: [{ id: 'recipe-uuid-1' }] })
+      ddbMock.on(UpdateCommand).resolves({ Attributes: oldItem })
+
+      const event = makeEvent({
+        routeKey: 'PATCH /recipes/{id}',
+        rawPath: '/recipes/recipe-uuid-1',
+        pathParameters: { id: 'recipe-uuid-1' },
+        headers: { authorization: `Bearer ${contributorToken}` },
+        body: JSON.stringify({ slug: 'new-slug' }),
+      })
+
+      const result = await handler(event)
+
+      expect(result.statusCode).toBe(200)
+      // The handler must have queried the slug-index (proving slugExists ran with excludeId).
+      const queryCalls = ddbMock.commandCalls(QueryCommand)
+      expect(queryCalls.length).toBeGreaterThanOrEqual(1)
+      const slugQuery = queryCalls.find((c) => c.args[0].input.IndexName === 'slug-index')
+      expect(slugQuery).toBeDefined()
+
+      const updateCalls = ddbMock.commandCalls(UpdateCommand)
+      expect(updateCalls).toHaveLength(1)
+      const values = updateCalls[0].args[0].input.ExpressionAttributeValues as Record<string, unknown>
+      expect(values[':slug']).toBe('new-slug')
+    })
+
+    it('UpdateCommand for a slug-changing PATCH includes a TOCTOU ConditionExpression with all three clauses', async () => {
+      const oldItem = publishedRecipeItem({
+        id: 'recipe-uuid-1',
+        slug: 'old-slug',
+        authorId: 'contributor-user-id',
+        imageStatus: {},
+      })
+      ddbMock.on(GetCommand).resolves({ Item: oldItem })
+      ddbMock.on(QueryCommand).resolves({ Items: [] })
+      ddbMock.on(UpdateCommand).resolves({
+        Attributes: { ...oldItem, slug: 'new-slug' },
+      })
+
+      const event = makeEvent({
+        routeKey: 'PATCH /recipes/{id}',
+        rawPath: '/recipes/recipe-uuid-1',
+        pathParameters: { id: 'recipe-uuid-1' },
+        headers: { authorization: `Bearer ${contributorToken}` },
+        body: JSON.stringify({ slug: 'new-slug' }),
+      })
+
+      const result = await handler(event)
+
+      expect(result.statusCode).toBe(200)
+
+      const updateCalls = ddbMock.commandCalls(UpdateCommand)
+      expect(updateCalls).toHaveLength(1)
+      const input = updateCalls[0].args[0].input
+      const condition = input.ConditionExpression
+      expect(typeof condition).toBe('string')
+      // attribute_exists(id) clause
+      expect(condition).toMatch(/attribute_exists\s*\(\s*id\s*\)/)
+      // imageStatus-empty clause: attribute_not_exists OR size = :zero
+      expect(condition).toMatch(/attribute_not_exists\s*\(\s*imageStatus\s*\)\s+OR\s+size\s*\(\s*imageStatus\s*\)\s*=\s*:zero/)
+      // expected old slug clause (PRD specifies :expectedOldSlug, but accept :oldSlug for flexibility).
+      expect(condition).toMatch(/slug\s*=\s*:(?:expectedOldSlug|oldSlug)/)
+
+      const values = input.ExpressionAttributeValues as Record<string, unknown>
+      expect(values[':zero']).toBe(0)
+      // The expected-old-slug binding must be present and match the existing slug.
+      const expectedOldSlugValue = values[':expectedOldSlug'] ?? values[':oldSlug']
+      expect(expectedOldSlugValue).toBe('old-slug')
+    })
+
+    it('maps ConditionalCheckFailedException to 409 slug_locked when re-read shows imageStatus has been populated', async () => {
+      const oldItem = publishedRecipeItem({
+        id: 'recipe-uuid-1',
+        slug: 'old-slug',
+        authorId: 'contributor-user-id',
+        imageStatus: {},
+      })
+      const reReadItem = {
+        ...oldItem,
+        imageStatus: { 'recipes/old-slug/cover': 1_745_000_000_000 },
+      }
+      // First Get is the pre-read; second Get is the re-read after the conditional failure.
+      ddbMock
+        .on(GetCommand)
+        .resolvesOnce({ Item: oldItem })
+        .resolvesOnce({ Item: reReadItem })
+      ddbMock.on(QueryCommand).resolves({ Items: [] })
+      ddbMock.on(UpdateCommand).rejects(
+        new ConditionalCheckFailedException({
+          $metadata: {},
+          message: 'The conditional request failed',
+        }),
+      )
+
+      const event = makeEvent({
+        routeKey: 'PATCH /recipes/{id}',
+        rawPath: '/recipes/recipe-uuid-1',
+        pathParameters: { id: 'recipe-uuid-1' },
+        headers: { authorization: `Bearer ${contributorToken}` },
+        body: JSON.stringify({ slug: 'new-slug' }),
+      })
+
+      const result = await handler(event)
+
+      expect(result.statusCode).toBe(409)
+      const body = JSON.parse(result.body as string)
+      expect(body.error).toBe('slug_locked')
+    })
+
+    it('maps ConditionalCheckFailedException to 409 conflict when re-read shows the slug changed underneath', async () => {
+      const oldItem = publishedRecipeItem({
+        id: 'recipe-uuid-1',
+        slug: 'old-slug',
+        authorId: 'contributor-user-id',
+        imageStatus: {},
+      })
+      const reReadItem = {
+        ...oldItem,
+        slug: 'someone-else-changed-it',
+        imageStatus: {},
+      }
+      ddbMock
+        .on(GetCommand)
+        .resolvesOnce({ Item: oldItem })
+        .resolvesOnce({ Item: reReadItem })
+      ddbMock.on(QueryCommand).resolves({ Items: [] })
+      ddbMock.on(UpdateCommand).rejects(
+        new ConditionalCheckFailedException({
+          $metadata: {},
+          message: 'The conditional request failed',
+        }),
+      )
+
+      const event = makeEvent({
+        routeKey: 'PATCH /recipes/{id}',
+        rawPath: '/recipes/recipe-uuid-1',
+        pathParameters: { id: 'recipe-uuid-1' },
+        headers: { authorization: `Bearer ${contributorToken}` },
+        body: JSON.stringify({ slug: 'new-slug' }),
+      })
+
+      const result = await handler(event)
+
+      expect(result.statusCode).toBe(409)
+      const body = JSON.parse(result.body as string)
+      expect(body.error).toBe('conflict')
+    })
+
+    it('does NOT add a ConditionExpression when slug is omitted from the patch body', async () => {
+      const oldItem = publishedRecipeItem({
+        id: 'recipe-uuid-1',
+        slug: 'old-slug',
+        authorId: 'contributor-user-id',
+        imageStatus: { 'recipes/old-slug/cover': 1_745_000_000_000 },
+      })
+      ddbMock.on(GetCommand).resolves({ Item: oldItem })
+      ddbMock.on(UpdateCommand).resolves({ Attributes: oldItem })
+
+      const event = makeEvent({
+        routeKey: 'PATCH /recipes/{id}',
+        rawPath: '/recipes/recipe-uuid-1',
+        pathParameters: { id: 'recipe-uuid-1' },
+        headers: { authorization: `Bearer ${contributorToken}` },
+        body: JSON.stringify({ title: 'Just a title change' }),
+      })
+
+      const result = await handler(event)
+
+      expect(result.statusCode).toBe(200)
+
+      const updateCalls = ddbMock.commandCalls(UpdateCommand)
+      expect(updateCalls).toHaveLength(1)
+      expect(updateCalls[0].args[0].input.ConditionExpression).toBeUndefined()
     })
   })
 


### PR DESCRIPTION
Closes #148

## What changed

- **`lambda/recipe-handler.ts`** — `handleUpdateRecipe` now accepts an optional `slug` field on PATCH:
  - Validation symmetry with POST: `isValidSlug` → 400 `invalid_slug`.
  - Lock-on-image rule: if `existing.imageStatus` has any entry → 409 `slug_locked` with the PRD-specified message (in-memory check; no UpdateCommand fired).
  - Uniqueness check via `slugExists(newSlug, id)` so a same-slug PATCH ignores itself in the GSI → 409 `slug_taken` with the same message format as POST.
  - Same-value PATCH (`slug === existing.slug`) is a true no-op: skips validation, lock check, uniqueness check, AND drops `slug` from the UpdateCommand entirely.
  - **TOCTOU-safe `ConditionExpression`** added to the `UpdateCommand` — but only when slug is changing. Gates on `attribute_exists(id) AND (attribute_not_exists(imageStatus) OR size(imageStatus) = :zero) AND slug = :expectedOldSlug`. Non-slug PATCHes are unchanged (no ConditionExpression added).
  - `ConditionalCheckFailedException` handler: re-reads via `getRecipeById(id)` and maps to 409 `slug_locked` (imageStatus populated since the read) or 409 `conflict` (slug changed underneath).
- **`test/lambda/recipe-handler.test.ts`** — 9 new TDD assertions covering each AC. The non-slug-PATCH characterisation test pins the existing behaviour (no ConditionExpression added) and continues passing post-implementation.

## Why

Required by the **Editable Recipe Slugs (Backend)** milestone. Without a server-side lock, two concurrent PATCHes could both observe an empty `imageStatus` in memory and race to set different slugs — leaving image keys orphaned under the original slug. The DynamoDB `ConditionExpression` makes the check atomic against the actual stored item; the in-memory check stays as a fast-fail before issuing the write.

Builds on:
- #146 — `slug-index` GSI (used by `slugExists` to check uniqueness).
- #147 — `isValidSlug` and `slugExists` helpers (now reused here, with `excludeId` exercised for the first time in production code).

## How to verify

- `pnpm test -- recipe-handler.test.ts` → 123/123
- `pnpm test` → 406/406
- `pnpm lint` → clean
- `pnpm exec tsc --noEmit` → only the pre-existing `sharp` baseline error; 0 new
- Manual: PATCH with `{"slug":"new-slug"}` on a recipe with `imageStatus: {}` → 200; on a recipe with any imageStatus entry → 409 `slug_locked`. PATCH with `{"slug":"BEANS"}` → 400. PATCH with another recipe's slug → 409 `slug_taken`. PATCH with the recipe's own slug → 200 (no-op).

## Decisions made

- **Same-value slug PATCH skips both checks AND skips writing slug** — a strict no-op. Otherwise we'd add a redundant `ConditionExpression` (and a redundant GSI Query) for a write that doesn't change the slug.
- **`ConditionExpression` is only added when the slug is changing.** Non-slug PATCHes preserve the pre-PR shape exactly — `ConditionExpression: undefined` makes the SDK omit the field. This is asserted by AC9.
- **In-memory `imageStatus`-empty check is kept** despite the `ConditionExpression` providing the same guarantee. It saves a round-trip to DynamoDB on the common-case lock violation; the conditional write covers the rare race-loss case.
- **`ConditionalCheckFailedException` handling uses `instanceof` + `.name` fallback.** The dual check is defensive against `aws-sdk-client-mock` not always preserving the exception prototype across mock instantiations. Production runs always hit the `instanceof` branch.

## Out of scope (handled by sibling issues / follow-up)

- **`ReturnValuesOnConditionCheckFailure: 'ALL_OLD'`** — flagged by /simplify as a real efficiency win: it would let the catch block read the current item from `err.Item` instead of issuing a follow-up `getRecipeById`. Skipped in this PR because it would require updating the AC7/AC8 tests (they currently mock a separate re-read). Worth a small follow-up issue once the milestone lands.
- Image-handler / resizer Lambda code — issues #149, #150.
- `composeImageProcessedAt` / step `stepId` validation rework — issue #151.

## Commits

Three logical stages:

1. `test(recipe-handler): add failing tests for PATCH slug acceptance with toctou guard` — TDD failing tests (9 cases)
2. `feat(recipe-handler): accept slug on PATCH with toctou-safe condition and lock` — implementation
3. `refactor(recipe-handler): reuse imageStatusOf and extract slug_locked response` — `/simplify` fixes (use existing `imageStatusOf` helper, extract duplicated `slug_locked` body to `SLUG_LOCKED_RESPONSE` const, fold the polarity-flipped `if (!slugChanging)` block into an `else`)