### PR TITLE
Image-resizer: delete source last so transient writeback errors can retry

### DIFF
--- a/docs/prds/editable-recipe-slugs.md
+++ b/docs/prds/editable-recipe-slugs.md
@@ -266,6 +266,8 @@ await docClient.send(new UpdateCommand({
 
 `ConditionalCheckFailedException` handling stays — covers the "recipe deleted while image was processing" race.
 
+**Source-delete ordering (durability).** The source object is deleted **last** — only after a successful `imageStatus` writeback or a deliberate, logged skip (`unrecognised_key_shape`, `recipe_not_found`, `recipe_deleted`). It is **not** deleted when the GSI lookup or `UpdateCommand` throws a transient error (throttling, network, IAM): the error propagates, the Lambda retries the S3 event, and because the variant PUTs are idempotent the retry regenerates them and completes the writeback. Deleting the source before the writeback (as an earlier draft did) meant a transient failure left the variants written but `imageStatus` never stamped, with the retry hitting a 404 on the already-deleted source — a permanent, silent "perpetually unprocessed" state. (Issue #161.)
+
 ### Recipe-image-handler changes
 
 ```ts
@@ -403,7 +405,7 @@ ACs are split into automated (Jest + `aws-cdk-lib/assertions` + Lambda unit test
 
 - [ ] `parseRecipeSlug('uploads/recipes/beans-on-toast/cover')` returns `'beans-on-toast'`.
 - [ ] `parseRecipeSlug('uploads/something-else/...')` returns `undefined`.
-- [ ] Resizer **flow order** (asserted via mock-call ordering): write variants → delete source → query GSI → update DDB. The variant PUTs and source delete fire regardless of whether the GSI lookup succeeds.
+- [ ] Resizer **flow order** (asserted via mock-call ordering): write variants → query GSI → update DDB → delete source. The source-delete fires last — after a successful writeback or a deliberate logged skip — but is skipped when the GSI lookup or `UpdateCommand` throws a transient error, leaving the source in place for the Lambda retry (durability, issue #161).
 - [ ] Resizer queries `slug-index` GSI to resolve slug → id; the resulting `id` is used in the `UpdateCommand.Key`.
 - [ ] If no recipe has the slug, the resizer logs `recipe_not_found` and skips the DDB write — variant PUTs and source delete still fire.
 - [ ] Documented edge case (no test required): if a slug is changed between upload-URL request and resizer execution, variants land under the old slug and stay orphaned. Frontend mitigates via pessimistic upload lock (sibling PRD).

--- a/lambda/image-resizer.ts
+++ b/lambda/image-resizer.ts
@@ -78,39 +78,44 @@ export async function handler(event: S3Event): Promise<void> {
     const logSkip = (reason: SkipReason) =>
       console.info({ event: 'resizer.writeback.skipped', reason, key })
 
-    await s3.send(
-      new DeleteObjectCommand({ Bucket: sourceBucket, Key: key }),
-    )
-
+    // Resolve the recipe and stamp imageStatus BEFORE deleting the source. The
+    // variant PUTs above are idempotent, so if the GSI lookup or UpdateCommand
+    // hits a transient error and throws, the source survives and the Lambda retry
+    // can regenerate the variants and complete the writeback. Only deliberate,
+    // logged skips fall through to the source-delete below.
     const slug = parseRecipeSlug(key)
     if (slug === undefined) {
       logSkip('unrecognised_key_shape')
-      continue
-    }
-
-    const recipeId = await findIdBySlug(slug)
-    if (!recipeId) {
-      logSkip('recipe_not_found')
-      continue
-    }
-
-    try {
-      await docClient.send(
-        new UpdateCommand({
-          TableName: tableName,
-          Key: { id: recipeId },
-          UpdateExpression: 'SET imageStatus.#k = :ts',
-          ConditionExpression: 'attribute_exists(id)',
-          ExpressionAttributeNames: { '#k': processedKey },
-          ExpressionAttributeValues: { ':ts': Date.now() },
-        }),
-      )
-    } catch (error) {
-      if (error instanceof ConditionalCheckFailedException) {
-        logSkip('recipe_deleted')
+    } else {
+      const recipeId = await findIdBySlug(slug)
+      if (!recipeId) {
+        logSkip('recipe_not_found')
       } else {
-        throw error
+        try {
+          await docClient.send(
+            new UpdateCommand({
+              TableName: tableName,
+              Key: { id: recipeId },
+              UpdateExpression: 'SET imageStatus.#k = :ts',
+              ConditionExpression: 'attribute_exists(id)',
+              ExpressionAttributeNames: { '#k': processedKey },
+              ExpressionAttributeValues: { ':ts': Date.now() },
+            }),
+          )
+        } catch (error) {
+          if (error instanceof ConditionalCheckFailedException) {
+            logSkip('recipe_deleted')
+          } else {
+            throw error
+          }
+        }
       }
     }
+
+    // Reached only after a successful writeback or a logged skip — never after a
+    // thrown transient error, so the source survives for the retry.
+    await s3.send(
+      new DeleteObjectCommand({ Bucket: sourceBucket, Key: key }),
+    )
   }
 }

--- a/test/lambda/image-resizer.test.ts
+++ b/test/lambda/image-resizer.test.ts
@@ -287,6 +287,26 @@ describe('image-resizer handler', () => {
     infoSpy.mockRestore()
   })
 
+  it('logs unrecognised_key_shape and still deletes the source for a key with extra path segments', async () => {
+    const infoSpy = jest.spyOn(console, 'info').mockImplementation(() => {})
+
+    // Passes toProcessedKey's prefix guard but parseRecipeSlug rejects the 3-segment tail.
+    await expect(handler(makeS3Event('uploads/recipes/abc/cover/extra'))).resolves.toBeUndefined()
+
+    // No recipe resolution attempted.
+    expect(ddbMock.commandCalls(QueryCommand)).toHaveLength(0)
+    expect(ddbMock.commandCalls(UpdateCommand)).toHaveLength(0)
+
+    // A deliberate, logged skip still deletes the source.
+    expect(s3Mock.commandCalls(DeleteObjectCommand)).toHaveLength(1)
+
+    expect(infoSpy).toHaveBeenCalledWith(
+      expect.objectContaining({ event: 'resizer.writeback.skipped', reason: 'unrecognised_key_shape' }),
+    )
+
+    infoSpy.mockRestore()
+  })
+
   it('rethrows non-conditional DDB errors and leaves the source in place for retry', async () => {
     ddbMock.on(UpdateCommand).rejects(new Error('boom'))
 

--- a/test/lambda/image-resizer.test.ts
+++ b/test/lambda/image-resizer.test.ts
@@ -256,7 +256,7 @@ describe('image-resizer handler', () => {
     infoSpy.mockRestore()
   })
 
-  it('swallows ConditionalCheckFailedException (recipe_deleted skip), with the source-delete already having fired before the UpdateCommand', async () => {
+  it('swallows ConditionalCheckFailedException (recipe_deleted skip) and still deletes the source after the skip', async () => {
     const infoSpy = jest.spyOn(console, 'info').mockImplementation(() => {})
 
     const condFailed = new ConditionalCheckFailedException({
@@ -267,7 +267,8 @@ describe('image-resizer handler', () => {
 
     await expect(handler(makeS3Event('uploads/recipes/abc/cover'))).resolves.toBeUndefined()
 
-    // Source-delete fired (earlier in the flow, before the UpdateCommand threw).
+    // recipe_deleted is a deliberate, logged skip, so the source-delete still fires
+    // (now at the end of the flow, after the swallowed UpdateCommand).
     const deleteCalls = s3Mock.commandCalls(DeleteObjectCommand)
     expect(deleteCalls).toHaveLength(1)
     expect(deleteCalls[0].args[0].input).toEqual({
@@ -286,10 +287,25 @@ describe('image-resizer handler', () => {
     infoSpy.mockRestore()
   })
 
-  it('rethrows non-conditional DDB errors', async () => {
+  it('rethrows non-conditional DDB errors and leaves the source in place for retry', async () => {
     ddbMock.on(UpdateCommand).rejects(new Error('boom'))
 
     await expect(handler(makeS3Event('uploads/recipes/abc/cover'))).rejects.toThrow('boom')
+
+    // Durability: a transient (non-conditional) writeback failure must NOT delete
+    // the source, so the Lambda retry can regenerate the variants and stamp
+    // imageStatus instead of hitting a 404 on the already-deleted source.
+    expect(s3Mock.commandCalls(DeleteObjectCommand)).toHaveLength(0)
+  })
+
+  it('rethrows a transient GSI-lookup failure and leaves the source in place for retry', async () => {
+    ddbMock.on(QueryCommand).rejects(new Error('throttled'))
+
+    await expect(handler(makeS3Event('uploads/recipes/abc/cover'))).rejects.toThrow('throttled')
+
+    // The lookup failed before the writeback; the source must survive the retry.
+    expect(ddbMock.commandCalls(UpdateCommand)).toHaveLength(0)
+    expect(s3Mock.commandCalls(DeleteObjectCommand)).toHaveLength(0)
   })
 
   it('throws and writes nothing for a malformed key that does not match uploads/recipes/<slug>/...', async () => {
@@ -303,10 +319,10 @@ describe('image-resizer handler', () => {
     expect(s3Mock.commandCalls(DeleteObjectCommand)).toHaveLength(0)
   })
 
-  it('invokes the source DeleteObjectCommand BEFORE the UpdateCommand (variants -> delete source -> query GSI -> update DDB)', async () => {
-    // Sequencing-probe trick (mirrors the previous "Update before Delete" assertion, inverted):
-    // if the UpdateCommand is issued AFTER the source DeleteObjectCommand, rejecting the
-    // UpdateCommand with a generic error must NOT prevent the source-delete from having fired.
+  it('does NOT delete the source when the UpdateCommand throws a transient error (writeback precedes delete)', async () => {
+    // Sequencing probe: the source-delete now fires LAST, after the writeback. So a
+    // generic (non-conditional) UpdateCommand rejection must prevent the source-delete
+    // from firing at all — the source survives for the Lambda retry.
     ddbMock.on(UpdateCommand).rejects(new Error('sequencing-probe'))
 
     await expect(handler(makeS3Event('uploads/recipes/abc/cover'))).rejects.toThrow(
@@ -314,11 +330,11 @@ describe('image-resizer handler', () => {
     )
 
     expect(ddbMock.commandCalls(UpdateCommand)).toHaveLength(1)
-    // Source-delete fired earlier in the flow, before the UpdateCommand threw.
-    expect(s3Mock.commandCalls(DeleteObjectCommand)).toHaveLength(1)
+    // Source-delete did NOT fire — it sits after the writeback that threw.
+    expect(s3Mock.commandCalls(DeleteObjectCommand)).toHaveLength(0)
   })
 
-  it('orders the resizer flow as: write variants -> delete source -> query GSI -> update DDB', async () => {
+  it('orders the resizer flow as: write variants -> query GSI -> update DDB -> delete source', async () => {
     // Track call order across both mocks via a shared sequence counter using jest.spyOn
     // on the underlying send methods. aws-sdk-client-mock exposes per-mock call lists but
     // not a cross-mock chronological one, so we tag calls as they happen.
@@ -344,10 +360,10 @@ describe('image-resizer handler', () => {
     await handler(makeS3Event('uploads/recipes/abc/cover'))
 
     // Three variant PUTs first (in any order amongst themselves — they fire concurrently),
-    // then the source delete, then the GSI query, then the update.
+    // then the GSI query, then the writeback, and the source delete fires LAST.
     expect(sequence.filter((step) => step === 's3:put')).toHaveLength(3)
     const tail = sequence.filter((step) => step !== 's3:put')
-    expect(tail).toEqual(['s3:delete', 'ddb:query', 'ddb:update'])
+    expect(tail).toEqual(['ddb:query', 'ddb:update', 's3:delete'])
 
     // And every PUT preceded the source delete.
     const lastPutIndex = sequence.lastIndexOf('s3:put')


### PR DESCRIPTION
Closes #161

## What changed
Reordered the per-record flow in `lambda/image-resizer.ts` so the source S3 object is deleted **last** — after a successful `imageStatus` writeback or a deliberate, logged skip — instead of before the GSI lookup + `UpdateCommand`.

**Decision:** chose **option 1** (reorder) from the issue over option 4 (document-only). Variant PUTs are idempotent, so deleting the source last is strictly safer for transient failures, and option 4 left a real silent-corruption window.

## Why
Previously: `read source → variants → DELETE source → GSI lookup → UpdateCommand`. If the lookup or update threw a transient error (DDB throttling, network, IAM), the Lambda retried the S3 event, hit a **404 on the already-deleted source**, and threw before the writeback — so the variants existed but `imageStatus` was never stamped and the recipe showed perpetually unprocessed.

Now: `read source → variants → GSI lookup → UpdateCommand → DELETE source`. A transient throw leaves the source in place; the retry regenerates the (idempotent) variants and completes the writeback.

The `continue`-based skips became a nested if/else so all non-throwing outcomes fall through to a single trailing delete; only a thrown transient error bypasses it.

## Behaviour preserved (the source is still deleted on):
- success
- `unrecognised_key_shape` (slug parse fails)
- `recipe_not_found` (GSI returns nothing)
- `recipe_deleted` (CCFE swallowed)

Only a **non-CCFE throw** from the GSI query or the update now withholds the delete.

## How to verify
- `pnpm test` — 210/210 lambda tests pass. Updated/added resizer tests:
  - flow-order assertion flipped to `variants → query → update → delete`.
  - two transient-failure tests (UpdateCommand `boom`, **GSI query `throttled`** — new coverage) assert `DeleteObjectCommand` count is **0**.
  - recipe_not_found / recipe_deleted / new unrecognised_key_shape tests assert the source **is** deleted.
- `pnpm lint`, `pnpm exec tsc --noEmit` — clean, no new errors.
- PRD `docs/prds/editable-recipe-slugs.md` updated: the "Resizer flow order" checklist item + a durability note in the Resizer-changes section.

## Note on labelling
Labelled `type:refactor` (the issue's label; the scheme has no `type:fix`), but this is a behaviour/durability fix — committed as `fix(image-resizer): …`. No version-bump impact (both map to a patch bump).

## Out of scope
- Metrics/alarms for the transient-failure case (a separate observability ticket if useful) — per the issue's out-of-scope list.