### PR TITLE
Sweep test fixtures: drop coverImage.key and step.image.key

### DIFF
--- a/lambda/recipe-handler.ts
+++ b/lambda/recipe-handler.ts
@@ -552,7 +552,7 @@ async function handleUpdateRecipe(event: APIGatewayProxyEventV2): Promise<APIGat
 interface PublishErrors {
   title?: string
   intro?: string
-  coverImage?: { key?: string; alt?: string; processedAt?: string }
+  coverImage?: { alt?: string; processedAt?: string }
   ingredients?: string
   steps?: string
   stepImages?: Array<{ order: number; processedAt: string }>
@@ -571,24 +571,19 @@ function validatePublishInput(item: Record<string, unknown>): PublishErrors {
     errors.intro = 'intro is required'
   }
 
-  const coverImage = item.coverImage as { key?: unknown; alt?: unknown } | undefined
-  const coverErrors: { key?: string; alt?: string; processedAt?: string } = {}
-  const coverKey = coverImage?.key
-  if (typeof coverKey !== 'string' || coverKey.trim().length === 0) {
-    coverErrors.key = 'coverImage.key is required'
-  }
+  const slug = typeof item.slug === 'string' ? item.slug : undefined
+  const imageStatus = imageStatusOf(item)
+  const coverImage = item.coverImage as { alt?: unknown } | undefined
+  const coverErrors: { alt?: string; processedAt?: string } = {}
+
   const coverAlt = coverImage?.alt
   if (typeof coverAlt !== 'string' || coverAlt.trim().length === 0) {
     coverErrors.alt = 'coverImage.alt is required'
-  }
-
-  const imageStatus = imageStatusOf(item)
-
-  if (!coverErrors.key && imageStatus[coverKey as string] === undefined) {
+  } else if (slug && imageStatus[`${PROCESSED_PREFIX}${slug}/cover`] === undefined) {
     coverErrors.processedAt = 'Cover image still processing'
   }
 
-  if (coverErrors.key || coverErrors.alt || coverErrors.processedAt) {
+  if (coverErrors.alt || coverErrors.processedAt) {
     errors.coverImage = coverErrors
   }
 
@@ -610,13 +605,15 @@ function validatePublishInput(item: Record<string, unknown>): PublishErrors {
     }
 
     const stepImageErrors: Array<{ order: number; processedAt: string }> = []
-    for (const step of steps) {
-      const typedStep = step as { order?: unknown; image?: { key?: unknown } }
-      const imageKey = typedStep.image?.key
-      if (typeof imageKey !== 'string' || imageKey.trim().length === 0) continue
-      if (imageStatus[imageKey] !== undefined) continue
-      const order = typeof typedStep.order === 'number' ? typedStep.order : 0
-      stepImageErrors.push({ order, processedAt: 'Step image still processing' })
+    if (slug) {
+      for (const step of steps) {
+        const typedStep = step as { order?: unknown; stepId?: unknown; image?: unknown }
+        if (!typedStep.image || typeof typedStep.stepId !== 'string') continue
+        const stepKey = `${PROCESSED_PREFIX}${slug}/step-${typedStep.stepId}`
+        if (imageStatus[stepKey] !== undefined) continue
+        const order = typeof typedStep.order === 'number' ? typedStep.order : 0
+        stepImageErrors.push({ order, processedAt: 'Step image still processing' })
+      }
     }
     if (stepImageErrors.length > 0) {
       errors.stepImages = stepImageErrors

--- a/lambda/recipe-handler.ts
+++ b/lambda/recipe-handler.ts
@@ -95,9 +95,13 @@ function imageStatusOf(item: Record<string, unknown>): Record<string, number> {
   return (item.imageStatus as Record<string, number> | undefined) ?? {}
 }
 
+function slugOf(item: Record<string, unknown>): string | undefined {
+  return typeof item.slug === 'string' ? item.slug : undefined
+}
+
 function composeImageProcessedAt<T extends Record<string, unknown>>(item: T): Omit<T, 'imageStatus'> {
   const imageStatus = imageStatusOf(item)
-  const slug = typeof item.slug === 'string' ? item.slug : undefined
+  const slug = slugOf(item)
   const coverImage = item.coverImage as Record<string, unknown> | undefined
 
   const coverDerivedKey = slug ? `${PROCESSED_PREFIX}${slug}/cover` : undefined
@@ -354,7 +358,7 @@ function variantKeysFor(key: string): readonly string[] {
 }
 
 function droppedImageBaseKeys(oldItem: Record<string, unknown>, updates: Record<string, unknown>): string[] {
-  const slug = typeof oldItem.slug === 'string' ? oldItem.slug : undefined
+  const slug = slugOf(oldItem)
   if (!slug) return []
   const droppedKeys: string[] = []
 
@@ -571,7 +575,7 @@ function validatePublishInput(item: Record<string, unknown>): PublishErrors {
     errors.intro = 'intro is required'
   }
 
-  const slug = typeof item.slug === 'string' ? item.slug : undefined
+  const slug = slugOf(item)
   const imageStatus = imageStatusOf(item)
   const coverImage = item.coverImage as { alt?: unknown } | undefined
   const coverErrors: { alt?: string; processedAt?: string } = {}
@@ -701,7 +705,7 @@ async function handleDeleteRecipe(event: APIGatewayProxyEventV2): Promise<APIGat
     return json(403, { error: 'Forbidden' })
   }
 
-  const slug = typeof existing.slug === 'string' ? existing.slug : undefined
+  const slug = slugOf(existing)
   if (slug) {
     const listResult = await s3Client.send(
       new ListObjectsV2Command({

--- a/test/lambda/recipe-handler.test.ts
+++ b/test/lambda/recipe-handler.test.ts
@@ -62,9 +62,9 @@ function publishedRecipeItem(overrides: Record<string, unknown> = {}): Record<st
     slug: 'slow-cooked-lamb-ragu',
     title: 'Slow-Cooked Lamb Ragu',
     intro: 'A rich, hearty ragu.',
-    coverImage: { key: 'recipes/images/recipe-uuid-1/cover', alt: 'A bowl of lamb ragu' },
+    coverImage: { alt: 'A bowl of lamb ragu' },
     ingredients: [{ item: 'lamb shoulder', quantity: '1', unit: 'kg' }],
-    steps: [{ order: 1, text: 'Season the lamb and sear.' }],
+    steps: [{ stepId: 'a0000000-0000-4000-8000-000000000001', order: 1, text: 'Season the lamb and sear.' }],
     tags: new Set(['Italian', 'Slow Cook']),
     prepTime: 20,
     cookTime: 240,
@@ -111,7 +111,7 @@ describe('Recipe Lambda handler', () => {
         id: 'recipe-uuid-1',
         title: 'Slow-Cooked Lamb Ragu',
         slug: 'slow-cooked-lamb-ragu',
-        coverImage: { key: 'recipes/images/recipe-uuid-1/cover', alt: 'A bowl of lamb ragu' },
+        coverImage: { alt: 'A bowl of lamb ragu' },
         tags: ['Italian', 'Slow Cook'],
         prepTime: 20,
         cookTime: 240,
@@ -1657,7 +1657,7 @@ describe('Recipe Lambda handler', () => {
       ddbMock.on(GetCommand).resolves({
         Item: draftRecipeItem({
           authorId: 'contributor-user-id',
-          imageStatus: { 'recipes/images/recipe-uuid-1/cover': 1_745_000_000_000 },
+          imageStatus: { 'recipes/my-draft-recipe/cover': 1_745_000_000_000 },
         }),
       })
       ddbMock.on(UpdateCommand).resolves({
@@ -1682,7 +1682,7 @@ describe('Recipe Lambda handler', () => {
       ddbMock.on(GetCommand).resolves({
         Item: draftRecipeItem({
           authorId: 'contributor-user-id',
-          imageStatus: { 'recipes/images/recipe-uuid-1/cover': 1_745_000_000_000 },
+          imageStatus: { 'recipes/my-draft-recipe/cover': 1_745_000_000_000 },
         }),
       })
       ddbMock.on(UpdateCommand).resolves({
@@ -1745,11 +1745,11 @@ describe('Recipe Lambda handler', () => {
         expect(body.errors).toHaveProperty('intro')
       })
 
-      it('returns 400 with a `coverImage.key` error when cover key is missing', async () => {
+      it('returns 400 with a `coverImage.alt` error when alt is missing', async () => {
         ddbMock.on(GetCommand).resolves({
           Item: draftRecipeItem({
             authorId: 'contributor-user-id',
-            coverImage: { key: '', alt: 'alt' },
+            coverImage: {},
           }),
         })
 
@@ -1757,14 +1757,15 @@ describe('Recipe Lambda handler', () => {
 
         expect(result.statusCode).toBe(400)
         const body = JSON.parse(result.body as string)
-        expect(body.errors).toHaveProperty('coverImage.key')
+        expect(body.errors.coverImage).toBeDefined()
+        expect(body.errors.coverImage.alt).toBe('coverImage.alt is required')
       })
 
-      it('returns 400 with a `coverImage.alt` error when cover alt is missing', async () => {
+      it('returns 400 with a `coverImage.alt` error when cover alt is empty', async () => {
         ddbMock.on(GetCommand).resolves({
           Item: draftRecipeItem({
             authorId: 'contributor-user-id',
-            coverImage: { key: 'recipes/images/recipe-uuid-1/cover', alt: '' },
+            coverImage: { alt: '' },
           }),
         })
 
@@ -1772,7 +1773,8 @@ describe('Recipe Lambda handler', () => {
 
         expect(result.statusCode).toBe(400)
         const body = JSON.parse(result.body as string)
-        expect(body.errors).toHaveProperty('coverImage.alt')
+        expect(body.errors.coverImage).toBeDefined()
+        expect(body.errors.coverImage.alt).toBe('coverImage.alt is required')
       })
 
       it('returns 400 with an `ingredients` error when ingredients list is empty', async () => {
@@ -1816,9 +1818,13 @@ describe('Recipe Lambda handler', () => {
     })
 
     describe('readiness validation — rejects recipes with unready images', () => {
-      const coverKey = 'recipes/recipe-uuid-1/cover'
-      const step1Key = 'recipes/recipe-uuid-1/step-1'
-      const step2Key = 'recipes/recipe-uuid-1/step-2'
+      const draftSlug = 'my-draft-recipe'
+      const publishedSlug = 'slow-cooked-lamb-ragu'
+      const stepIdA = 'a0000000-0000-4000-8000-000000000001'
+      const stepIdB = 'a0000000-0000-4000-8000-000000000002'
+      const coverKey = `recipes/${draftSlug}/cover`
+      const step1Key = `recipes/${draftSlug}/step-${stepIdA}`
+      const step2Key = `recipes/${draftSlug}/step-${stepIdB}`
       const coverTs = 1_745_000_000_001
       const step1Ts = 1_745_000_000_002
       const step2Ts = 1_745_000_000_003
@@ -1836,9 +1842,9 @@ describe('Recipe Lambda handler', () => {
         ddbMock.on(GetCommand).resolves({
           Item: draftRecipeItem({
             authorId: 'contributor-user-id',
-            coverImage: { key: coverKey, alt: 'A bowl of lamb ragu' },
+            coverImage: { alt: 'A bowl of lamb ragu' },
             steps: [
-              { order: 1, text: 'Sear.', image: { key: step1Key, alt: 'seared' } },
+              { stepId: stepIdA, order: 1, text: 'Sear.', image: { alt: 'seared' } },
             ],
             imageStatus: { [step1Key]: step1Ts },
           }),
@@ -1857,14 +1863,14 @@ describe('Recipe Lambda handler', () => {
         expect(body.errors).not.toHaveProperty('stepImages')
       })
 
-      it('returns 400 with errors.stepImages for each step whose image key has no imageStatus entry (cover ready)', async () => {
+      it('returns 400 with errors.stepImages for each step whose image has no imageStatus entry (cover ready)', async () => {
         ddbMock.on(GetCommand).resolves({
           Item: draftRecipeItem({
             authorId: 'contributor-user-id',
-            coverImage: { key: coverKey, alt: 'A bowl of lamb ragu' },
+            coverImage: { alt: 'A bowl of lamb ragu' },
             steps: [
-              { order: 1, text: 'Sear.', image: { key: step1Key, alt: 'seared' } },
-              { order: 2, text: 'Simmer.', image: { key: step2Key, alt: 'simmering' } },
+              { stepId: stepIdA, order: 1, text: 'Sear.', image: { alt: 'seared' } },
+              { stepId: stepIdB, order: 2, text: 'Simmer.', image: { alt: 'simmering' } },
             ],
             imageStatus: { [coverKey]: coverTs, [step1Key]: step1Ts },
           }),
@@ -1888,10 +1894,10 @@ describe('Recipe Lambda handler', () => {
         ddbMock.on(GetCommand).resolves({
           Item: draftRecipeItem({
             authorId: 'contributor-user-id',
-            coverImage: { key: coverKey, alt: 'A bowl of lamb ragu' },
+            coverImage: { alt: 'A bowl of lamb ragu' },
             steps: [
-              { order: 1, text: 'Sear.', image: { key: step1Key, alt: 'seared' } },
-              { order: 2, text: 'Simmer.', image: { key: step2Key, alt: 'simmering' } },
+              { stepId: stepIdA, order: 1, text: 'Sear.', image: { alt: 'seared' } },
+              { stepId: stepIdB, order: 2, text: 'Simmer.', image: { alt: 'simmering' } },
             ],
             imageStatus: {},
           }),
@@ -1916,7 +1922,7 @@ describe('Recipe Lambda handler', () => {
           Item: draftRecipeItem({
             authorId: 'contributor-user-id',
             title: '',
-            coverImage: { key: coverKey, alt: 'A bowl of lamb ragu' },
+            coverImage: { alt: 'A bowl of lamb ragu' },
             imageStatus: {},
           }),
         })
@@ -1930,14 +1936,13 @@ describe('Recipe Lambda handler', () => {
         expect(body.errors.coverImage.processedAt).toBe('Cover image still processing')
       })
 
-      it('returns 400 when republishing a currently-published recipe whose cover was swapped to an unready new key', async () => {
-        const oldCoverKey = 'recipes/recipe-uuid-1/cover-old'
-        const newCoverKey = 'recipes/recipe-uuid-1/cover'
+      it('returns 400 when republishing a currently-published recipe whose cover has no imageStatus entry under the slug-derived key', async () => {
+        const staleLegacyKey = 'recipes/recipe-uuid-1/cover'
         ddbMock.on(GetCommand).resolves({
           Item: publishedRecipeItem({
             authorId: 'contributor-user-id',
-            coverImage: { key: newCoverKey, alt: 'New cover' },
-            imageStatus: { [oldCoverKey]: coverTs },
+            coverImage: { alt: 'New cover' },
+            imageStatus: { [staleLegacyKey]: coverTs },
           }),
         })
 
@@ -1954,8 +1959,11 @@ describe('Recipe Lambda handler', () => {
         ddbMock.on(GetCommand).resolves({
           Item: draftRecipeItem({
             authorId: 'contributor-user-id',
-            coverImage: { key: coverKey, alt: 'A bowl of lamb ragu' },
-            steps: [{ order: 1, text: '' }, { order: 2, text: '   ' }],
+            coverImage: { alt: 'A bowl of lamb ragu' },
+            steps: [
+              { stepId: stepIdA, order: 1, text: '' },
+              { stepId: stepIdB, order: 2, text: '   ' },
+            ],
             imageStatus: { [coverKey]: coverTs },
           }),
         })
@@ -1969,16 +1977,81 @@ describe('Recipe Lambda handler', () => {
         expect(body.errors.steps).not.toEqual(expect.any(Array))
       })
 
-      it('publishes successfully when every image key has a matching imageStatus entry', async () => {
+      it('publishes successfully when every image key has a matching slug-derived imageStatus entry', async () => {
         ddbMock.on(GetCommand).resolves({
           Item: draftRecipeItem({
             authorId: 'contributor-user-id',
-            coverImage: { key: coverKey, alt: 'A bowl of lamb ragu' },
+            coverImage: { alt: 'A bowl of lamb ragu' },
             steps: [
-              { order: 1, text: 'Sear.', image: { key: step1Key, alt: 'seared' } },
-              { order: 2, text: 'Simmer.', image: { key: step2Key, alt: 'simmering' } },
+              { stepId: stepIdA, order: 1, text: 'Sear.', image: { alt: 'seared' } },
+              { stepId: stepIdB, order: 2, text: 'Simmer.', image: { alt: 'simmering' } },
             ],
             imageStatus: { [coverKey]: coverTs, [step1Key]: step1Ts, [step2Key]: step2Ts },
+          }),
+        })
+        ddbMock.on(UpdateCommand).resolves({
+          Attributes: publishedRecipeItem({ authorId: 'contributor-user-id' }),
+        })
+
+        const result = await handler(publishEvent())
+
+        expect(result.statusCode).toBe(200)
+      })
+
+      it('publishes successfully when steps have no images and only the cover is ready (no stepImages errors emitted)', async () => {
+        ddbMock.on(GetCommand).resolves({
+          Item: draftRecipeItem({
+            authorId: 'contributor-user-id',
+            coverImage: { alt: 'A bowl of lamb ragu' },
+            steps: [
+              { stepId: stepIdA, order: 1, text: 'Sear.' },
+              { stepId: stepIdB, order: 2, text: 'Simmer.' },
+            ],
+            imageStatus: { [coverKey]: coverTs },
+          }),
+        })
+        ddbMock.on(UpdateCommand).resolves({
+          Attributes: publishedRecipeItem({ authorId: 'contributor-user-id' }),
+        })
+
+        const result = await handler(publishEvent())
+
+        expect(result.statusCode).toBe(200)
+      })
+
+      it('emits one stepImages entry per step with image but no slug+stepId imageStatus entry', async () => {
+        ddbMock.on(GetCommand).resolves({
+          Item: draftRecipeItem({
+            authorId: 'contributor-user-id',
+            coverImage: { alt: 'A bowl of lamb ragu' },
+            steps: [
+              { stepId: stepIdA, order: 1, text: 'Sear.', image: { alt: 'seared' } },
+              { stepId: stepIdB, order: 2, text: 'Simmer.', image: { alt: 'simmering' } },
+            ],
+            imageStatus: { [coverKey]: coverTs },
+          }),
+        })
+
+        const result = await handler(publishEvent())
+
+        expect(result.statusCode).toBe(400)
+        const body = JSON.parse(result.body as string)
+        expect(body.errors).not.toHaveProperty('coverImage')
+        expect(body.errors.stepImages).toEqual([
+          { order: 1, processedAt: 'Step image still processing' },
+          { order: 2, processedAt: 'Step image still processing' },
+        ])
+      })
+
+      // Reference to publishedSlug to keep the constant tied to documented intent
+      // (the slug-derived imageStatus key for published-state assertions lives elsewhere).
+      it('uses the published recipe\'s slug-derived key for republish readiness', async () => {
+        const publishedCoverKey = `recipes/${publishedSlug}/cover`
+        ddbMock.on(GetCommand).resolves({
+          Item: publishedRecipeItem({
+            authorId: 'contributor-user-id',
+            coverImage: { alt: 'A bowl of lamb ragu' },
+            imageStatus: { [publishedCoverKey]: coverTs },
           }),
         })
         ddbMock.on(UpdateCommand).resolves({
@@ -1995,7 +2068,7 @@ describe('Recipe Lambda handler', () => {
       ddbMock.on(GetCommand).resolves({
         Item: publishedRecipeItem({
           authorId: 'contributor-user-id',
-          imageStatus: { 'recipes/images/recipe-uuid-1/cover': 1_745_000_000_000 },
+          imageStatus: { 'recipes/slow-cooked-lamb-ragu/cover': 1_745_000_000_000 },
         }),
       })
       ddbMock.on(UpdateCommand).resolves({
@@ -2497,14 +2570,12 @@ describe('Recipe Lambda handler', () => {
     // AC 6: PATCH /recipes/{id}/publish response composes processedAt.
     it('PATCH /recipes/{id}/publish response composes processedAt onto the returned recipe', async () => {
       // Draft we read for validation passes all existing checks AND has readiness on every image.
-      // Note: validatePublishInput still reads `coverImage.key` / `step.image.key` (not in scope
-      // for this issue) — keep those literal keys present in the validation fixture so it passes.
       const fullyReadyDraft = recipeWithImageStatus({
         status: 'draft',
         authorId: 'contributor-user-id',
-        coverImage: { key: coverKey, alt: 'A bowl of lamb ragu' },
+        coverImage: { alt: 'A bowl of lamb ragu' },
         steps: [
-          { stepId: stepId1, order: 1, text: 'Sear.', image: { key: step1Key, alt: 'seared lamb' } },
+          { stepId: stepId1, order: 1, text: 'Sear.', image: { alt: 'seared lamb' } },
         ],
         imageStatus: { [coverKey]: coverTs, [step1Key]: step1Ts },
       })
@@ -2626,12 +2697,11 @@ describe('Recipe Lambda handler', () => {
       })
 
       it('PATCH /recipes/{id}/publish strips imageStatus', async () => {
-        // Validation still uses coverImage.key/step.image.key — keep them populated for this fixture.
         const fullyReadyDraft = recipeWithImageStatus({
           status: 'draft',
           authorId: 'contributor-user-id',
-          coverImage: { key: coverKey, alt: 'A bowl of lamb ragu' },
-          steps: [{ stepId: stepId1, order: 1, text: 'Sear.', image: { key: step1Key, alt: 'seared lamb' } }],
+          coverImage: { alt: 'A bowl of lamb ragu' },
+          steps: [{ stepId: stepId1, order: 1, text: 'Sear.', image: { alt: 'seared lamb' } }],
           imageStatus: { [coverKey]: coverTs, [step1Key]: step1Ts },
         })
         ddbMock.on(GetCommand).resolves({ Item: fullyReadyDraft })


### PR DESCRIPTION
Closes #152

## What changed

- **`lambda/recipe-handler.ts`** — `validatePublishInput` migrated from reading `coverImage.key` / `step.image.key` to deriving keys from the recipe's slug + per-step stepId. The `PublishErrors.coverImage.key` field is dropped (no error possible without a key field). Cover validation now requires `imageStatus[recipes/<slug>/cover]` once `alt` is set; step validation requires `imageStatus[recipes/<slug>/step-<stepId>]` for each step that has an `image`.
- **`lambda/recipe-handler.ts`** — extracted a `slugOf(item)` helper alongside `imageStatusOf` and refactored the 4 places (`composeImageProcessedAt`, `droppedImageBaseKeys`, `validatePublishInput`, `handleDeleteRecipe`) that used the inline `typeof item.slug === 'string' ? item.slug : undefined` pattern.
- **`test/lambda/recipe-handler.test.ts`** — fixture sweep across the publish-related tests:
  - `publishedRecipeItem` default: dropped `coverImage.key`, added stepId UUID.
  - `validatePublishInput` validation block: rewrote the `coverImage.key is required` test as `coverImage.alt is required`. Added 3 new tests (cover ready + steps without images publishes successfully; per-step `stepImages` errors; published-recipe republish readiness with slug-derived keys).
  - Outer publish tests: switched legacy `imageStatus: { 'recipes/<id>/cover': … }` keys to slug-derived `recipes/<slug>/cover`.
  - Removed obsolete in-source comments noting "validatePublishInput still reads `.key`".

## Why

The final piece of the **Editable Recipe Slugs (Backend)** milestone's data-model migration. After #149/#150/#151, the only place still reading the legacy `.key` fields was `validatePublishInput`. This issue completes the cutover so the production code never reads those fields again — confirmed by the AC greps below.

## How to verify

- `pnpm test` → 430/430
- `pnpm lint` → clean
- `pnpm exec tsc --noEmit` → only the pre-existing `sharp` baseline error; 0 new
- `grep -rn -F 'coverImage.key' lambda/` → 0 matches
- `grep -rn -F '.image.key' lambda/` → 0 matches
- `grep -rnE 'step-\${.*order\}' lambda/` → 0 matches
- `grep -rnE 'step-1[^0-9a-f]|step-2[^0-9a-f]|step-3[^0-9a-f]' lambda/` → 0 matches

## Decisions made

- **`PublishErrors.coverImage.key` dropped from the wire format.** This is intentional and required by the AC (production code can no longer produce that error). Frontend consumers reading `body.errors.coverImage.key` will see `undefined`. The sibling frontend PRD already drops this read.
- **"No cover at all" maps to `coverImage.alt is required`.** Without a `.key` field, the server can't distinguish "no upload started" from "uploaded but processing". The `alt` requirement is the user-facing signal that a cover is needed; the `processedAt` error fires only when alt is present but the imageStatus entry isn't.
- **Step iteration nested inside `if (slug)`** — slug-less legacy items (shouldn't exist in practice) silently pass step validation. Symmetric with `composeImageProcessedAt` and `droppedImageBaseKeys`. A slug-less item wouldn't be publishable anyway via other paths.
- **`slugOf(item)` helper added now** rather than deferred to #159, because the new `validatePublishInput` made it the 4th identical call site within the same file. Cheap, local, mirrors `imageStatusOf`.

## Out of scope (filed as follow-up issues)

- **#159** (already filed and updated) — Shared `recipe-store.ts` module covering `getRecipeById`, `findIdBySlug`, `SLUG_INDEX_NAME`, and now `STEP_ID_REGEX`. The /simplify reuse review for this issue confirmed the key-derivation literals (`recipes/<slug>/cover`, `recipes/<slug>/step-<stepId>`) appear in 6+ sites; the recommendation is to fold `coverKeyFor(slug)` / `stepKeyFor(slug, stepId)` into #159's scope.

## Out of scope (skipped without follow-up)

- Tightening `typedStep.image` from a truthy check to an explicit object check — would diverge from `composeImageProcessedAt`'s own truthy check; better addressed by the shared key-derivation helpers in #159.
- The `errors.stepImages[].order` collision when multiple steps lack an order field (all collapse to `0`) — pre-existing behaviour of the function, not introduced by this diff. Frontend can disambiguate via stepId in subsequent fetches if it cares.

## Commits

1. `refactor(recipe-handler): migrate validatePublishInput to slug-derived keys` — production migration + fixture sweep.
2. `refactor(recipe-handler): extract slugOf helper for item slug extraction` — `/simplify` polish.

Note: this PR has no separate `test:` and `feat:` commits because the work is a behaviour-preserving migration (Migration/Refactor type, not Feature). The production code change and the test updates landed together since the tests were testing the old behaviour and needed to follow the migration in the same commit.