### PR TITLE
Drop CCFE re-read in PATCH /recipes/{id} via ReturnValuesOnConditionCheckFailure

### DIFF
--- a/lambda/recipe-handler.ts
+++ b/lambda/recipe-handler.ts
@@ -2,6 +2,7 @@ import { randomUUID } from 'node:crypto'
 import { ConditionalCheckFailedException } from '@aws-sdk/client-dynamodb'
 import { S3Client, ListObjectsV2Command, DeleteObjectsCommand } from '@aws-sdk/client-s3'
 import { QueryCommand, PutCommand, UpdateCommand, DeleteCommand, ScanCommand } from '@aws-sdk/lib-dynamodb'
+import { unmarshall } from '@aws-sdk/util-dynamodb'
 import type { APIGatewayProxyEventV2, APIGatewayProxyStructuredResultV2 } from 'aws-lambda'
 import { VARIANT_SUFFIXES, PROCESSED_PREFIX } from './image-variants'
 import { docClient, getRecipeById, isValidStepId, queryRecipeIdsBySlug } from './recipe-store'
@@ -506,12 +507,17 @@ async function handleUpdateRecipe(event: APIGatewayProxyEventV2): Promise<APIGat
         ExpressionAttributeValues: expressionValues,
         ConditionExpression: conditionExpression,
         ReturnValues: 'ALL_OLD',
+        ReturnValuesOnConditionCheckFailure: slugChanging ? 'ALL_OLD' : undefined,
       }),
     )
   } catch (err) {
     if (err instanceof ConditionalCheckFailedException || (err as { name?: string }).name === 'ConditionalCheckFailedException') {
-      const reRead = await getRecipeById(id)
-      if (reRead && Object.keys(imageStatusOf(reRead)).length > 0) {
+      // The CCFE carries the atomic snapshot under err.Item, but lib-dynamodb only
+      // unmarshalls success outputs — a thrown exception's Item stays in raw
+      // AttributeValue form, so unmarshall it before reading imageStatus.
+      const marshalled = (err as ConditionalCheckFailedException).Item
+      const current: Record<string, unknown> | undefined = marshalled ? unmarshall(marshalled) : undefined
+      if (current && Object.keys(imageStatusOf(current)).length > 0) {
         return json(409, SLUG_LOCKED_RESPONSE)
       }
       return json(409, { error: 'conflict', message: 'Recipe was modified by another request. Please retry.' })

--- a/test/lambda/recipe-handler.test.ts
+++ b/test/lambda/recipe-handler.test.ts
@@ -1,6 +1,7 @@
 import { ConditionalCheckFailedException } from '@aws-sdk/client-dynamodb'
 import { S3Client, ListObjectsV2Command, DeleteObjectsCommand } from '@aws-sdk/client-s3'
 import { DynamoDBDocumentClient, QueryCommand, GetCommand, PutCommand, UpdateCommand, DeleteCommand, ScanCommand } from '@aws-sdk/lib-dynamodb'
+import { marshall } from '@aws-sdk/util-dynamodb'
 import type { APIGatewayProxyEventV2 } from 'aws-lambda'
 import { mockClient } from 'aws-sdk-client-mock'
 
@@ -1545,27 +1546,26 @@ describe('Recipe Lambda handler', () => {
       expect(expectedOldSlugValue).toBe('old-slug')
     })
 
-    it('maps ConditionalCheckFailedException to 409 slug_locked when re-read shows imageStatus has been populated', async () => {
+    it('maps ConditionalCheckFailedException to 409 slug_locked when the atomic snapshot shows imageStatus has been populated', async () => {
       const oldItem = publishedRecipeItem({
         id: 'recipe-uuid-1',
         slug: 'old-slug',
         authorId: 'contributor-user-id',
         imageStatus: {},
       })
-      const reReadItem = {
+      // The race-loss snapshot rides on err.Item as raw, marshalled AttributeValues —
+      // lib-dynamodb does not unmarshall a thrown exception's Item, so the handler must.
+      const atomicSnapshot = {
         ...oldItem,
         imageStatus: { 'recipes/old-slug/cover': 1_745_000_000_000 },
       }
-      // First Get is the pre-read; second Get is the re-read after the conditional failure.
-      ddbMock
-        .on(GetCommand)
-        .resolvesOnce({ Item: oldItem })
-        .resolvesOnce({ Item: reReadItem })
+      ddbMock.on(GetCommand).resolves({ Item: oldItem })
       ddbMock.on(QueryCommand).resolves({ Items: [] })
       ddbMock.on(UpdateCommand).rejects(
         new ConditionalCheckFailedException({
           $metadata: {},
           message: 'The conditional request failed',
+          Item: marshall(atomicSnapshot),
         }),
       )
 
@@ -1582,24 +1582,56 @@ describe('Recipe Lambda handler', () => {
       expect(result.statusCode).toBe(409)
       const body = JSON.parse(result.body as string)
       expect(body.error).toBe('slug_locked')
+      // Race-loss path must not issue a second Get — only the pre-read.
+      expect(ddbMock.commandCalls(GetCommand)).toHaveLength(1)
     })
 
-    it('maps ConditionalCheckFailedException to 409 conflict when re-read shows the slug changed underneath', async () => {
+    it('maps ConditionalCheckFailedException to 409 conflict when the atomic snapshot shows the slug changed underneath', async () => {
       const oldItem = publishedRecipeItem({
         id: 'recipe-uuid-1',
         slug: 'old-slug',
         authorId: 'contributor-user-id',
         imageStatus: {},
       })
-      const reReadItem = {
+      const atomicSnapshot = {
         ...oldItem,
         slug: 'someone-else-changed-it',
         imageStatus: {},
       }
-      ddbMock
-        .on(GetCommand)
-        .resolvesOnce({ Item: oldItem })
-        .resolvesOnce({ Item: reReadItem })
+      ddbMock.on(GetCommand).resolves({ Item: oldItem })
+      ddbMock.on(QueryCommand).resolves({ Items: [] })
+      ddbMock.on(UpdateCommand).rejects(
+        new ConditionalCheckFailedException({
+          $metadata: {},
+          message: 'The conditional request failed',
+          Item: marshall(atomicSnapshot),
+        }),
+      )
+
+      const event = makeEvent({
+        routeKey: 'PATCH /recipes/{id}',
+        rawPath: '/recipes/recipe-uuid-1',
+        pathParameters: { id: 'recipe-uuid-1' },
+        headers: { authorization: `Bearer ${contributorToken}` },
+        body: JSON.stringify({ slug: 'new-slug' }),
+      })
+
+      const result = await handler(event)
+
+      expect(result.statusCode).toBe(409)
+      const body = JSON.parse(result.body as string)
+      expect(body.error).toBe('conflict')
+      expect(ddbMock.commandCalls(GetCommand)).toHaveLength(1)
+    })
+
+    it('falls back to 409 conflict when the conditional failure carries no Item snapshot', async () => {
+      const oldItem = publishedRecipeItem({
+        id: 'recipe-uuid-1',
+        slug: 'old-slug',
+        authorId: 'contributor-user-id',
+        imageStatus: {},
+      })
+      ddbMock.on(GetCommand).resolves({ Item: oldItem })
       ddbMock.on(QueryCommand).resolves({ Items: [] })
       ddbMock.on(UpdateCommand).rejects(
         new ConditionalCheckFailedException({
@@ -1621,6 +1653,7 @@ describe('Recipe Lambda handler', () => {
       expect(result.statusCode).toBe(409)
       const body = JSON.parse(result.body as string)
       expect(body.error).toBe('conflict')
+      expect(ddbMock.commandCalls(GetCommand)).toHaveLength(1)
     })
 
     it('does NOT add a ConditionExpression when slug is omitted from the patch body', async () => {


### PR DESCRIPTION
Closes #158

## What changed
On the slug-changing PATCH `/recipes/{id}` conditional write, pass `ReturnValuesOnConditionCheckFailure: 'ALL_OLD'` so the lost-race snapshot rides on the thrown `ConditionalCheckFailedException`, and drop the follow-up `getRecipeById(id)` re-read in the catch block. The catch now derives `slug_locked` vs `conflict` from `err.Item`.

## Why
- **Correctness:** `err.Item` is the atomic snapshot from the exact moment the condition failed, closing the small TOCTOU window the separate re-read left open (another writer could change state between the failed write and the re-read).
- **Efficiency:** the race-loss path drops from 2 reads + 1 failed write to 1 failed write.

See issue #158 and epic #154.

## Heads-up for the reviewer (corrected premise)
The issue assumed `lib-dynamodb` auto-unmarshalls `err.Item`. It does **not** for the installed `@aws-sdk/lib-dynamodb@3.1027.0` — the document-unmarshalling middleware only runs on the **success** output:
```js
const deserialized = await next(args);                    // throws here on CCFE
deserialized.output = unmarshallOutput(deserialized.output, ...);  // never reached
```
So a thrown exception's `Item` stays in raw `AttributeValue` form. Implementing it literally would pass tests (mocks use plain objects) but return `slug_locked` on every race-loss in production (`imageStatus` stays wrapped as `{ M: {...} }`, so `Object.keys(...).length` is always ≥ 1). The handler therefore unmarshalls `err.Item` explicitly via `@aws-sdk/util-dynamodb` `unmarshall()` (a declared dep, bundled by esbuild). Issue AC#2 was reworded to match.

## How to verify
- `pnpm test` — 209/209 lambda tests pass. The three CCFE tests now mock `err.Item` as **marshalled** (`marshall(snapshot)`) AttributeValues to stay faithful to production, and assert `commandCalls(GetCommand)` is `1` (pre-read only, no re-read).
- Regression guard: the `conflict` test (empty `imageStatus`, marshalled to `{ M: {} }`) fails-closed if the `unmarshall()` call is ever dropped — it would return `slug_locked` instead of `conflict`.
- `pnpm lint`, `pnpm exec tsc --noEmit` — clean, no new errors.

## Decisions made
- `ReturnValuesOnConditionCheckFailure` is set only when `slugChanging` (the only path with a `ConditionExpression`, so the only path a CCFE can fire); `undefined` otherwise is a no-op.
- Added a third test covering the `err.Item === undefined` defence-in-depth fallback → `409 conflict` (e.g. the `attribute_exists(id)` failure where DynamoDB returns no `Item`).
- Reviewed a NIT (the `slug_locked` test doesn't *independently* exercise the unmarshall path) and left it: the handler doesn't use `imageStatus` values downstream, so there's nothing extra to assert, and the `conflict` test already fails-closed on a dropped unmarshall.

## Out of scope
- Any other use of `ReturnValuesOnConditionCheckFailure` in the codebase.