### PR TITLE
Recipe-image-handler: build upload key from looked-up slug, drop key from response

### DIFF
--- a/lambda/recipe-image-handler.ts
+++ b/lambda/recipe-image-handler.ts
@@ -1,10 +1,17 @@
+import { DynamoDBClient } from '@aws-sdk/client-dynamodb'
 import { S3Client, PutObjectCommand } from '@aws-sdk/client-s3'
+import { DynamoDBDocumentClient, GetCommand } from '@aws-sdk/lib-dynamodb'
 import { getSignedUrl } from '@aws-sdk/s3-request-presigner'
 import type { APIGatewayProxyEventV2, APIGatewayProxyStructuredResultV2 } from 'aws-lambda'
-import { UPLOAD_PREFIX, toProcessedKey } from './image-variants'
+import { UPLOAD_PREFIX } from './image-variants'
 
 const s3 = new S3Client({})
+const ddbClient = new DynamoDBClient({})
+const docClient = DynamoDBDocumentClient.from(ddbClient)
 const IMAGE_BUCKET_NAME = process.env.IMAGE_BUCKET_NAME ?? ''
+const TABLE_NAME = process.env.TABLE_NAME ?? ''
+
+const UUID_REGEX = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i
 
 function json(statusCode: number, body: Record<string, unknown>): APIGatewayProxyStructuredResultV2 {
   return { statusCode, headers: { 'Content-Type': 'application/json' }, body: JSON.stringify(body) }
@@ -29,7 +36,11 @@ function decodeToken(event: APIGatewayProxyEventV2): Record<string, unknown> | u
 interface UploadUrlBody {
   readonly recipeId?: string
   readonly imageType?: string
-  readonly stepOrder?: number
+  readonly stepId?: string
+}
+
+interface RecipeStep {
+  readonly stepId?: string
 }
 
 export async function handler(event: APIGatewayProxyEventV2): Promise<APIGatewayProxyStructuredResultV2> {
@@ -49,13 +60,28 @@ async function handleUploadUrl(event: APIGatewayProxyEventV2): Promise<APIGatewa
   const payload = decodeToken(event)
   if (!payload) return json(401, { error: 'Unauthorised' })
 
-  const { recipeId, imageType, stepOrder } = JSON.parse(event.body ?? '{}') as UploadUrlBody
+  const { recipeId, imageType, stepId } = JSON.parse(event.body ?? '{}') as UploadUrlBody
   if (!recipeId || !imageType) return json(400, { error: 'recipeId and imageType are required' })
-  if (imageType !== 'cover' && !stepOrder) return json(400, { error: 'stepOrder is required for step images' })
 
-  const uploadKey = imageType === 'cover'
-    ? `${UPLOAD_PREFIX}${recipeId}/cover`
-    : `${UPLOAD_PREFIX}${recipeId}/step-${stepOrder}`
+  // Step uploads must validate stepId BEFORE issuing the GetItem — saves a DDB read on a clearly-bad request.
+  if (imageType !== 'cover') {
+    if (!stepId) return json(400, { error: 'stepId is required for step images' })
+    if (!UUID_REGEX.test(stepId)) return json(400, { error: 'invalid_stepId' })
+  }
+
+  const recipe = await docClient.send(new GetCommand({ TableName: TABLE_NAME, Key: { id: recipeId } }))
+  if (!recipe.Item) return json(404, { error: 'Recipe not found' })
+
+  const slug = recipe.Item.slug as string
+
+  let uploadKey: string
+  if (imageType === 'cover') {
+    uploadKey = `${UPLOAD_PREFIX}${slug}/cover`
+  } else {
+    const steps = (recipe.Item.steps as RecipeStep[] | undefined) ?? []
+    if (!steps.some((s) => s.stepId === stepId)) return json(404, { error: 'step_not_found' })
+    uploadKey = `${UPLOAD_PREFIX}${slug}/step-${stepId}`
+  }
 
   const uploadUrl = await getSignedUrl(
     s3,
@@ -63,10 +89,5 @@ async function handleUploadUrl(event: APIGatewayProxyEventV2): Promise<APIGatewa
     { expiresIn: 900 },
   )
 
-  // `key` is where the resizer writes variants (the caller stores this and
-  // constructs image URLs like `/images/<key>-<variant>.webp`). The presigned
-  // URL still targets the raw uploads prefix that triggers the resizer.
-  const key = toProcessedKey(uploadKey)
-
-  return json(200, { uploadUrl, key })
+  return json(200, { uploadUrl })
 }

--- a/test/lambda/recipe-image-handler.test.ts
+++ b/test/lambda/recipe-image-handler.test.ts
@@ -1,4 +1,6 @@
 import { S3Client } from '@aws-sdk/client-s3'
+import type { PutObjectCommand } from '@aws-sdk/client-s3'
+import { DynamoDBDocumentClient, GetCommand } from '@aws-sdk/lib-dynamodb'
 import { getSignedUrl } from '@aws-sdk/s3-request-presigner'
 import type { APIGatewayProxyEventV2 } from 'aws-lambda'
 import { mockClient } from 'aws-sdk-client-mock'
@@ -9,8 +11,10 @@ jest.mock('@aws-sdk/s3-request-presigner', () => ({
 }))
 
 const s3Mock = mockClient(S3Client)
+const ddbMock = mockClient(DynamoDBDocumentClient)
 
 process.env.IMAGE_BUCKET_NAME = 'test-recipe-images-bucket'
+process.env.TABLE_NAME = 'test-recipes-table'
 
 import { handler } from '../../lambda/recipe-image-handler'
 
@@ -23,6 +27,24 @@ function fakeJwt(payload: Record<string, unknown>): string {
 }
 
 const contributorToken = fakeJwt({ 'cognito:groups': ['contributor'], sub: 'contributor-user-id', email: 'contributor@example.com', name: 'Test Contributor' })
+
+const RECIPE_ID = 'recipe-uuid-1'
+const RECIPE_SLUG = 'beans-on-toast'
+const STEP_ID_A = '9d904a59-e83f-43b8-9f40-fbdb3008974c'
+const STEP_ID_B = 'b51ad2e3-2c3e-4b6e-9d3a-1f8e8b2a7c11'
+const STEP_ID_NOT_IN_RECIPE = 'cccccccc-cccc-4ccc-bccc-cccccccccccc'
+
+function recipeItem(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    id: RECIPE_ID,
+    slug: RECIPE_SLUG,
+    steps: [
+      { stepId: STEP_ID_A, order: 1, text: 'Toast the bread.' },
+      { stepId: STEP_ID_B, order: 2, text: 'Heat the beans.' },
+    ],
+    ...overrides,
+  }
+}
 
 function makeEvent(overrides: Partial<APIGatewayProxyEventV2> = {}): APIGatewayProxyEventV2 {
   return {
@@ -54,19 +76,28 @@ function makeEvent(overrides: Partial<APIGatewayProxyEventV2> = {}): APIGatewayP
   } as APIGatewayProxyEventV2
 }
 
+function lastPresignedKey(): string | undefined {
+  const calls = (getSignedUrl as jest.Mock).mock.calls
+  if (calls.length === 0) return undefined
+  const command = calls[calls.length - 1][1] as PutObjectCommand
+  return command.input.Key
+}
+
 describe('Recipe Image handler', () => {
   beforeEach(() => {
     s3Mock.reset()
+    ddbMock.reset()
     ;(getSignedUrl as jest.Mock).mockClear()
     ;(getSignedUrl as jest.Mock).mockResolvedValue('https://mock-presigned-url.s3.amazonaws.com/test')
   })
 
-  // ─── POST /recipes/images/upload-url — presigned URL generation ────
-  describe('POST /recipes/images/upload-url — presigned URL generation', () => {
-    it('returns 200 with uploadUrl and key', async () => {
+  // ─── POST /recipes/images/upload-url — response shape ───────────────
+  describe('POST /recipes/images/upload-url — response shape', () => {
+    it('returns 200 with uploadUrl and no key field', async () => {
+      ddbMock.on(GetCommand).resolves({ Item: recipeItem() })
       const event = makeEvent({
         headers: { authorization: `Bearer ${contributorToken}` },
-        body: JSON.stringify({ recipeId: 'abc', imageType: 'cover' }),
+        body: JSON.stringify({ recipeId: RECIPE_ID, imageType: 'cover' }),
       })
 
       const result = await handler(event)
@@ -74,40 +105,139 @@ describe('Recipe Image handler', () => {
       expect(result.statusCode).toBe(200)
       const body = JSON.parse(result.body as string)
       expect(typeof body.uploadUrl).toBe('string')
-      expect(typeof body.key).toBe('string')
-      expect(body.key).toMatch(/^recipes\/[^/]+\//)
+      expect(body).not.toHaveProperty('key')
     })
+  })
 
-    it('generates correct S3 key for cover image', async () => {
+  // ─── POST /recipes/images/upload-url — cover image ──────────────────
+  describe('POST /recipes/images/upload-url — cover image', () => {
+    it('builds the presigned key as uploads/recipes/<slug>/cover using the slug from the recipe item', async () => {
+      ddbMock.on(GetCommand).resolves({ Item: recipeItem() })
       const event = makeEvent({
         headers: { authorization: `Bearer ${contributorToken}` },
-        body: JSON.stringify({ recipeId: 'abc', imageType: 'cover' }),
+        body: JSON.stringify({ recipeId: RECIPE_ID, imageType: 'cover' }),
       })
 
       const result = await handler(event)
 
       expect(result.statusCode).toBe(200)
-      const body = JSON.parse(result.body as string)
-      expect(body.key).toBe('recipes/abc/cover')
+      expect(lastPresignedKey()).toBe(`uploads/recipes/${RECIPE_SLUG}/cover`)
     })
 
-    it('generates correct S3 key for step image', async () => {
+    it('ignores a stray stepId on a cover request (no 400) and still produces the cover key', async () => {
+      ddbMock.on(GetCommand).resolves({ Item: recipeItem() })
       const event = makeEvent({
         headers: { authorization: `Bearer ${contributorToken}` },
-        body: JSON.stringify({ recipeId: 'abc', imageType: 'step', stepOrder: 3 }),
+        body: JSON.stringify({ recipeId: RECIPE_ID, imageType: 'cover', stepId: STEP_ID_A }),
       })
 
       const result = await handler(event)
 
       expect(result.statusCode).toBe(200)
-      const body = JSON.parse(result.body as string)
-      expect(body.key).toBe('recipes/abc/step-3')
+      expect(lastPresignedKey()).toBe(`uploads/recipes/${RECIPE_SLUG}/cover`)
+    })
+  })
+
+  // ─── POST /recipes/images/upload-url — step image ───────────────────
+  describe('POST /recipes/images/upload-url — step image', () => {
+    it('builds the presigned key as uploads/recipes/<slug>/step-<stepId> using the slug from the recipe item', async () => {
+      ddbMock.on(GetCommand).resolves({ Item: recipeItem() })
+      const event = makeEvent({
+        headers: { authorization: `Bearer ${contributorToken}` },
+        body: JSON.stringify({ recipeId: RECIPE_ID, imageType: 'step', stepId: STEP_ID_A }),
+      })
+
+      const result = await handler(event)
+
+      expect(result.statusCode).toBe(200)
+      expect(lastPresignedKey()).toBe(`uploads/recipes/${RECIPE_SLUG}/step-${STEP_ID_A}`)
     })
 
+    it('returns 400 when a step upload arrives without a stepId', async () => {
+      ddbMock.on(GetCommand).resolves({ Item: recipeItem() })
+      const event = makeEvent({
+        headers: { authorization: `Bearer ${contributorToken}` },
+        body: JSON.stringify({ recipeId: RECIPE_ID, imageType: 'step' }),
+      })
+
+      const result = await handler(event)
+
+      expect(result.statusCode).toBe(400)
+      const body = JSON.parse(result.body as string)
+      expect(body).toHaveProperty('error')
+    })
+
+    it.each([
+      ['not-a-uuid'],
+      ['abc'],
+      ['12345'],
+      ['00000000-0000-0000-0000-000000000000'], // valid format-ish but not v1-5 (version nibble 0)
+    ])('returns 400 when stepId %s is not a valid UUID', async (badStepId) => {
+      ddbMock.on(GetCommand).resolves({ Item: recipeItem() })
+      const event = makeEvent({
+        headers: { authorization: `Bearer ${contributorToken}` },
+        body: JSON.stringify({ recipeId: RECIPE_ID, imageType: 'step', stepId: badStepId }),
+      })
+
+      const result = await handler(event)
+
+      expect(result.statusCode).toBe(400)
+      const body = JSON.parse(result.body as string)
+      expect(body).toHaveProperty('error')
+    })
+
+    it("returns 404 when stepId is a valid UUID but doesn't appear in the recipe's steps", async () => {
+      ddbMock.on(GetCommand).resolves({ Item: recipeItem() })
+      const event = makeEvent({
+        headers: { authorization: `Bearer ${contributorToken}` },
+        body: JSON.stringify({ recipeId: RECIPE_ID, imageType: 'step', stepId: STEP_ID_NOT_IN_RECIPE }),
+      })
+
+      const result = await handler(event)
+
+      expect(result.statusCode).toBe(404)
+      const body = JSON.parse(result.body as string)
+      expect(body).toHaveProperty('error')
+    })
+  })
+
+  // ─── POST /recipes/images/upload-url — recipe not found ─────────────
+  describe('POST /recipes/images/upload-url — recipe not found', () => {
+    it('returns 404 for a cover upload when GetItem returns no Item', async () => {
+      ddbMock.on(GetCommand).resolves({})
+      const event = makeEvent({
+        headers: { authorization: `Bearer ${contributorToken}` },
+        body: JSON.stringify({ recipeId: 'nonexistent-id', imageType: 'cover' }),
+      })
+
+      const result = await handler(event)
+
+      expect(result.statusCode).toBe(404)
+      const body = JSON.parse(result.body as string)
+      expect(body).toHaveProperty('error')
+    })
+
+    it('returns 404 for a step upload when GetItem returns no Item', async () => {
+      ddbMock.on(GetCommand).resolves({})
+      const event = makeEvent({
+        headers: { authorization: `Bearer ${contributorToken}` },
+        body: JSON.stringify({ recipeId: 'nonexistent-id', imageType: 'step', stepId: STEP_ID_A }),
+      })
+
+      const result = await handler(event)
+
+      expect(result.statusCode).toBe(404)
+      const body = JSON.parse(result.body as string)
+      expect(body).toHaveProperty('error')
+    })
+  })
+
+  // ─── POST /recipes/images/upload-url — auth + validation ────────────
+  describe('POST /recipes/images/upload-url — auth + validation', () => {
     it('returns 401 without bearer token', async () => {
       const event = makeEvent({
         headers: {},
-        body: JSON.stringify({ recipeId: 'abc', imageType: 'cover' }),
+        body: JSON.stringify({ recipeId: RECIPE_ID, imageType: 'cover' }),
       })
 
       const result = await handler(event)
@@ -133,7 +263,7 @@ describe('Recipe Image handler', () => {
     it('returns 400 for missing imageType', async () => {
       const event = makeEvent({
         headers: { authorization: `Bearer ${contributorToken}` },
-        body: JSON.stringify({ recipeId: 'abc' }),
+        body: JSON.stringify({ recipeId: RECIPE_ID }),
       })
 
       const result = await handler(event)


### PR DESCRIPTION
Closes #149

## What changed

- **`lambda/recipe-image-handler.ts`** — `handleUploadUrl` now:
  - Validates `stepId` (presence + UUID format) before issuing any DynamoDB call (cheap fast-fail).
  - Issues a single `GetCommand` to fetch the recipe (`{ id: recipeId }`).
  - Returns 404 if the recipe doesn't exist.
  - Cover branch: builds the upload key as `uploads/recipes/<slug>/cover` using the slug from the fetched item; ignores any stray `stepId` in the body.
  - Step branch: validates the stepId exists in `recipe.steps[].stepId` (404 otherwise), then builds `uploads/recipes/<slug>/step-<stepId>`.
  - Drops the `key` field from the response — returns `{ uploadUrl }` only. Frontend now derives image URLs from `(slug, imageType[, stepId])`.
  - Drops the `stepOrder` field from the request body in favour of `stepId` (UUID, generated client-side per the PRD).
- **`test/lambda/recipe-image-handler.test.ts`** — 12 new TDD assertions covering response shape, slug-based key construction (cover and step), stepId UUID validation, stepId-not-in-steps-array, and recipe-not-found. Three obsolete tests deleted (asserted the dropped `key` field and the dropped `stepOrder` parameter).

## Why

Required by the **Editable Recipe Slugs (Backend)** milestone. Phase 1 (UUID-based image keys) is being replaced with slug-based keys so image URLs match the user-facing recipe URL. The handler was the last place that still constructed keys from the raw `recipeId`; it now reads the slug from the table.

Builds on:
- #146 — `dynamodb:GetItem` IAM grant + `TABLE_NAME` env var on this Lambda.
- #147 / #148 — slug as a first-class user-editable field, with a server-side lock once images exist.

The new `stepId` UUID makes step image URLs reorder-stable: a step keeps its image when reordered, instead of the image jumping to whichever step lands in the original `order` position.

## How to verify

- `pnpm test -- recipe-image-handler.test.ts` → 16/16
- `pnpm test` → 415/415
- `pnpm lint` → clean
- `pnpm exec tsc --noEmit` → only the pre-existing `sharp` baseline error; 0 new

Manual checks (post-deploy, covered by #153):
- `POST /recipes/images/upload-url` with `{recipeId, imageType:'cover'}` returns `{uploadUrl}` only; uploading via the URL produces variants under `recipes/<slug>/cover-*.webp`.
- Step upload with valid stepId returns `{uploadUrl}`; uploading produces `recipes/<slug>/step-<uuid>-*.webp`.
- Step upload with unknown stepId → 404 `step_not_found`.

## Decisions made

- **stepId is validated for UUID format before the GetItem.** Cheaper fast-fail and limits exposure of the recipes table to malformed IDs. The "stepId is in the recipe's steps array" check happens after the GetItem (it requires the recipe data).
- **Cover branch silently ignores stray `stepId`.** Per AC3 — frontends might hold on to a stepId across cover/step toggles; rejecting it would be brittle.
- **Recipe-not-found returns 404 even if `imageType` would otherwise be invalid.** Order: auth → required fields → stepId format → recipe exists → image-type-specific check.

## Out of scope (filed as follow-up issues)

- **`getRecipeById` extraction** — `recipe-handler.ts` already has the same helper; this Lambda now duplicates the `GetCommand` shape. Tracked separately (#159) — cross-file refactor, didn't want to expand this PR's scope.

## Commits

1. `test(recipe-image-handler): add failing tests for slug-based upload keys and stepId validation` — TDD failing tests
2. `feat(recipe-image-handler): build upload key from slug and validate stepId` — implementation