### PR TITLE
chore: commit pnpm-workspace.yaml to allow esbuild/sharp builds

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,3 @@
+allowBuilds:
+  esbuild: true
+  sharp: true


### PR DESCRIPTION
## What changed
Adds `pnpm-workspace.yaml` with `allowBuilds` approvals for `esbuild` and `sharp`.

## Why
pnpm 10+ blocks dependency build scripts by default. Without these approvals, a fresh `pnpm install` silently skips `sharp`'s native build, which breaks the lambda tests that import `sharp` (and trips pnpm's deps-status check on `pnpm test`). Committing the approvals makes installs reproducible across machines and CI with no manual `pnpm approve-builds` step.

Mirrors the existing convention in `personal-website`, which tracks an identical file.

## How to verify
- Fresh `pnpm install` builds `sharp` without prompting.
- `pnpm test` runs the lambda suites (stack suites still require Docker for bundling — unrelated).