### PR TITLE
Image-resizer: parse slug from upload key + resolve id via slug-index GSI

### DIFF
--- a/lambda/image-resizer.ts
+++ b/lambda/image-resizer.ts
@@ -1,6 +1,6 @@
 import { ConditionalCheckFailedException, DynamoDBClient } from '@aws-sdk/client-dynamodb'
 import { S3Client, GetObjectCommand, PutObjectCommand, DeleteObjectCommand } from '@aws-sdk/client-s3'
-import { DynamoDBDocumentClient, UpdateCommand } from '@aws-sdk/lib-dynamodb'
+import { DynamoDBDocumentClient, QueryCommand, UpdateCommand } from '@aws-sdk/lib-dynamodb'
 import type { S3Event } from 'aws-lambda'
 import sharp from 'sharp'
 import { VARIANT_SUFFIXES, toProcessedKey, UPLOAD_PREFIX, type VariantSuffix } from './image-variants'
@@ -25,14 +25,14 @@ const VARIANTS: readonly ImageVariant[] = VARIANT_SUFFIXES.map((suffix) => ({
   ...VARIANT_SIZING[suffix],
 }))
 
-// Accepts exactly `uploads/recipes/<id>/<type>` — extra trailing segments are rejected.
-function parseRecipeId(uploadKey: string): string | undefined {
+// Accepts exactly `uploads/recipes/<slug>/<type>` — extra trailing segments are rejected.
+export function parseRecipeSlug(uploadKey: string): string | undefined {
   if (!uploadKey.startsWith(UPLOAD_PREFIX)) return undefined
   const segments = uploadKey.slice(UPLOAD_PREFIX.length).split('/')
   if (segments.length !== 2) return undefined
-  const id = segments[0]
-  if (!id) return undefined
-  return id
+  const slug = segments[0]
+  if (!slug) return undefined
+  return slug
 }
 
 export async function handler(event: S3Event): Promise<void> {
@@ -76,32 +76,47 @@ export async function handler(event: S3Event): Promise<void> {
     const logSkip = (reason: string) =>
       console.info({ event: 'resizer.writeback.skipped', reason, key })
 
-    const recipeId = parseRecipeId(key)
-    if (recipeId === undefined) {
-      logSkip('unrecognised_key_shape')
-    } else {
-      try {
-        await docClient.send(
-          new UpdateCommand({
-            TableName: tableName,
-            Key: { id: recipeId },
-            UpdateExpression: 'SET imageStatus.#k = :ts',
-            ConditionExpression: 'attribute_exists(id)',
-            ExpressionAttributeNames: { '#k': processedKey },
-            ExpressionAttributeValues: { ':ts': Date.now() },
-          }),
-        )
-      } catch (error) {
-        if (error instanceof ConditionalCheckFailedException) {
-          logSkip('recipe_deleted')
-        } else {
-          throw error
-        }
-      }
-    }
-
     await s3.send(
       new DeleteObjectCommand({ Bucket: sourceBucket, Key: key }),
     )
+
+    const slug = parseRecipeSlug(key)
+    if (slug === undefined) {
+      logSkip('unrecognised_key_shape')
+      continue
+    }
+
+    const lookup = await docClient.send(
+      new QueryCommand({
+        TableName: tableName,
+        IndexName: 'slug-index',
+        KeyConditionExpression: 'slug = :slug',
+        ExpressionAttributeValues: { ':slug': slug },
+      }),
+    )
+    const recipeId = (lookup.Items?.[0] as { id?: string } | undefined)?.id
+    if (!recipeId) {
+      logSkip('recipe_not_found')
+      continue
+    }
+
+    try {
+      await docClient.send(
+        new UpdateCommand({
+          TableName: tableName,
+          Key: { id: recipeId },
+          UpdateExpression: 'SET imageStatus.#k = :ts',
+          ConditionExpression: 'attribute_exists(id)',
+          ExpressionAttributeNames: { '#k': processedKey },
+          ExpressionAttributeValues: { ':ts': Date.now() },
+        }),
+      )
+    } catch (error) {
+      if (error instanceof ConditionalCheckFailedException) {
+        logSkip('recipe_deleted')
+      } else {
+        throw error
+      }
+    }
   }
 }

--- a/lambda/image-resizer.ts
+++ b/lambda/image-resizer.ts
@@ -25,6 +25,8 @@ const VARIANTS: readonly ImageVariant[] = VARIANT_SUFFIXES.map((suffix) => ({
   ...VARIANT_SIZING[suffix],
 }))
 
+type SkipReason = 'unrecognised_key_shape' | 'recipe_not_found' | 'recipe_deleted'
+
 // Accepts exactly `uploads/recipes/<slug>/<type>` — extra trailing segments are rejected.
 export function parseRecipeSlug(uploadKey: string): string | undefined {
   if (!uploadKey.startsWith(UPLOAD_PREFIX)) return undefined
@@ -73,7 +75,7 @@ export async function handler(event: S3Event): Promise<void> {
       }),
     )
 
-    const logSkip = (reason: string) =>
+    const logSkip = (reason: SkipReason) =>
       console.info({ event: 'resizer.writeback.skipped', reason, key })
 
     await s3.send(
@@ -94,7 +96,8 @@ export async function handler(event: S3Event): Promise<void> {
         ExpressionAttributeValues: { ':slug': slug },
       }),
     )
-    const recipeId = (lookup.Items?.[0] as { id?: string } | undefined)?.id
+    const [item] = lookup.Items ?? []
+    const recipeId = (item as { id?: string } | undefined)?.id
     if (!recipeId) {
       logSkip('recipe_not_found')
       continue

--- a/test/lambda/image-resizer.test.ts
+++ b/test/lambda/image-resizer.test.ts
@@ -1,6 +1,6 @@
 import { ConditionalCheckFailedException } from '@aws-sdk/client-dynamodb'
 import { S3Client, GetObjectCommand, PutObjectCommand, DeleteObjectCommand } from '@aws-sdk/client-s3'
-import { DynamoDBDocumentClient, UpdateCommand } from '@aws-sdk/lib-dynamodb'
+import { DynamoDBDocumentClient, QueryCommand, UpdateCommand } from '@aws-sdk/lib-dynamodb'
 import type { S3Event } from 'aws-lambda'
 import { mockClient } from 'aws-sdk-client-mock'
 
@@ -17,7 +17,11 @@ jest.mock('sharp', () => jest.fn(() => mockSharp))
 process.env.IMAGE_BUCKET_NAME = 'test-image-bucket'
 process.env.TABLE_NAME = 'test-recipes-table'
 
-import { handler } from '../../lambda/image-resizer'
+import * as imageResizer from '../../lambda/image-resizer'
+
+const { handler } = imageResizer
+
+const RESOLVED_ID = 'recipe-id-resolved-by-gsi'
 
 function makeS3Event(key: string, bucket = 'test-image-bucket'): S3Event {
   return {
@@ -54,6 +58,37 @@ function makeS3Event(key: string, bucket = 'test-image-bucket'): S3Event {
   }
 }
 
+describe('parseRecipeSlug', () => {
+  type ParseRecipeSlug = (key: string) => string | undefined
+
+  function getParseRecipeSlug(): ParseRecipeSlug {
+    const exported = (imageResizer as unknown as Record<string, unknown>).parseRecipeSlug
+    if (typeof exported !== 'function') {
+      throw new Error('parseRecipeSlug is not exported from image-resizer.ts')
+    }
+    return exported as ParseRecipeSlug
+  }
+
+  it('returns the slug segment for a well-formed cover upload key', () => {
+    const parseRecipeSlug = getParseRecipeSlug()
+    expect(parseRecipeSlug('uploads/recipes/beans-on-toast/cover')).toBe('beans-on-toast')
+  })
+
+  it('returns undefined for a key that does not start with the upload prefix', () => {
+    const parseRecipeSlug = getParseRecipeSlug()
+    expect(parseRecipeSlug('uploads/something-else/beans-on-toast/cover')).toBeUndefined()
+  })
+
+  it('is the only key-parser exported from image-resizer.ts (no parseRecipeId)', () => {
+    expect(
+      (imageResizer as unknown as Record<string, unknown>).parseRecipeId,
+    ).toBeUndefined()
+    expect(
+      typeof (imageResizer as unknown as Record<string, unknown>).parseRecipeSlug,
+    ).toBe('function')
+  })
+})
+
 describe('image-resizer handler', () => {
   beforeEach(() => {
     s3Mock.reset()
@@ -67,6 +102,7 @@ describe('image-resizer handler', () => {
     })
     s3Mock.on(PutObjectCommand).resolves({})
     s3Mock.on(DeleteObjectCommand).resolves({})
+    ddbMock.on(QueryCommand).resolves({ Items: [{ id: RESOLVED_ID }] })
     ddbMock.on(UpdateCommand).resolves({})
   })
 
@@ -139,7 +175,20 @@ describe('image-resizer handler', () => {
     }
   })
 
-  it('writes back imageStatus to DynamoDB after variant PUTs for a cover image', async () => {
+  it('queries the slug-index GSI to resolve the parsed slug to a recipe id', async () => {
+    await handler(makeS3Event('uploads/recipes/beans-on-toast/cover'))
+
+    const queryCalls = ddbMock.commandCalls(QueryCommand)
+    expect(queryCalls).toHaveLength(1)
+
+    const input = queryCalls[0].args[0].input
+    expect(input.TableName).toBe('test-recipes-table')
+    expect(input.IndexName).toBe('slug-index')
+    expect(input.KeyConditionExpression).toBe('slug = :slug')
+    expect(input.ExpressionAttributeValues).toEqual({ ':slug': 'beans-on-toast' })
+  })
+
+  it('writes back imageStatus to DynamoDB after variant PUTs for a cover image, keyed by the GSI-resolved id', async () => {
     const before = Date.now()
     await handler(makeS3Event('uploads/recipes/abc/cover'))
     const after = Date.now()
@@ -149,7 +198,8 @@ describe('image-resizer handler', () => {
 
     const input = updateCalls[0].args[0].input
     expect(input.TableName).toBe('test-recipes-table')
-    expect(input.Key).toEqual({ id: 'abc' })
+    // The path segment 'abc' is the slug; the id used in the Key comes from the GSI lookup.
+    expect(input.Key).toEqual({ id: RESOLVED_ID })
     expect(input.UpdateExpression).toBe('SET imageStatus.#k = :ts')
     expect(input.ConditionExpression).toBe('attribute_exists(id)')
     expect(input.ExpressionAttributeNames).toEqual({ '#k': 'recipes/abc/cover' })
@@ -161,18 +211,52 @@ describe('image-resizer handler', () => {
     expect(ts).toBeLessThanOrEqual(after)
   })
 
-  it('writes back imageStatus to DynamoDB for a step image key', async () => {
-    await handler(makeS3Event('uploads/recipes/abc/step-2'))
+  it('writes back imageStatus to DynamoDB for a step image key, keyed by the GSI-resolved id', async () => {
+    await handler(makeS3Event('uploads/recipes/abc/step-9d904a59-e83f-43b8-9f40-fbdb3008974c'))
 
     const updateCalls = ddbMock.commandCalls(UpdateCommand)
     expect(updateCalls).toHaveLength(1)
 
     const input = updateCalls[0].args[0].input
-    expect(input.Key).toEqual({ id: 'abc' })
-    expect(input.ExpressionAttributeNames).toEqual({ '#k': 'recipes/abc/step-2' })
+    expect(input.Key).toEqual({ id: RESOLVED_ID })
+    expect(input.ExpressionAttributeNames).toEqual({
+      '#k': 'recipes/abc/step-9d904a59-e83f-43b8-9f40-fbdb3008974c',
+    })
   })
 
-  it('swallows ConditionalCheckFailedException, still deletes source, and logs skip event', async () => {
+  it('logs recipe_not_found and skips the DDB write when the GSI returns no items; variant PUTs and source delete still ran', async () => {
+    const infoSpy = jest.spyOn(console, 'info').mockImplementation(() => {})
+    ddbMock.on(QueryCommand).resolves({ Items: [] })
+
+    await expect(handler(makeS3Event('uploads/recipes/missing-slug/cover'))).resolves.toBeUndefined()
+
+    // Variant PUTs still ran.
+    expect(s3Mock.commandCalls(PutObjectCommand)).toHaveLength(3)
+
+    // Source delete still ran.
+    const deleteCalls = s3Mock.commandCalls(DeleteObjectCommand)
+    expect(deleteCalls).toHaveLength(1)
+    expect(deleteCalls[0].args[0].input).toEqual({
+      Bucket: 'test-image-bucket',
+      Key: 'uploads/recipes/missing-slug/cover',
+    })
+
+    // No UpdateCommand was issued.
+    expect(ddbMock.commandCalls(UpdateCommand)).toHaveLength(0)
+
+    // Structured info log emitted with the expected reason and key.
+    expect(infoSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        event: 'resizer.writeback.skipped',
+        reason: 'recipe_not_found',
+        key: 'uploads/recipes/missing-slug/cover',
+      }),
+    )
+
+    infoSpy.mockRestore()
+  })
+
+  it('swallows ConditionalCheckFailedException (recipe_deleted skip), with the source-delete already having fired before the UpdateCommand', async () => {
     const infoSpy = jest.spyOn(console, 'info').mockImplementation(() => {})
 
     const condFailed = new ConditionalCheckFailedException({
@@ -183,7 +267,7 @@ describe('image-resizer handler', () => {
 
     await expect(handler(makeS3Event('uploads/recipes/abc/cover'))).resolves.toBeUndefined()
 
-    // Source-delete still runs.
+    // Source-delete fired (earlier in the flow, before the UpdateCommand threw).
     const deleteCalls = s3Mock.commandCalls(DeleteObjectCommand)
     expect(deleteCalls).toHaveLength(1)
     expect(deleteCalls[0].args[0].input).toEqual({
@@ -208,21 +292,21 @@ describe('image-resizer handler', () => {
     await expect(handler(makeS3Event('uploads/recipes/abc/cover'))).rejects.toThrow('boom')
   })
 
-  it('throws and writes nothing for a malformed key that does not match uploads/recipes/<id>/...', async () => {
+  it('throws and writes nothing for a malformed key that does not match uploads/recipes/<slug>/...', async () => {
     // With UPLOAD_PREFIX = 'uploads/recipes/', this key fails the prefix guard
     // inside toProcessedKey and the handler now refuses to process it.
     await expect(handler(makeS3Event('uploads/not-recipes/x'))).rejects.toThrow(/uploads\/recipes\//)
 
+    expect(ddbMock.commandCalls(QueryCommand)).toHaveLength(0)
     expect(ddbMock.commandCalls(UpdateCommand)).toHaveLength(0)
     expect(s3Mock.commandCalls(PutObjectCommand)).toHaveLength(0)
     expect(s3Mock.commandCalls(DeleteObjectCommand)).toHaveLength(0)
   })
 
-  it('invokes DDB UpdateCommand before the source DeleteObjectCommand', async () => {
-    // Sequencing is enforced via the handler's error-propagation contract: if the
-    // UpdateCommand is issued BEFORE the source DeleteObjectCommand, rejecting the
-    // UpdateCommand with a generic error must prevent the source-delete from firing.
-    // If the delete were issued first, it would run regardless of the DDB outcome.
+  it('invokes the source DeleteObjectCommand BEFORE the UpdateCommand (variants -> delete source -> query GSI -> update DDB)', async () => {
+    // Sequencing-probe trick (mirrors the previous "Update before Delete" assertion, inverted):
+    // if the UpdateCommand is issued AFTER the source DeleteObjectCommand, rejecting the
+    // UpdateCommand with a generic error must NOT prevent the source-delete from having fired.
     ddbMock.on(UpdateCommand).rejects(new Error('sequencing-probe'))
 
     await expect(handler(makeS3Event('uploads/recipes/abc/cover'))).rejects.toThrow(
@@ -230,7 +314,44 @@ describe('image-resizer handler', () => {
     )
 
     expect(ddbMock.commandCalls(UpdateCommand)).toHaveLength(1)
-    // Source-delete never fires because the update threw first.
-    expect(s3Mock.commandCalls(DeleteObjectCommand)).toHaveLength(0)
+    // Source-delete fired earlier in the flow, before the UpdateCommand threw.
+    expect(s3Mock.commandCalls(DeleteObjectCommand)).toHaveLength(1)
+  })
+
+  it('orders the resizer flow as: write variants -> delete source -> query GSI -> update DDB', async () => {
+    // Track call order across both mocks via a shared sequence counter using jest.spyOn
+    // on the underlying send methods. aws-sdk-client-mock exposes per-mock call lists but
+    // not a cross-mock chronological one, so we tag calls as they happen.
+    const sequence: string[] = []
+
+    s3Mock.on(PutObjectCommand).callsFake(async () => {
+      sequence.push('s3:put')
+      return {}
+    })
+    s3Mock.on(DeleteObjectCommand).callsFake(async () => {
+      sequence.push('s3:delete')
+      return {}
+    })
+    ddbMock.on(QueryCommand).callsFake(async () => {
+      sequence.push('ddb:query')
+      return { Items: [{ id: RESOLVED_ID }] }
+    })
+    ddbMock.on(UpdateCommand).callsFake(async () => {
+      sequence.push('ddb:update')
+      return {}
+    })
+
+    await handler(makeS3Event('uploads/recipes/abc/cover'))
+
+    // Three variant PUTs first (in any order amongst themselves — they fire concurrently),
+    // then the source delete, then the GSI query, then the update.
+    expect(sequence.filter((step) => step === 's3:put')).toHaveLength(3)
+    const tail = sequence.filter((step) => step !== 's3:put')
+    expect(tail).toEqual(['s3:delete', 'ddb:query', 'ddb:update'])
+
+    // And every PUT preceded the source delete.
+    const lastPutIndex = sequence.lastIndexOf('s3:put')
+    const deleteIndex = sequence.indexOf('s3:delete')
+    expect(lastPutIndex).toBeLessThan(deleteIndex)
   })
 })


### PR DESCRIPTION
Closes #150

## What changed

- **`lambda/image-resizer.ts`** — the S3-event-triggered resizer Lambda:
  - `parseRecipeId` renamed to `parseRecipeSlug` and exported. Same shape — extracts the segment after `UPLOAD_PREFIX`. The pre-existing `parseRecipeId` is removed entirely.
  - Per-record flow reordered to: `variant PUTs → DeleteObjectCommand (source) → parseRecipeSlug → QueryCommand (slug-index) → UpdateCommand`. Variant PUTs and source delete now fire before any DDB work.
  - Added a `QueryCommand` against the `slug-index` GSI (`KEYS_ONLY`, `KeyConditionExpression: 'slug = :slug'`) to resolve `slug → id`. The resolved `id` is used in `UpdateCommand.Key`.
  - New skip path: if the GSI Query returns no items, log `recipe_not_found` and continue. Variant PUTs and source delete still ran above.
  - Existing `recipe_deleted` skip (CCFE on the UpdateCommand) preserved.
  - Added a `SkipReason` string-union type for `logSkip` so the closed set of reasons (`unrecognised_key_shape | recipe_not_found | recipe_deleted`) is type-checked.
- **`test/lambda/image-resizer.test.ts`** — 9 new TDD assertions, 5 updated to reflect the GSI-resolved id, 1 inverted (the old "Update before Delete" sequencing test).

## Why

Required by the **Editable Recipe Slugs (Backend)** milestone. The resizer is the last writer of `imageStatus` keyed by recipe id; the upload key now carries a slug, so the resizer needs a slug → id lookup. Builds on #146 (slug-index GSI + `dynamodb:Query` IAM grant).

## How to verify

- `pnpm test -- image-resizer.test.ts` → 17/17
- `pnpm test` → 421/421
- `pnpm lint` → clean
- `pnpm exec tsc --noEmit` → only the pre-existing `sharp` baseline error; 0 new

Manual checks (post-deploy, covered by #153):
- Upload to `uploads/recipes/<slug>/cover` triggers the resizer; variants land at `recipes/<slug>/cover-{thumb,medium,full}.webp` and the recipe item's `imageStatus` map gains `recipes/<slug>/cover` keyed by the timestamp.
- Upload to a key whose slug doesn't appear in the GSI logs `recipe_not_found` and skips the writeback (variants still written, source still deleted).

## Decisions made

- **Source delete moved before the GSI/Update steps.** Per the AC: "variant PUTs and source delete fire regardless of GSI lookup outcome." This intentionally trades durability on transient DDB errors for simpler "uploads always get cleaned up" semantics — see follow-up #161 below.
- **`KEYS_ONLY` projection** on the GSI Query — returns `id` + `slug`, which is exactly what the resizer needs. No `ProjectionExpression` required.
- **Sequencing assertions in tests** use the existing "rejection probe" trick (reject one command, assert the next didn't fire) rather than chronological mock-call interleaving. The test file already used this pattern; the inverted ordering test mirrors it.

## Out of scope (filed as follow-up issues)

- **#161** — Image-resizer durability regression after source-delete on transient DDB error. The new flow can leave variants written but `imageStatus` unstamped if the GSI Query or UpdateCommand fails after the source has been deleted. Surfaced by /simplify; the AC mandates this order, so revisiting it deserves its own discussion.
- **#159** (updated) — Extract a shared `recipe-store.ts` module for `getRecipeById` + `findIdBySlug` + `SLUG_INDEX_NAME`. Now spans three Lambdas (`recipe-handler`, `recipe-image-handler`, `image-resizer`) duplicating the same GSI Query shape and `'slug-index'` literal. Issue body and title updated to reflect the broader scope.

## Commits

1. `test(image-resizer): add failing tests for slug-based GSI lookup and reordered flow` — TDD failing tests
2. `feat(image-resizer): resolve recipe id via slug-index gsi and reorder flow` — implementation
3. `refactor(image-resizer): add SkipReason type and tidy gsi item destructure` — `/simplify` polish