### PR TITLE
Extract shared recipe-store module (getRecipeById + findIdBySlug + SLUG_INDEX_NAME)

### DIFF
--- a/lambda/image-resizer.ts
+++ b/lambda/image-resizer.ts
@@ -1,13 +1,12 @@
-import { ConditionalCheckFailedException, DynamoDBClient } from '@aws-sdk/client-dynamodb'
+import { ConditionalCheckFailedException } from '@aws-sdk/client-dynamodb'
 import { S3Client, GetObjectCommand, PutObjectCommand, DeleteObjectCommand } from '@aws-sdk/client-s3'
-import { DynamoDBDocumentClient, UpdateCommand } from '@aws-sdk/lib-dynamodb'
+import { UpdateCommand } from '@aws-sdk/lib-dynamodb'
 import type { S3Event } from 'aws-lambda'
 import sharp from 'sharp'
 import { VARIANT_SUFFIXES, toProcessedKey, UPLOAD_PREFIX, type VariantSuffix } from './image-variants'
-import { findIdBySlug } from './recipe-store'
+import { docClient, findIdBySlug } from './recipe-store'
 
 const s3 = new S3Client({})
-const docClient = DynamoDBDocumentClient.from(new DynamoDBClient({}))
 
 interface ImageVariant {
   readonly suffix: VariantSuffix

--- a/lambda/image-resizer.ts
+++ b/lambda/image-resizer.ts
@@ -1,9 +1,10 @@
 import { ConditionalCheckFailedException, DynamoDBClient } from '@aws-sdk/client-dynamodb'
 import { S3Client, GetObjectCommand, PutObjectCommand, DeleteObjectCommand } from '@aws-sdk/client-s3'
-import { DynamoDBDocumentClient, QueryCommand, UpdateCommand } from '@aws-sdk/lib-dynamodb'
+import { DynamoDBDocumentClient, UpdateCommand } from '@aws-sdk/lib-dynamodb'
 import type { S3Event } from 'aws-lambda'
 import sharp from 'sharp'
 import { VARIANT_SUFFIXES, toProcessedKey, UPLOAD_PREFIX, type VariantSuffix } from './image-variants'
+import { findIdBySlug } from './recipe-store'
 
 const s3 = new S3Client({})
 const docClient = DynamoDBDocumentClient.from(new DynamoDBClient({}))
@@ -88,16 +89,7 @@ export async function handler(event: S3Event): Promise<void> {
       continue
     }
 
-    const lookup = await docClient.send(
-      new QueryCommand({
-        TableName: tableName,
-        IndexName: 'slug-index',
-        KeyConditionExpression: 'slug = :slug',
-        ExpressionAttributeValues: { ':slug': slug },
-      }),
-    )
-    const [item] = lookup.Items ?? []
-    const recipeId = (item as { id?: string } | undefined)?.id
+    const recipeId = await findIdBySlug(slug)
     if (!recipeId) {
       logSkip('recipe_not_found')
       continue

--- a/lambda/recipe-handler.ts
+++ b/lambda/recipe-handler.ts
@@ -1,9 +1,10 @@
 import { randomUUID } from 'node:crypto'
 import { ConditionalCheckFailedException, DynamoDBClient } from '@aws-sdk/client-dynamodb'
 import { S3Client, ListObjectsV2Command, DeleteObjectsCommand } from '@aws-sdk/client-s3'
-import { DynamoDBDocumentClient, QueryCommand, GetCommand, PutCommand, UpdateCommand, DeleteCommand, ScanCommand } from '@aws-sdk/lib-dynamodb'
+import { DynamoDBDocumentClient, QueryCommand, PutCommand, UpdateCommand, DeleteCommand, ScanCommand } from '@aws-sdk/lib-dynamodb'
 import type { APIGatewayProxyEventV2, APIGatewayProxyStructuredResultV2 } from 'aws-lambda'
 import { VARIANT_SUFFIXES, PROCESSED_PREFIX } from './image-variants'
+import { getRecipeById, queryRecipeIdsBySlug, STEP_ID_REGEX } from './recipe-store'
 
 const ddbClient = new DynamoDBClient({})
 const docClient = DynamoDBDocumentClient.from(ddbClient)
@@ -68,7 +69,6 @@ const SLUG_LOCKED_RESPONSE = {
 } as const
 
 const SLUG_REGEX = /^[a-z0-9](?:[a-z0-9-]*[a-z0-9])?$/
-const STEP_ID_REGEX = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i
 
 export function isValidSlug(slug: string): boolean {
   if (slug.length < 1 || slug.length > 100) return false
@@ -78,16 +78,9 @@ export function isValidSlug(slug: string): boolean {
 }
 
 export async function slugExists(slug: string, excludeId?: string): Promise<boolean> {
-  const result = await docClient.send(
-    new QueryCommand({
-      TableName: TABLE_NAME,
-      IndexName: 'slug-index',
-      KeyConditionExpression: 'slug = :slug',
-      ExpressionAttributeValues: { ':slug': slug },
-    }),
-  )
-  if (!result.Items || result.Items.length === 0) return false
-  if (excludeId) return result.Items.some((i) => (i as { id: string }).id !== excludeId)
+  const ids = await queryRecipeIdsBySlug(slug)
+  if (ids.length === 0) return false
+  if (excludeId) return ids.some((id) => id !== excludeId)
   return true
 }
 
@@ -729,11 +722,6 @@ async function handleDeleteRecipe(event: APIGatewayProxyEventV2): Promise<APIGat
   await docClient.send(new DeleteCommand({ TableName: TABLE_NAME, Key: { id } }))
 
   return json(200, { message: 'Recipe deleted successfully' })
-}
-
-async function getRecipeById(id: string): Promise<Record<string, unknown> | undefined> {
-  const result = await docClient.send(new GetCommand({ TableName: TABLE_NAME, Key: { id } }))
-  return result.Item as Record<string, unknown> | undefined
 }
 
 function isOwnerOrAdmin(authorId: string, currentUserId: string, event: APIGatewayProxyEventV2): boolean {

--- a/lambda/recipe-handler.ts
+++ b/lambda/recipe-handler.ts
@@ -1,13 +1,11 @@
 import { randomUUID } from 'node:crypto'
-import { ConditionalCheckFailedException, DynamoDBClient } from '@aws-sdk/client-dynamodb'
+import { ConditionalCheckFailedException } from '@aws-sdk/client-dynamodb'
 import { S3Client, ListObjectsV2Command, DeleteObjectsCommand } from '@aws-sdk/client-s3'
-import { DynamoDBDocumentClient, QueryCommand, PutCommand, UpdateCommand, DeleteCommand, ScanCommand } from '@aws-sdk/lib-dynamodb'
+import { QueryCommand, PutCommand, UpdateCommand, DeleteCommand, ScanCommand } from '@aws-sdk/lib-dynamodb'
 import type { APIGatewayProxyEventV2, APIGatewayProxyStructuredResultV2 } from 'aws-lambda'
 import { VARIANT_SUFFIXES, PROCESSED_PREFIX } from './image-variants'
-import { getRecipeById, queryRecipeIdsBySlug, STEP_ID_REGEX } from './recipe-store'
+import { docClient, getRecipeById, isValidStepId, queryRecipeIdsBySlug } from './recipe-store'
 
-const ddbClient = new DynamoDBClient({})
-const docClient = DynamoDBDocumentClient.from(ddbClient)
 const s3Client = new S3Client({})
 
 const TABLE_NAME = process.env.TABLE_NAME ?? ''
@@ -424,7 +422,7 @@ async function handleUpdateRecipe(event: APIGatewayProxyEventV2): Promise<APIGat
     const seenStepIds = new Set<string>()
     for (const step of updates.steps as Array<Record<string, unknown>>) {
       const stepId = step.stepId
-      if (typeof stepId !== 'string' || !STEP_ID_REGEX.test(stepId)) {
+      if (typeof stepId !== 'string' || !isValidStepId(stepId)) {
         return json(400, { error: 'invalid_stepId' })
       }
       if (seenStepIds.has(stepId)) {

--- a/lambda/recipe-image-handler.ts
+++ b/lambda/recipe-image-handler.ts
@@ -1,17 +1,11 @@
-import { DynamoDBClient } from '@aws-sdk/client-dynamodb'
 import { S3Client, PutObjectCommand } from '@aws-sdk/client-s3'
-import { DynamoDBDocumentClient, GetCommand } from '@aws-sdk/lib-dynamodb'
 import { getSignedUrl } from '@aws-sdk/s3-request-presigner'
 import type { APIGatewayProxyEventV2, APIGatewayProxyStructuredResultV2 } from 'aws-lambda'
 import { UPLOAD_PREFIX } from './image-variants'
+import { getRecipeById, isValidStepId } from './recipe-store'
 
 const s3 = new S3Client({})
-const ddbClient = new DynamoDBClient({})
-const docClient = DynamoDBDocumentClient.from(ddbClient)
 const IMAGE_BUCKET_NAME = process.env.IMAGE_BUCKET_NAME ?? ''
-const TABLE_NAME = process.env.TABLE_NAME ?? ''
-
-const UUID_REGEX = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i
 
 function json(statusCode: number, body: Record<string, unknown>): APIGatewayProxyStructuredResultV2 {
   return { statusCode, headers: { 'Content-Type': 'application/json' }, body: JSON.stringify(body) }
@@ -39,10 +33,6 @@ interface UploadUrlBody {
   readonly stepId?: string
 }
 
-interface RecipeStep {
-  readonly stepId?: string
-}
-
 export async function handler(event: APIGatewayProxyEventV2): Promise<APIGatewayProxyStructuredResultV2> {
   try {
     switch (event.routeKey) {
@@ -66,19 +56,19 @@ async function handleUploadUrl(event: APIGatewayProxyEventV2): Promise<APIGatewa
   // Step uploads must validate stepId BEFORE issuing the GetItem — saves a DDB read on a clearly-bad request.
   if (imageType !== 'cover') {
     if (!stepId) return json(400, { error: 'stepId is required for step images' })
-    if (!UUID_REGEX.test(stepId)) return json(400, { error: 'invalid_stepId' })
+    if (!isValidStepId(stepId)) return json(400, { error: 'invalid_stepId' })
   }
 
-  const recipe = await docClient.send(new GetCommand({ TableName: TABLE_NAME, Key: { id: recipeId } }))
-  if (!recipe.Item) return json(404, { error: 'Recipe not found' })
+  const recipe = await getRecipeById(recipeId)
+  if (!recipe) return json(404, { error: 'Recipe not found' })
 
-  const slug = recipe.Item.slug as string
+  const slug = recipe.slug
 
   let uploadKey: string
   if (imageType === 'cover') {
     uploadKey = `${UPLOAD_PREFIX}${slug}/cover`
   } else {
-    const steps = (recipe.Item.steps as RecipeStep[] | undefined) ?? []
+    const steps = recipe.steps ?? []
     if (!steps.some((s) => s.stepId === stepId)) return json(404, { error: 'step_not_found' })
     uploadKey = `${UPLOAD_PREFIX}${slug}/step-${stepId}`
   }

--- a/lambda/recipe-store.ts
+++ b/lambda/recipe-store.ts
@@ -1,12 +1,12 @@
 import { DynamoDBClient } from '@aws-sdk/client-dynamodb'
 import { DynamoDBDocumentClient, GetCommand, QueryCommand } from '@aws-sdk/lib-dynamodb'
 
-const docClient = DynamoDBDocumentClient.from(new DynamoDBClient({}))
+export const docClient = DynamoDBDocumentClient.from(new DynamoDBClient({}))
 const TABLE_NAME = process.env.TABLE_NAME ?? ''
 
 export const SLUG_INDEX_NAME = 'slug-index'
 
-export const STEP_ID_REGEX = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i
+const STEP_ID_REGEX = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i
 
 export function isValidStepId(stepId: string): boolean {
   return STEP_ID_REGEX.test(stepId)
@@ -20,7 +20,6 @@ export interface Recipe extends Record<string, unknown> {
   readonly id?: string
   readonly slug?: string
   readonly steps?: readonly RecipeStep[]
-  readonly imageStatus?: Record<string, number>
 }
 
 export async function getRecipeById(id: string): Promise<Recipe | undefined> {

--- a/lambda/recipe-store.ts
+++ b/lambda/recipe-store.ts
@@ -1,0 +1,49 @@
+import { DynamoDBClient } from '@aws-sdk/client-dynamodb'
+import { DynamoDBDocumentClient, GetCommand, QueryCommand } from '@aws-sdk/lib-dynamodb'
+
+const docClient = DynamoDBDocumentClient.from(new DynamoDBClient({}))
+const TABLE_NAME = process.env.TABLE_NAME ?? ''
+
+export const SLUG_INDEX_NAME = 'slug-index'
+
+export const STEP_ID_REGEX = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i
+
+export function isValidStepId(stepId: string): boolean {
+  return STEP_ID_REGEX.test(stepId)
+}
+
+export interface RecipeStep {
+  readonly stepId?: string
+}
+
+export interface Recipe extends Record<string, unknown> {
+  readonly id?: string
+  readonly slug?: string
+  readonly steps?: readonly RecipeStep[]
+  readonly imageStatus?: Record<string, number>
+}
+
+export async function getRecipeById(id: string): Promise<Recipe | undefined> {
+  const result = await docClient.send(new GetCommand({ TableName: TABLE_NAME, Key: { id } }))
+  return result.Item as Recipe | undefined
+}
+
+// Returns the id of every recipe row matching the slug. The slug-index GSI tolerates
+// transient duplicate-slug rows, so callers that need exclude-self semantics inspect
+// the full list rather than the first hit.
+export async function queryRecipeIdsBySlug(slug: string): Promise<(string | undefined)[]> {
+  const result = await docClient.send(
+    new QueryCommand({
+      TableName: TABLE_NAME,
+      IndexName: SLUG_INDEX_NAME,
+      KeyConditionExpression: 'slug = :slug',
+      ExpressionAttributeValues: { ':slug': slug },
+    }),
+  )
+  return (result.Items ?? []).map((item) => (item as { id?: string }).id)
+}
+
+export async function findIdBySlug(slug: string): Promise<string | undefined> {
+  const [id] = await queryRecipeIdsBySlug(slug)
+  return id
+}


### PR DESCRIPTION
Closes #159

## What changed
Extracted a shared `lambda/recipe-store.ts` that owns the recipe read path and the DynamoDB document client, and rewired all three recipe Lambdas to use it:

- `getRecipeById(id)` — the by-id `GetCommand` lookup (was duplicated in recipe-handler + inline in recipe-image-handler).
- `queryRecipeIdsBySlug(slug)` / `findIdBySlug(slug)` — the `slug-index` GSI lookup (was inline in recipe-handler's `slugExists` and image-resizer).
- `SLUG_INDEX_NAME`, `STEP_ID_REGEX`/`isValidStepId`, and a typed `Recipe`/`RecipeStep` shape.
- The `DynamoDBDocumentClient` singleton is exported and consumed by recipe-handler and image-resizer, so one client/connection pool serves all recipe DynamoDB access.

`recipe-handler`'s `slugExists` is reimplemented on `queryRecipeIdsBySlug`, preserving its `excludeId`-over-the-full-result-set semantics. `recipe-image-handler` drops its `as string` slug cast (now type-safe via `Recipe`) and its duplicate UUID regex.

## Why
Follow-up surfaced by `/simplify` across #149/#150/#151: three Lambdas independently re-implemented the recipe fetch, the slug→id lookup, the `'slug-index'` literal, and the step-id regex. A typo in any one (e.g. the resizer's index name) would have failed silently. This consolidates them into a single source of truth. See the PRD `docs/prds/editable-recipe-slugs.md` and epic #154.

## How to verify
- `pnpm test` (or `./node_modules/.bin/jest test/lambda`) — **208/208 lambda tests pass with no test changes**.
- `./node_modules/.bin/eslint lambda/` — clean.
- `./node_modules/.bin/tsc --noEmit` — no new errors (the pre-existing `sharp` TS2688 baseline is unchanged on this branch and on the epic base).
- Diff is behaviour-preserving: every extracted helper issues the identical DynamoDB command shape as the code it replaced.

## Decisions made
- **Two commits:** the mechanical extraction, then a `/simplify` pass that shared the DDB client and collapsed the `STEP_ID_REGEX`/`isValidStepId` export pair.
- **`slugExists` stays in recipe-handler** (it encodes recipe-handler-specific exclude-self policy); only the `queryRecipeIdsBySlug` mechanism moved to the store.
- **`findIdBySlug` kept** as an intent-revealing wrapper over `queryRecipeIdsBySlug` despite being one line — it's the resizer's public entry point.
- **`SLUG_INDEX_NAME` is exported** per the issue AC even though current consumers reach it only through the query helpers.
- **image-resizer keeps its handler-entry `TABLE_NAME` throw** — a test asserts it throws before the source object is deleted; the shared module captures `TABLE_NAME` with the same `?? ''` convention used elsewhere in the codebase. The minor env-var-validation split this creates was considered and left as-is to keep the diff mechanical and consistent with existing handlers.
- `lib/recipe-stack.ts` keeps `'slug-index'` inline — sharing the constant across the CDK/Lambda boundary is explicitly out of scope per the issue.

## Out of scope (filed as follow-up issues)
- **#166** — Have `recipe-store` own *all* recipe DynamoDB access (extract `putRecipe`/`updateRecipe`/`queryByStatus` write helpers and widen the typed `Recipe`). Deferred because it spans ~10 call sites in recipe-handler and deserves its own review; this PR intentionally extracts only the read path.