### PR TITLE
recipe-store: own all recipe DynamoDB access (extract write helpers)

### DIFF
--- a/lambda/recipe-handler.ts
+++ b/lambda/recipe-handler.ts
@@ -1,15 +1,23 @@
 import { randomUUID } from 'node:crypto'
 import { ConditionalCheckFailedException } from '@aws-sdk/client-dynamodb'
 import { S3Client, ListObjectsV2Command, DeleteObjectsCommand } from '@aws-sdk/client-s3'
-import { QueryCommand, PutCommand, UpdateCommand, DeleteCommand, ScanCommand } from '@aws-sdk/lib-dynamodb'
 import { unmarshall } from '@aws-sdk/util-dynamodb'
 import type { APIGatewayProxyEventV2, APIGatewayProxyStructuredResultV2 } from 'aws-lambda'
 import { VARIANT_SUFFIXES, PROCESSED_PREFIX } from './image-variants'
-import { docClient, getRecipeById, isValidStepId, queryRecipeIdsBySlug } from './recipe-store'
+import {
+  getRecipeById,
+  isValidStepId,
+  queryRecipeIdsBySlug,
+  queryRecipesByStatus,
+  queryRecipesByAuthor,
+  scanRecipes,
+  putRecipe,
+  updateRecipe,
+  deleteRecipe,
+} from './recipe-store'
 
 const s3Client = new S3Client({})
 
-const TABLE_NAME = process.env.TABLE_NAME ?? ''
 const IMAGE_BUCKET_NAME = process.env.IMAGE_BUCKET_NAME ?? ''
 const DRAFT_TTL_SECONDS = 30 * 24 * 60 * 60
 
@@ -188,18 +196,15 @@ export async function handler(event: APIGatewayProxyEventV2): Promise<APIGateway
 }
 
 async function handleListTags(): Promise<APIGatewayProxyStructuredResultV2> {
-  const result = await docClient.send(
-    new ScanCommand({
-      TableName: TABLE_NAME,
-      FilterExpression: '#status = :status',
-      ExpressionAttributeNames: { '#status': 'status' },
-      ExpressionAttributeValues: { ':status': PUBLISHED },
-      ProjectionExpression: 'tags',
-    }),
-  )
+  const items = await scanRecipes({
+    FilterExpression: '#status = :status',
+    ExpressionAttributeNames: { '#status': 'status' },
+    ExpressionAttributeValues: { ':status': PUBLISHED },
+    ProjectionExpression: 'tags',
+  })
 
   const countMap: Record<string, number> = {}
-  for (const item of result.Items ?? []) {
+  for (const item of items) {
     const tags = tagsToArray(item.tags)
     for (const tag of tags) {
       countMap[tag] = (countMap[tag] ?? 0) + 1
@@ -213,23 +218,10 @@ async function handleListTags(): Promise<APIGatewayProxyStructuredResultV2> {
   return json(200, sorted)
 }
 
-function queryRecipesByStatus(status: RecipeStatus) {
-  return docClient.send(
-    new QueryCommand({
-      TableName: TABLE_NAME,
-      IndexName: 'status-createdAt-index',
-      KeyConditionExpression: '#status = :status',
-      ExpressionAttributeNames: { '#status': 'status' },
-      ExpressionAttributeValues: { ':status': status },
-      ScanIndexForward: false,
-    }),
-  )
-}
-
 async function handleListPublished(): Promise<APIGatewayProxyStructuredResultV2> {
-  const result = await queryRecipesByStatus(PUBLISHED)
+  const items = await queryRecipesByStatus(PUBLISHED)
 
-  const recipes = (result.Items ?? []).map((item) => lightweightRecipe(item as Record<string, unknown>))
+  const recipes = items.map((item) => lightweightRecipe(item))
   return json(200, recipes)
 }
 
@@ -237,10 +229,10 @@ async function handleListForAdmin(event: APIGatewayProxyEventV2): Promise<APIGat
   if (!decodeJwt(event)) return json(401, { error: 'Unauthorised' })
   if (!isAdmin(event)) return json(403, { error: 'Forbidden' })
 
-  const [publishedResult, draftResult] = await Promise.all([queryRecipesByStatus(PUBLISHED), queryRecipesByStatus(DRAFT)])
+  const [published, drafts] = await Promise.all([queryRecipesByStatus(PUBLISHED), queryRecipesByStatus(DRAFT)])
 
   const nowSeconds = Math.floor(Date.now() / 1000)
-  const merged = [...(publishedResult.Items ?? []), ...(draftResult.Items ?? [])] as Record<string, unknown>[]
+  const merged = [...published, ...drafts]
   const live = merged.filter((item) => typeof item.ttl !== 'number' || item.ttl > nowSeconds)
 
   return json(200, live.map(lightweightAdminRecipe))
@@ -263,19 +255,16 @@ async function handleGetBySlug(event: APIGatewayProxyEventV2): Promise<APIGatewa
   const slug = event.pathParameters?.slug
   if (!slug) return json(400, { error: 'slug is required' })
 
-  const result = await docClient.send(
-    new ScanCommand({
-      TableName: TABLE_NAME,
-      FilterExpression: 'slug = :slug',
-      ExpressionAttributeValues: { ':slug': slug },
-    }),
-  )
+  const items = await scanRecipes({
+    FilterExpression: 'slug = :slug',
+    ExpressionAttributeValues: { ':slug': slug },
+  })
 
-  if (!result.Items || result.Items.length === 0) {
+  if (items.length === 0) {
     return json(404, { error: 'Recipe not found' })
   }
 
-  const recipe = result.Items[0] as Record<string, unknown>
+  const recipe = items[0]
   if (recipe.status !== PUBLISHED) {
     return json(404, { error: 'Recipe not found' })
   }
@@ -287,17 +276,9 @@ async function handleListUserRecipes(event: APIGatewayProxyEventV2): Promise<API
   const payload = decodeJwt(event)
   if (!payload) return json(401, { error: 'Unauthorised' })
 
-  const result = await docClient.send(
-    new QueryCommand({
-      TableName: TABLE_NAME,
-      IndexName: 'authorId-createdAt-index',
-      KeyConditionExpression: 'authorId = :authorId',
-      ExpressionAttributeValues: { ':authorId': payload.sub },
-      ScanIndexForward: false,
-    }),
-  )
+  const items = await queryRecipesByAuthor(payload.sub)
 
-  const recipes = (result.Items ?? []).map((item) => convertRecipeTags(item as Record<string, unknown>))
+  const recipes = items.map((item) => convertRecipeTags(item))
   return json(200, recipes)
 }
 
@@ -340,7 +321,7 @@ async function handleCreateDraft(event: APIGatewayProxyEventV2): Promise<APIGate
     updatedAt: now,
   }
 
-  await docClient.send(new PutCommand({ TableName: TABLE_NAME, Item: item }))
+  await putRecipe(item)
 
   return json(201, { id, slug })
 }
@@ -498,18 +479,15 @@ async function handleUpdateRecipe(event: APIGatewayProxyEventV2): Promise<APIGat
 
   let updateResult
   try {
-    updateResult = await docClient.send(
-      new UpdateCommand({
-        TableName: TABLE_NAME,
-        Key: { id },
-        UpdateExpression: updateExpression,
-        ExpressionAttributeNames: expressionNames,
-        ExpressionAttributeValues: expressionValues,
-        ConditionExpression: conditionExpression,
-        ReturnValues: 'ALL_OLD',
-        ReturnValuesOnConditionCheckFailure: slugChanging ? 'ALL_OLD' : undefined,
-      }),
-    )
+    updateResult = await updateRecipe({
+      Key: { id },
+      UpdateExpression: updateExpression,
+      ExpressionAttributeNames: expressionNames,
+      ExpressionAttributeValues: expressionValues,
+      ConditionExpression: conditionExpression,
+      ReturnValues: 'ALL_OLD',
+      ReturnValuesOnConditionCheckFailure: slugChanging ? 'ALL_OLD' : undefined,
+    })
   } catch (err) {
     if (err instanceof ConditionalCheckFailedException || (err as { name?: string }).name === 'ConditionalCheckFailedException') {
       // The CCFE carries the atomic snapshot under err.Item, but lib-dynamodb only
@@ -643,16 +621,13 @@ async function handlePublish(event: APIGatewayProxyEventV2): Promise<APIGatewayP
   }
 
   const now = new Date().toISOString()
-  const result = await docClient.send(
-    new UpdateCommand({
-      TableName: TABLE_NAME,
-      Key: { id },
-      UpdateExpression: 'SET #status = :status, #updatedAt = :updatedAt REMOVE #ttl',
-      ExpressionAttributeNames: { '#status': 'status', '#updatedAt': 'updatedAt', '#ttl': 'ttl' },
-      ExpressionAttributeValues: { ':status': PUBLISHED, ':updatedAt': now },
-      ReturnValues: 'ALL_NEW',
-    }),
-  )
+  const result = await updateRecipe({
+    Key: { id },
+    UpdateExpression: 'SET #status = :status, #updatedAt = :updatedAt REMOVE #ttl',
+    ExpressionAttributeNames: { '#status': 'status', '#updatedAt': 'updatedAt', '#ttl': 'ttl' },
+    ExpressionAttributeValues: { ':status': PUBLISHED, ':updatedAt': now },
+    ReturnValues: 'ALL_NEW',
+  })
 
   return json(200, convertRecipeTags(result.Attributes as Record<string, unknown>))
 }
@@ -674,16 +649,13 @@ async function handleUnpublish(event: APIGatewayProxyEventV2): Promise<APIGatewa
 
   const now = new Date().toISOString()
   const ttl = Math.floor(Date.now() / 1000) + DRAFT_TTL_SECONDS
-  const result = await docClient.send(
-    new UpdateCommand({
-      TableName: TABLE_NAME,
-      Key: { id },
-      UpdateExpression: 'SET #status = :status, #updatedAt = :updatedAt, #ttl = :ttl',
-      ExpressionAttributeNames: { '#status': 'status', '#updatedAt': 'updatedAt', '#ttl': 'ttl' },
-      ExpressionAttributeValues: { ':status': DRAFT, ':updatedAt': now, ':ttl': ttl },
-      ReturnValues: 'ALL_NEW',
-    }),
-  )
+  const result = await updateRecipe({
+    Key: { id },
+    UpdateExpression: 'SET #status = :status, #updatedAt = :updatedAt, #ttl = :ttl',
+    ExpressionAttributeNames: { '#status': 'status', '#updatedAt': 'updatedAt', '#ttl': 'ttl' },
+    ExpressionAttributeValues: { ':status': DRAFT, ':updatedAt': now, ':ttl': ttl },
+    ReturnValues: 'ALL_NEW',
+  })
 
   return json(200, convertRecipeTags(result.Attributes as Record<string, unknown>))
 }
@@ -723,7 +695,7 @@ async function handleDeleteRecipe(event: APIGatewayProxyEventV2): Promise<APIGat
     }
   }
 
-  await docClient.send(new DeleteCommand({ TableName: TABLE_NAME, Key: { id } }))
+  await deleteRecipe(id)
 
   return json(200, { message: 'Recipe deleted successfully' })
 }

--- a/lambda/recipe-store.ts
+++ b/lambda/recipe-store.ts
@@ -1,10 +1,23 @@
 import { DynamoDBClient } from '@aws-sdk/client-dynamodb'
-import { DynamoDBDocumentClient, GetCommand, QueryCommand } from '@aws-sdk/lib-dynamodb'
+import {
+  DynamoDBDocumentClient,
+  GetCommand,
+  QueryCommand,
+  PutCommand,
+  UpdateCommand,
+  DeleteCommand,
+  ScanCommand,
+  type UpdateCommandInput,
+  type UpdateCommandOutput,
+  type ScanCommandInput,
+} from '@aws-sdk/lib-dynamodb'
 
 export const docClient = DynamoDBDocumentClient.from(new DynamoDBClient({}))
 const TABLE_NAME = process.env.TABLE_NAME ?? ''
 
 export const SLUG_INDEX_NAME = 'slug-index'
+const STATUS_INDEX_NAME = 'status-createdAt-index'
+const AUTHOR_INDEX_NAME = 'authorId-createdAt-index'
 
 const STEP_ID_REGEX = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i
 
@@ -19,6 +32,10 @@ export interface RecipeStep {
 export interface Recipe extends Record<string, unknown> {
   readonly id?: string
   readonly slug?: string
+  readonly status?: string
+  readonly authorId?: string
+  readonly ttl?: number
+  readonly imageStatus?: Record<string, number>
   readonly steps?: readonly RecipeStep[]
 }
 
@@ -45,4 +62,50 @@ export async function queryRecipeIdsBySlug(slug: string): Promise<(string | unde
 export async function findIdBySlug(slug: string): Promise<string | undefined> {
   const [id] = await queryRecipeIdsBySlug(slug)
   return id
+}
+
+export async function queryRecipesByStatus(status: string): Promise<Recipe[]> {
+  const result = await docClient.send(
+    new QueryCommand({
+      TableName: TABLE_NAME,
+      IndexName: STATUS_INDEX_NAME,
+      KeyConditionExpression: '#status = :status',
+      ExpressionAttributeNames: { '#status': 'status' },
+      ExpressionAttributeValues: { ':status': status },
+      ScanIndexForward: false,
+    }),
+  )
+  return (result.Items ?? []) as Recipe[]
+}
+
+export async function queryRecipesByAuthor(authorId: string): Promise<Recipe[]> {
+  const result = await docClient.send(
+    new QueryCommand({
+      TableName: TABLE_NAME,
+      IndexName: AUTHOR_INDEX_NAME,
+      KeyConditionExpression: 'authorId = :authorId',
+      ExpressionAttributeValues: { ':authorId': authorId },
+      ScanIndexForward: false,
+    }),
+  )
+  return (result.Items ?? []) as Recipe[]
+}
+
+export async function scanRecipes(input: Omit<ScanCommandInput, 'TableName'>): Promise<Recipe[]> {
+  const result = await docClient.send(new ScanCommand({ TableName: TABLE_NAME, ...input }))
+  return (result.Items ?? []) as Recipe[]
+}
+
+export async function putRecipe(item: Record<string, unknown>): Promise<void> {
+  await docClient.send(new PutCommand({ TableName: TABLE_NAME, Item: item }))
+}
+
+export async function deleteRecipe(id: string): Promise<void> {
+  await docClient.send(new DeleteCommand({ TableName: TABLE_NAME, Key: { id } }))
+}
+
+// Update seam: owns the table name and client; callers supply the rest of the
+// UpdateCommand input (Key, expressions, ReturnValues, condition handling).
+export function updateRecipe(input: Omit<UpdateCommandInput, 'TableName'>): Promise<UpdateCommandOutput> {
+  return docClient.send(new UpdateCommand({ TableName: TABLE_NAME, ...input }))
 }


### PR DESCRIPTION
Closes #166

## What changed
Moved every remaining inline DynamoDB command out of `recipe-handler.ts` and behind typed helpers in `recipe-store.ts`, so the store is now the single seam for all recipe persistence. New store helpers:

- `putRecipe(item)`, `deleteRecipe(id)`
- `updateRecipe(input)` — generic update seam (owns `TableName`; callers pass `Key`/expressions/`ReturnValues`/condition handling). Used by the PATCH conditional write and publish/unpublish.
- `queryRecipesByStatus(status)` / `queryRecipesByAuthor(authorId)` — own the GSI names `status-createdAt-index` / `authorId-createdAt-index` (now module-level consts, like `SLUG_INDEX_NAME`), return `Recipe[]`.
- `scanRecipes(input)` — generic scan seam (tags projection + slug-filter callers).

`recipe-handler.ts` no longer references `docClient`, `TABLE_NAME`, or constructs any `new XCommand`. The shared `Recipe` type was widened with the fields callers read (`status`, `authorId`, `ttl`, `imageStatus`), letting the `as Record<string, unknown>` item casts at the query/scan call sites drop away.

## Why
Follow-up surfaced by `/simplify` during #159: after the read-path extraction, `recipe-handler` still constructed writes inline, so the "shared store" was really a "shared reader". This completes the data-layer ownership — region/retry/projection/GSI-name changes now land in one place, and an index-name typo is impossible (constants, not literals). See epic #154.

## How to verify
- `pnpm test` — **209/209 lambda tests pass with zero test changes** (the behaviour-preservation contract for this refactor).
- `pnpm lint`, `pnpm exec tsc --noEmit` — clean, no new errors.
- Every rewired command is byte-identical to its inline original (same TableName/IndexName/expressions/ReturnValues/condition handling) — the generic helpers inject only `TableName` and spread the caller's input.

## Decisions made
- **`updateRecipe`/`scanRecipes` are generic pass-throughs** (inject `TableName`, spread the rest) rather than semantic helpers like `publishRecipe`. Semantic helpers would reshape the call sites and risk the byte-identical guarantee this PR depends on; the generic seam is the honest minimum that achieves "store owns the client + table name" with no behaviour change. The other helpers (`putRecipe`/`deleteRecipe`/`queryRecipesBy*`) are semantic where the call shape was already stable.
- **GSI name constants** (`STATUS_INDEX_NAME`, `AUTHOR_INDEX_NAME`) kept internal to the store — no external consumer needs them (unlike `SLUG_INDEX_NAME`, which the AC required exporting).
- `existing.authorId as string` (delete handler) kept — `authorId` is `string | undefined` on `Recipe`, so the cast narrows rather than being redundant; removing it cleanly would need a behaviour-affecting `?? ''`.

## Out of scope
- Extracting write helpers for the other Lambdas (image-resizer keeps its own `UpdateCommand`; `docClient` stays exported for it).
- Sharing GSI name constants with `lib/recipe-stack.ts` (CDK/Lambda constant pools kept separate, per the epic's earlier decisions).