### PR TITLE
Editable Recipe Slugs (Backend): slug-based image keys + editable slugs

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Setup pnpm
         uses: pnpm/action-setup@v5
         with:
-          version: 8
+          version: 10
 
       - name: Install dependencies
         run: pnpm install --no-frozen-lockfile
@@ -55,7 +55,7 @@ jobs:
       - name: Setup pnpm
         uses: pnpm/action-setup@v5
         with:
-          version: 8
+          version: 10
 
       - name: Install dependencies
         run: pnpm install --no-frozen-lockfile

--- a/docs/prds/editable-recipe-slugs.md
+++ b/docs/prds/editable-recipe-slugs.md
@@ -266,6 +266,8 @@ await docClient.send(new UpdateCommand({
 
 `ConditionalCheckFailedException` handling stays — covers the "recipe deleted while image was processing" race.
 
+**Source-delete ordering (durability).** The source object is deleted **last** — only after a successful `imageStatus` writeback or a deliberate, logged skip (`unrecognised_key_shape`, `recipe_not_found`, `recipe_deleted`). It is **not** deleted when the GSI lookup or `UpdateCommand` throws a transient error (throttling, network, IAM): the error propagates, the Lambda retries the S3 event, and because the variant PUTs are idempotent the retry regenerates them and completes the writeback. Deleting the source before the writeback (as an earlier draft did) meant a transient failure left the variants written but `imageStatus` never stamped, with the retry hitting a 404 on the already-deleted source — a permanent, silent "perpetually unprocessed" state. (Issue #161.)
+
 ### Recipe-image-handler changes
 
 ```ts
@@ -403,7 +405,7 @@ ACs are split into automated (Jest + `aws-cdk-lib/assertions` + Lambda unit test
 
 - [ ] `parseRecipeSlug('uploads/recipes/beans-on-toast/cover')` returns `'beans-on-toast'`.
 - [ ] `parseRecipeSlug('uploads/something-else/...')` returns `undefined`.
-- [ ] Resizer **flow order** (asserted via mock-call ordering): write variants → delete source → query GSI → update DDB. The variant PUTs and source delete fire regardless of whether the GSI lookup succeeds.
+- [ ] Resizer **flow order** (asserted via mock-call ordering): write variants → query GSI → update DDB → delete source. The source-delete fires last — after a successful writeback or a deliberate logged skip — but is skipped when the GSI lookup or `UpdateCommand` throws a transient error, leaving the source in place for the Lambda retry (durability, issue #161).
 - [ ] Resizer queries `slug-index` GSI to resolve slug → id; the resulting `id` is used in the `UpdateCommand.Key`.
 - [ ] If no recipe has the slug, the resizer logs `recipe_not_found` and skips the DDB write — variant PUTs and source delete still fire.
 - [ ] Documented edge case (no test required): if a slug is changed between upload-URL request and resizer execution, variants land under the old slug and stay orphaned. Frontend mitigates via pessimistic upload lock (sibling PRD).

--- a/lambda/image-resizer.ts
+++ b/lambda/image-resizer.ts
@@ -1,6 +1,6 @@
 import { ConditionalCheckFailedException, DynamoDBClient } from '@aws-sdk/client-dynamodb'
 import { S3Client, GetObjectCommand, PutObjectCommand, DeleteObjectCommand } from '@aws-sdk/client-s3'
-import { DynamoDBDocumentClient, UpdateCommand } from '@aws-sdk/lib-dynamodb'
+import { DynamoDBDocumentClient, QueryCommand, UpdateCommand } from '@aws-sdk/lib-dynamodb'
 import type { S3Event } from 'aws-lambda'
 import sharp from 'sharp'
 import { VARIANT_SUFFIXES, toProcessedKey, UPLOAD_PREFIX, type VariantSuffix } from './image-variants'
@@ -25,14 +25,14 @@ const VARIANTS: readonly ImageVariant[] = VARIANT_SUFFIXES.map((suffix) => ({
   ...VARIANT_SIZING[suffix],
 }))
 
-// Accepts exactly `uploads/recipes/<id>/<type>` — extra trailing segments are rejected.
-function parseRecipeId(uploadKey: string): string | undefined {
+// Accepts exactly `uploads/recipes/<slug>/<type>` — extra trailing segments are rejected.
+export function parseRecipeSlug(uploadKey: string): string | undefined {
   if (!uploadKey.startsWith(UPLOAD_PREFIX)) return undefined
   const segments = uploadKey.slice(UPLOAD_PREFIX.length).split('/')
   if (segments.length !== 2) return undefined
-  const id = segments[0]
-  if (!id) return undefined
-  return id
+  const slug = segments[0]
+  if (!slug) return undefined
+  return slug
 }
 
 export async function handler(event: S3Event): Promise<void> {
@@ -76,32 +76,47 @@ export async function handler(event: S3Event): Promise<void> {
     const logSkip = (reason: string) =>
       console.info({ event: 'resizer.writeback.skipped', reason, key })
 
-    const recipeId = parseRecipeId(key)
-    if (recipeId === undefined) {
-      logSkip('unrecognised_key_shape')
-    } else {
-      try {
-        await docClient.send(
-          new UpdateCommand({
-            TableName: tableName,
-            Key: { id: recipeId },
-            UpdateExpression: 'SET imageStatus.#k = :ts',
-            ConditionExpression: 'attribute_exists(id)',
-            ExpressionAttributeNames: { '#k': processedKey },
-            ExpressionAttributeValues: { ':ts': Date.now() },
-          }),
-        )
-      } catch (error) {
-        if (error instanceof ConditionalCheckFailedException) {
-          logSkip('recipe_deleted')
-        } else {
-          throw error
-        }
-      }
-    }
-
     await s3.send(
       new DeleteObjectCommand({ Bucket: sourceBucket, Key: key }),
     )
+
+    const slug = parseRecipeSlug(key)
+    if (slug === undefined) {
+      logSkip('unrecognised_key_shape')
+      continue
+    }
+
+    const lookup = await docClient.send(
+      new QueryCommand({
+        TableName: tableName,
+        IndexName: 'slug-index',
+        KeyConditionExpression: 'slug = :slug',
+        ExpressionAttributeValues: { ':slug': slug },
+      }),
+    )
+    const recipeId = (lookup.Items?.[0] as { id?: string } | undefined)?.id
+    if (!recipeId) {
+      logSkip('recipe_not_found')
+      continue
+    }
+
+    try {
+      await docClient.send(
+        new UpdateCommand({
+          TableName: tableName,
+          Key: { id: recipeId },
+          UpdateExpression: 'SET imageStatus.#k = :ts',
+          ConditionExpression: 'attribute_exists(id)',
+          ExpressionAttributeNames: { '#k': processedKey },
+          ExpressionAttributeValues: { ':ts': Date.now() },
+        }),
+      )
+    } catch (error) {
+      if (error instanceof ConditionalCheckFailedException) {
+        logSkip('recipe_deleted')
+      } else {
+        throw error
+      }
+    }
   }
 }

--- a/lambda/image-resizer.ts
+++ b/lambda/image-resizer.ts
@@ -1,13 +1,12 @@
-import { ConditionalCheckFailedException, DynamoDBClient } from '@aws-sdk/client-dynamodb'
+import { ConditionalCheckFailedException } from '@aws-sdk/client-dynamodb'
 import { S3Client, GetObjectCommand, PutObjectCommand, DeleteObjectCommand } from '@aws-sdk/client-s3'
-import { DynamoDBDocumentClient, UpdateCommand } from '@aws-sdk/lib-dynamodb'
+import { UpdateCommand } from '@aws-sdk/lib-dynamodb'
 import type { S3Event } from 'aws-lambda'
 import sharp from 'sharp'
 import { VARIANT_SUFFIXES, toProcessedKey, UPLOAD_PREFIX, type VariantSuffix } from './image-variants'
-import { findIdBySlug } from './recipe-store'
+import { docClient, findIdBySlug } from './recipe-store'
 
 const s3 = new S3Client({})
-const docClient = DynamoDBDocumentClient.from(new DynamoDBClient({}))
 
 interface ImageVariant {
   readonly suffix: VariantSuffix

--- a/lambda/image-resizer.ts
+++ b/lambda/image-resizer.ts
@@ -1,9 +1,10 @@
 import { ConditionalCheckFailedException, DynamoDBClient } from '@aws-sdk/client-dynamodb'
 import { S3Client, GetObjectCommand, PutObjectCommand, DeleteObjectCommand } from '@aws-sdk/client-s3'
-import { DynamoDBDocumentClient, QueryCommand, UpdateCommand } from '@aws-sdk/lib-dynamodb'
+import { DynamoDBDocumentClient, UpdateCommand } from '@aws-sdk/lib-dynamodb'
 import type { S3Event } from 'aws-lambda'
 import sharp from 'sharp'
 import { VARIANT_SUFFIXES, toProcessedKey, UPLOAD_PREFIX, type VariantSuffix } from './image-variants'
+import { findIdBySlug } from './recipe-store'
 
 const s3 = new S3Client({})
 const docClient = DynamoDBDocumentClient.from(new DynamoDBClient({}))
@@ -88,16 +89,7 @@ export async function handler(event: S3Event): Promise<void> {
       continue
     }
 
-    const lookup = await docClient.send(
-      new QueryCommand({
-        TableName: tableName,
-        IndexName: 'slug-index',
-        KeyConditionExpression: 'slug = :slug',
-        ExpressionAttributeValues: { ':slug': slug },
-      }),
-    )
-    const [item] = lookup.Items ?? []
-    const recipeId = (item as { id?: string } | undefined)?.id
+    const recipeId = await findIdBySlug(slug)
     if (!recipeId) {
       logSkip('recipe_not_found')
       continue

--- a/lambda/image-resizer.ts
+++ b/lambda/image-resizer.ts
@@ -78,39 +78,44 @@ export async function handler(event: S3Event): Promise<void> {
     const logSkip = (reason: SkipReason) =>
       console.info({ event: 'resizer.writeback.skipped', reason, key })
 
-    await s3.send(
-      new DeleteObjectCommand({ Bucket: sourceBucket, Key: key }),
-    )
-
+    // Resolve the recipe and stamp imageStatus BEFORE deleting the source. The
+    // variant PUTs above are idempotent, so if the GSI lookup or UpdateCommand
+    // hits a transient error and throws, the source survives and the Lambda retry
+    // can regenerate the variants and complete the writeback. Only deliberate,
+    // logged skips fall through to the source-delete below.
     const slug = parseRecipeSlug(key)
     if (slug === undefined) {
       logSkip('unrecognised_key_shape')
-      continue
-    }
-
-    const recipeId = await findIdBySlug(slug)
-    if (!recipeId) {
-      logSkip('recipe_not_found')
-      continue
-    }
-
-    try {
-      await docClient.send(
-        new UpdateCommand({
-          TableName: tableName,
-          Key: { id: recipeId },
-          UpdateExpression: 'SET imageStatus.#k = :ts',
-          ConditionExpression: 'attribute_exists(id)',
-          ExpressionAttributeNames: { '#k': processedKey },
-          ExpressionAttributeValues: { ':ts': Date.now() },
-        }),
-      )
-    } catch (error) {
-      if (error instanceof ConditionalCheckFailedException) {
-        logSkip('recipe_deleted')
+    } else {
+      const recipeId = await findIdBySlug(slug)
+      if (!recipeId) {
+        logSkip('recipe_not_found')
       } else {
-        throw error
+        try {
+          await docClient.send(
+            new UpdateCommand({
+              TableName: tableName,
+              Key: { id: recipeId },
+              UpdateExpression: 'SET imageStatus.#k = :ts',
+              ConditionExpression: 'attribute_exists(id)',
+              ExpressionAttributeNames: { '#k': processedKey },
+              ExpressionAttributeValues: { ':ts': Date.now() },
+            }),
+          )
+        } catch (error) {
+          if (error instanceof ConditionalCheckFailedException) {
+            logSkip('recipe_deleted')
+          } else {
+            throw error
+          }
+        }
       }
     }
+
+    // Reached only after a successful writeback or a logged skip — never after a
+    // thrown transient error, so the source survives for the retry.
+    await s3.send(
+      new DeleteObjectCommand({ Bucket: sourceBucket, Key: key }),
+    )
   }
 }

--- a/lambda/image-resizer.ts
+++ b/lambda/image-resizer.ts
@@ -25,6 +25,8 @@ const VARIANTS: readonly ImageVariant[] = VARIANT_SUFFIXES.map((suffix) => ({
   ...VARIANT_SIZING[suffix],
 }))
 
+type SkipReason = 'unrecognised_key_shape' | 'recipe_not_found' | 'recipe_deleted'
+
 // Accepts exactly `uploads/recipes/<slug>/<type>` — extra trailing segments are rejected.
 export function parseRecipeSlug(uploadKey: string): string | undefined {
   if (!uploadKey.startsWith(UPLOAD_PREFIX)) return undefined
@@ -73,7 +75,7 @@ export async function handler(event: S3Event): Promise<void> {
       }),
     )
 
-    const logSkip = (reason: string) =>
+    const logSkip = (reason: SkipReason) =>
       console.info({ event: 'resizer.writeback.skipped', reason, key })
 
     await s3.send(
@@ -94,7 +96,8 @@ export async function handler(event: S3Event): Promise<void> {
         ExpressionAttributeValues: { ':slug': slug },
       }),
     )
-    const recipeId = (lookup.Items?.[0] as { id?: string } | undefined)?.id
+    const [item] = lookup.Items ?? []
+    const recipeId = (item as { id?: string } | undefined)?.id
     if (!recipeId) {
       logSkip('recipe_not_found')
       continue

--- a/lambda/recipe-handler.ts
+++ b/lambda/recipe-handler.ts
@@ -60,16 +60,14 @@ function tagsToArray(tags: unknown): string[] {
   return []
 }
 
-// ── Slug validation (issue #147) ────────────────────────────────────────────
-export const RESERVED_SLUGS = ['new', 'admin', 'drafts', 'images'] as const
+export const RESERVED_SLUGS: readonly string[] = ['new', 'admin', 'drafts', 'images']
 
 const SLUG_REGEX = /^[a-z0-9](?:[a-z0-9-]*[a-z0-9])?$/
 
 export function isValidSlug(slug: string): boolean {
-  if (typeof slug !== 'string') return false
   if (slug.length < 1 || slug.length > 100) return false
   if (!SLUG_REGEX.test(slug)) return false
-  if ((RESERVED_SLUGS as readonly string[]).includes(slug)) return false
+  if (RESERVED_SLUGS.includes(slug)) return false
   return true
 }
 

--- a/lambda/recipe-handler.ts
+++ b/lambda/recipe-handler.ts
@@ -62,6 +62,11 @@ function tagsToArray(tags: unknown): string[] {
 
 export const RESERVED_SLUGS: readonly string[] = ['new', 'admin', 'drafts', 'images']
 
+const SLUG_LOCKED_RESPONSE = {
+  error: 'slug_locked',
+  message: 'Cannot change slug after images have been uploaded. Delete uploaded images first.',
+} as const
+
 const SLUG_REGEX = /^[a-z0-9](?:[a-z0-9-]*[a-z0-9])?$/
 
 export function isValidSlug(slug: string): boolean {
@@ -421,20 +426,14 @@ async function handleUpdateRecipe(event: APIGatewayProxyEventV2): Promise<APIGat
   if (slugChanging) {
     if (!isValidSlug(requestedSlug)) return json(400, { error: 'invalid_slug' })
 
-    const imageStatusMap = (existing.imageStatus as Record<string, unknown> | undefined) ?? {}
-    if (Object.keys(imageStatusMap).length > 0) {
-      return json(409, {
-        error: 'slug_locked',
-        message: 'Cannot change slug after images have been uploaded. Delete uploaded images first.',
-      })
+    if (Object.keys(imageStatusOf(existing)).length > 0) {
+      return json(409, SLUG_LOCKED_RESPONSE)
     }
 
     if (await slugExists(requestedSlug, id)) {
       return json(409, { error: 'slug_taken', message: `Slug "${requestedSlug}" is already in use.` })
     }
-  }
-
-  if (!slugChanging) {
+  } else {
     delete updates.slug
   }
 
@@ -500,12 +499,8 @@ async function handleUpdateRecipe(event: APIGatewayProxyEventV2): Promise<APIGat
   } catch (err) {
     if (err instanceof ConditionalCheckFailedException || (err as { name?: string }).name === 'ConditionalCheckFailedException') {
       const reRead = await getRecipeById(id)
-      const reReadImageStatus = (reRead?.imageStatus as Record<string, unknown> | undefined) ?? {}
-      if (Object.keys(reReadImageStatus).length > 0) {
-        return json(409, {
-          error: 'slug_locked',
-          message: 'Cannot change slug after images have been uploaded. Delete uploaded images first.',
-        })
+      if (reRead && Object.keys(imageStatusOf(reRead)).length > 0) {
+        return json(409, SLUG_LOCKED_RESPONSE)
       }
       return json(409, { error: 'conflict', message: 'Recipe was modified by another request. Please retry.' })
     }

--- a/lambda/recipe-handler.ts
+++ b/lambda/recipe-handler.ts
@@ -552,7 +552,7 @@ async function handleUpdateRecipe(event: APIGatewayProxyEventV2): Promise<APIGat
 interface PublishErrors {
   title?: string
   intro?: string
-  coverImage?: { key?: string; alt?: string; processedAt?: string }
+  coverImage?: { alt?: string; processedAt?: string }
   ingredients?: string
   steps?: string
   stepImages?: Array<{ order: number; processedAt: string }>
@@ -571,24 +571,19 @@ function validatePublishInput(item: Record<string, unknown>): PublishErrors {
     errors.intro = 'intro is required'
   }
 
-  const coverImage = item.coverImage as { key?: unknown; alt?: unknown } | undefined
-  const coverErrors: { key?: string; alt?: string; processedAt?: string } = {}
-  const coverKey = coverImage?.key
-  if (typeof coverKey !== 'string' || coverKey.trim().length === 0) {
-    coverErrors.key = 'coverImage.key is required'
-  }
+  const slug = typeof item.slug === 'string' ? item.slug : undefined
+  const imageStatus = imageStatusOf(item)
+  const coverImage = item.coverImage as { alt?: unknown } | undefined
+  const coverErrors: { alt?: string; processedAt?: string } = {}
+
   const coverAlt = coverImage?.alt
   if (typeof coverAlt !== 'string' || coverAlt.trim().length === 0) {
     coverErrors.alt = 'coverImage.alt is required'
-  }
-
-  const imageStatus = imageStatusOf(item)
-
-  if (!coverErrors.key && imageStatus[coverKey as string] === undefined) {
+  } else if (slug && imageStatus[`${PROCESSED_PREFIX}${slug}/cover`] === undefined) {
     coverErrors.processedAt = 'Cover image still processing'
   }
 
-  if (coverErrors.key || coverErrors.alt || coverErrors.processedAt) {
+  if (coverErrors.alt || coverErrors.processedAt) {
     errors.coverImage = coverErrors
   }
 
@@ -610,13 +605,15 @@ function validatePublishInput(item: Record<string, unknown>): PublishErrors {
     }
 
     const stepImageErrors: Array<{ order: number; processedAt: string }> = []
-    for (const step of steps) {
-      const typedStep = step as { order?: unknown; image?: { key?: unknown } }
-      const imageKey = typedStep.image?.key
-      if (typeof imageKey !== 'string' || imageKey.trim().length === 0) continue
-      if (imageStatus[imageKey] !== undefined) continue
-      const order = typeof typedStep.order === 'number' ? typedStep.order : 0
-      stepImageErrors.push({ order, processedAt: 'Step image still processing' })
+    if (slug) {
+      for (const step of steps) {
+        const typedStep = step as { order?: unknown; stepId?: unknown; image?: unknown }
+        if (!typedStep.image || typeof typedStep.stepId !== 'string') continue
+        const stepKey = `${PROCESSED_PREFIX}${slug}/step-${typedStep.stepId}`
+        if (imageStatus[stepKey] !== undefined) continue
+        const order = typeof typedStep.order === 'number' ? typedStep.order : 0
+        stepImageErrors.push({ order, processedAt: 'Step image still processing' })
+      }
     }
     if (stepImageErrors.length > 0) {
       errors.stepImages = stepImageErrors

--- a/lambda/recipe-handler.ts
+++ b/lambda/recipe-handler.ts
@@ -1,9 +1,10 @@
 import { randomUUID } from 'node:crypto'
 import { ConditionalCheckFailedException, DynamoDBClient } from '@aws-sdk/client-dynamodb'
 import { S3Client, ListObjectsV2Command, DeleteObjectsCommand } from '@aws-sdk/client-s3'
-import { DynamoDBDocumentClient, QueryCommand, GetCommand, PutCommand, UpdateCommand, DeleteCommand, ScanCommand } from '@aws-sdk/lib-dynamodb'
+import { DynamoDBDocumentClient, QueryCommand, PutCommand, UpdateCommand, DeleteCommand, ScanCommand } from '@aws-sdk/lib-dynamodb'
 import type { APIGatewayProxyEventV2, APIGatewayProxyStructuredResultV2 } from 'aws-lambda'
 import { VARIANT_SUFFIXES, PROCESSED_PREFIX } from './image-variants'
+import { getRecipeById, queryRecipeIdsBySlug, STEP_ID_REGEX } from './recipe-store'
 
 const ddbClient = new DynamoDBClient({})
 const docClient = DynamoDBDocumentClient.from(ddbClient)
@@ -68,7 +69,6 @@ const SLUG_LOCKED_RESPONSE = {
 } as const
 
 const SLUG_REGEX = /^[a-z0-9](?:[a-z0-9-]*[a-z0-9])?$/
-const STEP_ID_REGEX = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i
 
 export function isValidSlug(slug: string): boolean {
   if (slug.length < 1 || slug.length > 100) return false
@@ -78,16 +78,9 @@ export function isValidSlug(slug: string): boolean {
 }
 
 export async function slugExists(slug: string, excludeId?: string): Promise<boolean> {
-  const result = await docClient.send(
-    new QueryCommand({
-      TableName: TABLE_NAME,
-      IndexName: 'slug-index',
-      KeyConditionExpression: 'slug = :slug',
-      ExpressionAttributeValues: { ':slug': slug },
-    }),
-  )
-  if (!result.Items || result.Items.length === 0) return false
-  if (excludeId) return result.Items.some((i) => (i as { id: string }).id !== excludeId)
+  const ids = await queryRecipeIdsBySlug(slug)
+  if (ids.length === 0) return false
+  if (excludeId) return ids.some((id) => id !== excludeId)
   return true
 }
 
@@ -729,11 +722,6 @@ async function handleDeleteRecipe(event: APIGatewayProxyEventV2): Promise<APIGat
   await docClient.send(new DeleteCommand({ TableName: TABLE_NAME, Key: { id } }))
 
   return json(200, { message: 'Recipe deleted successfully' })
-}
-
-async function getRecipeById(id: string): Promise<Record<string, unknown> | undefined> {
-  const result = await docClient.send(new GetCommand({ TableName: TABLE_NAME, Key: { id } }))
-  return result.Item as Record<string, unknown> | undefined
 }
 
 function isOwnerOrAdmin(authorId: string, currentUserId: string, event: APIGatewayProxyEventV2): boolean {

--- a/lambda/recipe-handler.ts
+++ b/lambda/recipe-handler.ts
@@ -95,9 +95,13 @@ function imageStatusOf(item: Record<string, unknown>): Record<string, number> {
   return (item.imageStatus as Record<string, number> | undefined) ?? {}
 }
 
+function slugOf(item: Record<string, unknown>): string | undefined {
+  return typeof item.slug === 'string' ? item.slug : undefined
+}
+
 function composeImageProcessedAt<T extends Record<string, unknown>>(item: T): Omit<T, 'imageStatus'> {
   const imageStatus = imageStatusOf(item)
-  const slug = typeof item.slug === 'string' ? item.slug : undefined
+  const slug = slugOf(item)
   const coverImage = item.coverImage as Record<string, unknown> | undefined
 
   const coverDerivedKey = slug ? `${PROCESSED_PREFIX}${slug}/cover` : undefined
@@ -354,7 +358,7 @@ function variantKeysFor(key: string): readonly string[] {
 }
 
 function droppedImageBaseKeys(oldItem: Record<string, unknown>, updates: Record<string, unknown>): string[] {
-  const slug = typeof oldItem.slug === 'string' ? oldItem.slug : undefined
+  const slug = slugOf(oldItem)
   if (!slug) return []
   const droppedKeys: string[] = []
 
@@ -571,7 +575,7 @@ function validatePublishInput(item: Record<string, unknown>): PublishErrors {
     errors.intro = 'intro is required'
   }
 
-  const slug = typeof item.slug === 'string' ? item.slug : undefined
+  const slug = slugOf(item)
   const imageStatus = imageStatusOf(item)
   const coverImage = item.coverImage as { alt?: unknown } | undefined
   const coverErrors: { alt?: string; processedAt?: string } = {}
@@ -701,7 +705,7 @@ async function handleDeleteRecipe(event: APIGatewayProxyEventV2): Promise<APIGat
     return json(403, { error: 'Forbidden' })
   }
 
-  const slug = typeof existing.slug === 'string' ? existing.slug : undefined
+  const slug = slugOf(existing)
   if (slug) {
     const listResult = await s3Client.send(
       new ListObjectsV2Command({

--- a/lambda/recipe-handler.ts
+++ b/lambda/recipe-handler.ts
@@ -1,15 +1,23 @@
 import { randomUUID } from 'node:crypto'
 import { ConditionalCheckFailedException } from '@aws-sdk/client-dynamodb'
 import { S3Client, ListObjectsV2Command, DeleteObjectsCommand } from '@aws-sdk/client-s3'
-import { QueryCommand, PutCommand, UpdateCommand, DeleteCommand, ScanCommand } from '@aws-sdk/lib-dynamodb'
 import { unmarshall } from '@aws-sdk/util-dynamodb'
 import type { APIGatewayProxyEventV2, APIGatewayProxyStructuredResultV2 } from 'aws-lambda'
 import { VARIANT_SUFFIXES, PROCESSED_PREFIX } from './image-variants'
-import { docClient, getRecipeById, isValidStepId, queryRecipeIdsBySlug } from './recipe-store'
+import {
+  getRecipeById,
+  isValidStepId,
+  queryRecipeIdsBySlug,
+  queryRecipesByStatus,
+  queryRecipesByAuthor,
+  scanRecipes,
+  putRecipe,
+  updateRecipe,
+  deleteRecipe,
+} from './recipe-store'
 
 const s3Client = new S3Client({})
 
-const TABLE_NAME = process.env.TABLE_NAME ?? ''
 const IMAGE_BUCKET_NAME = process.env.IMAGE_BUCKET_NAME ?? ''
 const DRAFT_TTL_SECONDS = 30 * 24 * 60 * 60
 
@@ -188,18 +196,15 @@ export async function handler(event: APIGatewayProxyEventV2): Promise<APIGateway
 }
 
 async function handleListTags(): Promise<APIGatewayProxyStructuredResultV2> {
-  const result = await docClient.send(
-    new ScanCommand({
-      TableName: TABLE_NAME,
-      FilterExpression: '#status = :status',
-      ExpressionAttributeNames: { '#status': 'status' },
-      ExpressionAttributeValues: { ':status': PUBLISHED },
-      ProjectionExpression: 'tags',
-    }),
-  )
+  const items = await scanRecipes({
+    FilterExpression: '#status = :status',
+    ExpressionAttributeNames: { '#status': 'status' },
+    ExpressionAttributeValues: { ':status': PUBLISHED },
+    ProjectionExpression: 'tags',
+  })
 
   const countMap: Record<string, number> = {}
-  for (const item of result.Items ?? []) {
+  for (const item of items) {
     const tags = tagsToArray(item.tags)
     for (const tag of tags) {
       countMap[tag] = (countMap[tag] ?? 0) + 1
@@ -213,23 +218,10 @@ async function handleListTags(): Promise<APIGatewayProxyStructuredResultV2> {
   return json(200, sorted)
 }
 
-function queryRecipesByStatus(status: RecipeStatus) {
-  return docClient.send(
-    new QueryCommand({
-      TableName: TABLE_NAME,
-      IndexName: 'status-createdAt-index',
-      KeyConditionExpression: '#status = :status',
-      ExpressionAttributeNames: { '#status': 'status' },
-      ExpressionAttributeValues: { ':status': status },
-      ScanIndexForward: false,
-    }),
-  )
-}
-
 async function handleListPublished(): Promise<APIGatewayProxyStructuredResultV2> {
-  const result = await queryRecipesByStatus(PUBLISHED)
+  const items = await queryRecipesByStatus(PUBLISHED)
 
-  const recipes = (result.Items ?? []).map((item) => lightweightRecipe(item as Record<string, unknown>))
+  const recipes = items.map((item) => lightweightRecipe(item))
   return json(200, recipes)
 }
 
@@ -237,10 +229,10 @@ async function handleListForAdmin(event: APIGatewayProxyEventV2): Promise<APIGat
   if (!decodeJwt(event)) return json(401, { error: 'Unauthorised' })
   if (!isAdmin(event)) return json(403, { error: 'Forbidden' })
 
-  const [publishedResult, draftResult] = await Promise.all([queryRecipesByStatus(PUBLISHED), queryRecipesByStatus(DRAFT)])
+  const [published, drafts] = await Promise.all([queryRecipesByStatus(PUBLISHED), queryRecipesByStatus(DRAFT)])
 
   const nowSeconds = Math.floor(Date.now() / 1000)
-  const merged = [...(publishedResult.Items ?? []), ...(draftResult.Items ?? [])] as Record<string, unknown>[]
+  const merged = [...published, ...drafts]
   const live = merged.filter((item) => typeof item.ttl !== 'number' || item.ttl > nowSeconds)
 
   return json(200, live.map(lightweightAdminRecipe))
@@ -263,19 +255,16 @@ async function handleGetBySlug(event: APIGatewayProxyEventV2): Promise<APIGatewa
   const slug = event.pathParameters?.slug
   if (!slug) return json(400, { error: 'slug is required' })
 
-  const result = await docClient.send(
-    new ScanCommand({
-      TableName: TABLE_NAME,
-      FilterExpression: 'slug = :slug',
-      ExpressionAttributeValues: { ':slug': slug },
-    }),
-  )
+  const items = await scanRecipes({
+    FilterExpression: 'slug = :slug',
+    ExpressionAttributeValues: { ':slug': slug },
+  })
 
-  if (!result.Items || result.Items.length === 0) {
+  if (items.length === 0) {
     return json(404, { error: 'Recipe not found' })
   }
 
-  const recipe = result.Items[0] as Record<string, unknown>
+  const recipe = items[0]
   if (recipe.status !== PUBLISHED) {
     return json(404, { error: 'Recipe not found' })
   }
@@ -287,17 +276,9 @@ async function handleListUserRecipes(event: APIGatewayProxyEventV2): Promise<API
   const payload = decodeJwt(event)
   if (!payload) return json(401, { error: 'Unauthorised' })
 
-  const result = await docClient.send(
-    new QueryCommand({
-      TableName: TABLE_NAME,
-      IndexName: 'authorId-createdAt-index',
-      KeyConditionExpression: 'authorId = :authorId',
-      ExpressionAttributeValues: { ':authorId': payload.sub },
-      ScanIndexForward: false,
-    }),
-  )
+  const items = await queryRecipesByAuthor(payload.sub)
 
-  const recipes = (result.Items ?? []).map((item) => convertRecipeTags(item as Record<string, unknown>))
+  const recipes = items.map((item) => convertRecipeTags(item))
   return json(200, recipes)
 }
 
@@ -340,7 +321,7 @@ async function handleCreateDraft(event: APIGatewayProxyEventV2): Promise<APIGate
     updatedAt: now,
   }
 
-  await docClient.send(new PutCommand({ TableName: TABLE_NAME, Item: item }))
+  await putRecipe(item)
 
   return json(201, { id, slug })
 }
@@ -498,18 +479,15 @@ async function handleUpdateRecipe(event: APIGatewayProxyEventV2): Promise<APIGat
 
   let updateResult
   try {
-    updateResult = await docClient.send(
-      new UpdateCommand({
-        TableName: TABLE_NAME,
-        Key: { id },
-        UpdateExpression: updateExpression,
-        ExpressionAttributeNames: expressionNames,
-        ExpressionAttributeValues: expressionValues,
-        ConditionExpression: conditionExpression,
-        ReturnValues: 'ALL_OLD',
-        ReturnValuesOnConditionCheckFailure: slugChanging ? 'ALL_OLD' : undefined,
-      }),
-    )
+    updateResult = await updateRecipe({
+      Key: { id },
+      UpdateExpression: updateExpression,
+      ExpressionAttributeNames: expressionNames,
+      ExpressionAttributeValues: expressionValues,
+      ConditionExpression: conditionExpression,
+      ReturnValues: 'ALL_OLD',
+      ReturnValuesOnConditionCheckFailure: slugChanging ? 'ALL_OLD' : undefined,
+    })
   } catch (err) {
     if (err instanceof ConditionalCheckFailedException || (err as { name?: string }).name === 'ConditionalCheckFailedException') {
       // The CCFE carries the atomic snapshot under err.Item, but lib-dynamodb only
@@ -643,16 +621,13 @@ async function handlePublish(event: APIGatewayProxyEventV2): Promise<APIGatewayP
   }
 
   const now = new Date().toISOString()
-  const result = await docClient.send(
-    new UpdateCommand({
-      TableName: TABLE_NAME,
-      Key: { id },
-      UpdateExpression: 'SET #status = :status, #updatedAt = :updatedAt REMOVE #ttl',
-      ExpressionAttributeNames: { '#status': 'status', '#updatedAt': 'updatedAt', '#ttl': 'ttl' },
-      ExpressionAttributeValues: { ':status': PUBLISHED, ':updatedAt': now },
-      ReturnValues: 'ALL_NEW',
-    }),
-  )
+  const result = await updateRecipe({
+    Key: { id },
+    UpdateExpression: 'SET #status = :status, #updatedAt = :updatedAt REMOVE #ttl',
+    ExpressionAttributeNames: { '#status': 'status', '#updatedAt': 'updatedAt', '#ttl': 'ttl' },
+    ExpressionAttributeValues: { ':status': PUBLISHED, ':updatedAt': now },
+    ReturnValues: 'ALL_NEW',
+  })
 
   return json(200, convertRecipeTags(result.Attributes as Record<string, unknown>))
 }
@@ -674,16 +649,13 @@ async function handleUnpublish(event: APIGatewayProxyEventV2): Promise<APIGatewa
 
   const now = new Date().toISOString()
   const ttl = Math.floor(Date.now() / 1000) + DRAFT_TTL_SECONDS
-  const result = await docClient.send(
-    new UpdateCommand({
-      TableName: TABLE_NAME,
-      Key: { id },
-      UpdateExpression: 'SET #status = :status, #updatedAt = :updatedAt, #ttl = :ttl',
-      ExpressionAttributeNames: { '#status': 'status', '#updatedAt': 'updatedAt', '#ttl': 'ttl' },
-      ExpressionAttributeValues: { ':status': DRAFT, ':updatedAt': now, ':ttl': ttl },
-      ReturnValues: 'ALL_NEW',
-    }),
-  )
+  const result = await updateRecipe({
+    Key: { id },
+    UpdateExpression: 'SET #status = :status, #updatedAt = :updatedAt, #ttl = :ttl',
+    ExpressionAttributeNames: { '#status': 'status', '#updatedAt': 'updatedAt', '#ttl': 'ttl' },
+    ExpressionAttributeValues: { ':status': DRAFT, ':updatedAt': now, ':ttl': ttl },
+    ReturnValues: 'ALL_NEW',
+  })
 
   return json(200, convertRecipeTags(result.Attributes as Record<string, unknown>))
 }
@@ -723,7 +695,7 @@ async function handleDeleteRecipe(event: APIGatewayProxyEventV2): Promise<APIGat
     }
   }
 
-  await docClient.send(new DeleteCommand({ TableName: TABLE_NAME, Key: { id } }))
+  await deleteRecipe(id)
 
   return json(200, { message: 'Recipe deleted successfully' })
 }

--- a/lambda/recipe-handler.ts
+++ b/lambda/recipe-handler.ts
@@ -68,6 +68,7 @@ const SLUG_LOCKED_RESPONSE = {
 } as const
 
 const SLUG_REGEX = /^[a-z0-9](?:[a-z0-9-]*[a-z0-9])?$/
+const STEP_ID_REGEX = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i
 
 export function isValidSlug(slug: string): boolean {
   if (slug.length < 1 || slug.length > 100) return false
@@ -423,7 +424,6 @@ async function handleUpdateRecipe(event: APIGatewayProxyEventV2): Promise<APIGat
   stripProcessedAtFromBody(updates)
 
   if ('steps' in updates && Array.isArray(updates.steps)) {
-    const STEP_ID_REGEX = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i
     const seenStepIds = new Set<string>()
     for (const step of updates.steps as Array<Record<string, unknown>>) {
       const stepId = step.stepId
@@ -704,23 +704,25 @@ async function handleDeleteRecipe(event: APIGatewayProxyEventV2): Promise<APIGat
     return json(403, { error: 'Forbidden' })
   }
 
-  const slug = existing.slug as string
-  const listResult = await s3Client.send(
-    new ListObjectsV2Command({
-      Bucket: IMAGE_BUCKET_NAME,
-      Prefix: `${PROCESSED_PREFIX}${slug}/`,
-    }),
-  )
-
-  if (listResult.Contents && listResult.Contents.length > 0) {
-    await s3Client.send(
-      new DeleteObjectsCommand({
+  const slug = typeof existing.slug === 'string' ? existing.slug : undefined
+  if (slug) {
+    const listResult = await s3Client.send(
+      new ListObjectsV2Command({
         Bucket: IMAGE_BUCKET_NAME,
-        Delete: {
-          Objects: listResult.Contents.map((obj) => ({ Key: obj.Key })),
-        },
+        Prefix: `${PROCESSED_PREFIX}${slug}/`,
       }),
     )
+
+    if (listResult.Contents && listResult.Contents.length > 0) {
+      await s3Client.send(
+        new DeleteObjectsCommand({
+          Bucket: IMAGE_BUCKET_NAME,
+          Delete: {
+            Objects: listResult.Contents.map((obj) => ({ Key: obj.Key })),
+          },
+        }),
+      )
+    }
   }
 
   await docClient.send(new DeleteCommand({ TableName: TABLE_NAME, Key: { id } }))

--- a/lambda/recipe-handler.ts
+++ b/lambda/recipe-handler.ts
@@ -1,5 +1,5 @@
 import { randomUUID } from 'node:crypto'
-import { DynamoDBClient } from '@aws-sdk/client-dynamodb'
+import { ConditionalCheckFailedException, DynamoDBClient } from '@aws-sdk/client-dynamodb'
 import { S3Client, ListObjectsV2Command, DeleteObjectsCommand } from '@aws-sdk/client-s3'
 import { DynamoDBDocumentClient, QueryCommand, GetCommand, PutCommand, UpdateCommand, DeleteCommand, ScanCommand } from '@aws-sdk/lib-dynamodb'
 import type { APIGatewayProxyEventV2, APIGatewayProxyStructuredResultV2 } from 'aws-lambda'
@@ -408,13 +408,35 @@ async function handleUpdateRecipe(event: APIGatewayProxyEventV2): Promise<APIGat
   }
 
   const updates = JSON.parse(event.body ?? '{}') as Record<string, unknown>
-  delete updates.slug
   delete updates.id
   delete updates.authorId
   delete updates.createdAt
   delete updates.status
   delete updates.ttl
   stripProcessedAtFromBody(updates)
+
+  const requestedSlug = typeof updates.slug === 'string' ? updates.slug : undefined
+  const slugChanging = requestedSlug !== undefined && requestedSlug !== existing.slug
+
+  if (slugChanging) {
+    if (!isValidSlug(requestedSlug)) return json(400, { error: 'invalid_slug' })
+
+    const imageStatusMap = (existing.imageStatus as Record<string, unknown> | undefined) ?? {}
+    if (Object.keys(imageStatusMap).length > 0) {
+      return json(409, {
+        error: 'slug_locked',
+        message: 'Cannot change slug after images have been uploaded. Delete uploaded images first.',
+      })
+    }
+
+    if (await slugExists(requestedSlug, id)) {
+      return json(409, { error: 'slug_taken', message: `Slug "${requestedSlug}" is already in use.` })
+    }
+  }
+
+  if (!slugChanging) {
+    delete updates.slug
+  }
 
   const now = new Date().toISOString()
   const setParts: string[] = []
@@ -453,16 +475,42 @@ async function handleUpdateRecipe(event: APIGatewayProxyEventV2): Promise<APIGat
     ? `SET ${setParts.join(', ')} REMOVE ${removeParts.join(', ')}`
     : `SET ${setParts.join(', ')}`
 
-  const updateResult = await docClient.send(
-    new UpdateCommand({
-      TableName: TABLE_NAME,
-      Key: { id },
-      UpdateExpression: updateExpression,
-      ExpressionAttributeNames: expressionNames,
-      ExpressionAttributeValues: expressionValues,
-      ReturnValues: 'ALL_OLD',
-    }),
-  )
+  const conditionExpression = slugChanging
+    ? 'attribute_exists(id) AND (attribute_not_exists(imageStatus) OR size(imageStatus) = :zero) AND slug = :expectedOldSlug'
+    : undefined
+
+  if (slugChanging) {
+    expressionValues[':zero'] = 0
+    expressionValues[':expectedOldSlug'] = existing.slug
+  }
+
+  let updateResult
+  try {
+    updateResult = await docClient.send(
+      new UpdateCommand({
+        TableName: TABLE_NAME,
+        Key: { id },
+        UpdateExpression: updateExpression,
+        ExpressionAttributeNames: expressionNames,
+        ExpressionAttributeValues: expressionValues,
+        ConditionExpression: conditionExpression,
+        ReturnValues: 'ALL_OLD',
+      }),
+    )
+  } catch (err) {
+    if (err instanceof ConditionalCheckFailedException || (err as { name?: string }).name === 'ConditionalCheckFailedException') {
+      const reRead = await getRecipeById(id)
+      const reReadImageStatus = (reRead?.imageStatus as Record<string, unknown> | undefined) ?? {}
+      if (Object.keys(reReadImageStatus).length > 0) {
+        return json(409, {
+          error: 'slug_locked',
+          message: 'Cannot change slug after images have been uploaded. Delete uploaded images first.',
+        })
+      }
+      return json(409, { error: 'conflict', message: 'Recipe was modified by another request. Please retry.' })
+    }
+    throw err
+  }
 
   const atomicOld = updateResult.Attributes as Record<string, unknown>
 

--- a/lambda/recipe-handler.ts
+++ b/lambda/recipe-handler.ts
@@ -60,42 +60,31 @@ function tagsToArray(tags: unknown): string[] {
   return []
 }
 
-function generateSlug(title: string): string {
-  return title
-    .toLowerCase()
-    .replace(/[^a-z0-9]+/g, '-')
-    .replace(/^-+|-+$/g, '')
-}
-
-async function findUniqueSlug(baseSlug: string): Promise<string> {
-  let candidate = baseSlug
-  let suffix = 2
-
-  while (true) {
-    const result = await docClient.send(
-      new ScanCommand({
-        TableName: TABLE_NAME,
-        FilterExpression: 'slug = :slug',
-        ExpressionAttributeValues: { ':slug': candidate },
-      }),
-    )
-
-    if (!result.Items || result.Items.length === 0) return candidate
-    candidate = `${baseSlug}-${suffix}`
-    suffix += 1
-  }
-}
-
 // ── Slug validation (issue #147) ────────────────────────────────────────────
-// Stubs: deliberately unimplemented so TDD tests fail at runtime, not compile.
-export const RESERVED_SLUGS: readonly string[] = []
+export const RESERVED_SLUGS = ['new', 'admin', 'drafts', 'images'] as const
 
-export function isValidSlug(_slug: string): boolean {
-  throw new Error('isValidSlug not implemented')
+const SLUG_REGEX = /^[a-z0-9](?:[a-z0-9-]*[a-z0-9])?$/
+
+export function isValidSlug(slug: string): boolean {
+  if (typeof slug !== 'string') return false
+  if (slug.length < 1 || slug.length > 100) return false
+  if (!SLUG_REGEX.test(slug)) return false
+  if ((RESERVED_SLUGS as readonly string[]).includes(slug)) return false
+  return true
 }
 
-export async function slugExists(_slug: string, _excludeId?: string): Promise<boolean> {
-  throw new Error('slugExists not implemented')
+export async function slugExists(slug: string, excludeId?: string): Promise<boolean> {
+  const result = await docClient.send(
+    new QueryCommand({
+      TableName: TABLE_NAME,
+      IndexName: 'slug-index',
+      KeyConditionExpression: 'slug = :slug',
+      ExpressionAttributeValues: { ':slug': slug },
+    }),
+  )
+  if (!result.Items || result.Items.length === 0) return false
+  if (excludeId) return result.Items.some((i) => (i as { id: string }).id !== excludeId)
+  return true
 }
 
 function imageStatusOf(item: Record<string, unknown>): Record<string, number> {
@@ -309,11 +298,21 @@ async function handleCreateDraft(event: APIGatewayProxyEventV2): Promise<APIGate
   if (!payload) return json(401, { error: 'Unauthorised' })
   if (!isAdmin(event)) return json(403, { error: 'Forbidden' })
 
-  const input = JSON.parse(event.body ?? '{}') as { title?: string }
-  const title = typeof input.title === 'string' ? input.title : ''
-
+  const input = JSON.parse(event.body ?? '{}') as { slug?: unknown }
   const id = randomUUID()
-  const slug = title.length > 0 ? await findUniqueSlug(generateSlug(title)) : `draft-${id}`
+  const requestedSlug = typeof input.slug === 'string' ? input.slug : undefined
+
+  let slug: string
+  if (requestedSlug !== undefined) {
+    if (!isValidSlug(requestedSlug)) return json(400, { error: 'invalid_slug' })
+    if (await slugExists(requestedSlug)) {
+      return json(409, { error: 'slug_taken', message: `Slug "${requestedSlug}" is already in use.` })
+    }
+    slug = requestedSlug
+  } else {
+    slug = `draft-${id.slice(0, 8)}`
+  }
+
   const ttl = Math.floor(Date.now() / 1000) + DRAFT_TTL_SECONDS
   const now = new Date().toISOString()
 
@@ -322,7 +321,7 @@ async function handleCreateDraft(event: APIGatewayProxyEventV2): Promise<APIGate
     slug,
     status: DRAFT,
     ttl,
-    title,
+    title: '',
     intro: '',
     ingredients: [],
     steps: [],

--- a/lambda/recipe-handler.ts
+++ b/lambda/recipe-handler.ts
@@ -86,6 +86,18 @@ async function findUniqueSlug(baseSlug: string): Promise<string> {
   }
 }
 
+// ── Slug validation (issue #147) ────────────────────────────────────────────
+// Stubs: deliberately unimplemented so TDD tests fail at runtime, not compile.
+export const RESERVED_SLUGS: readonly string[] = []
+
+export function isValidSlug(_slug: string): boolean {
+  throw new Error('isValidSlug not implemented')
+}
+
+export async function slugExists(_slug: string, _excludeId?: string): Promise<boolean> {
+  throw new Error('slugExists not implemented')
+}
+
 function imageStatusOf(item: Record<string, unknown>): Record<string, number> {
   return (item.imageStatus as Record<string, number> | undefined) ?? {}
 }

--- a/lambda/recipe-handler.ts
+++ b/lambda/recipe-handler.ts
@@ -2,6 +2,7 @@ import { randomUUID } from 'node:crypto'
 import { ConditionalCheckFailedException } from '@aws-sdk/client-dynamodb'
 import { S3Client, ListObjectsV2Command, DeleteObjectsCommand } from '@aws-sdk/client-s3'
 import { QueryCommand, PutCommand, UpdateCommand, DeleteCommand, ScanCommand } from '@aws-sdk/lib-dynamodb'
+import { unmarshall } from '@aws-sdk/util-dynamodb'
 import type { APIGatewayProxyEventV2, APIGatewayProxyStructuredResultV2 } from 'aws-lambda'
 import { VARIANT_SUFFIXES, PROCESSED_PREFIX } from './image-variants'
 import { docClient, getRecipeById, isValidStepId, queryRecipeIdsBySlug } from './recipe-store'
@@ -506,12 +507,17 @@ async function handleUpdateRecipe(event: APIGatewayProxyEventV2): Promise<APIGat
         ExpressionAttributeValues: expressionValues,
         ConditionExpression: conditionExpression,
         ReturnValues: 'ALL_OLD',
+        ReturnValuesOnConditionCheckFailure: slugChanging ? 'ALL_OLD' : undefined,
       }),
     )
   } catch (err) {
     if (err instanceof ConditionalCheckFailedException || (err as { name?: string }).name === 'ConditionalCheckFailedException') {
-      const reRead = await getRecipeById(id)
-      if (reRead && Object.keys(imageStatusOf(reRead)).length > 0) {
+      // The CCFE carries the atomic snapshot under err.Item, but lib-dynamodb only
+      // unmarshalls success outputs — a thrown exception's Item stays in raw
+      // AttributeValue form, so unmarshall it before reading imageStatus.
+      const marshalled = (err as ConditionalCheckFailedException).Item
+      const current: Record<string, unknown> | undefined = marshalled ? unmarshall(marshalled) : undefined
+      if (current && Object.keys(imageStatusOf(current)).length > 0) {
         return json(409, SLUG_LOCKED_RESPONSE)
       }
       return json(409, { error: 'conflict', message: 'Recipe was modified by another request. Please retry.' })

--- a/lambda/recipe-handler.ts
+++ b/lambda/recipe-handler.ts
@@ -96,16 +96,24 @@ function imageStatusOf(item: Record<string, unknown>): Record<string, number> {
 
 function composeImageProcessedAt<T extends Record<string, unknown>>(item: T): Omit<T, 'imageStatus'> {
   const imageStatus = imageStatusOf(item)
-  const coverImage = item.coverImage as { key?: string } | undefined
-  const coverProcessedAt = coverImage?.key ? imageStatus[coverImage.key] : undefined
+  const slug = typeof item.slug === 'string' ? item.slug : undefined
+  const coverImage = item.coverImage as Record<string, unknown> | undefined
+
+  const coverDerivedKey = slug ? `${PROCESSED_PREFIX}${slug}/cover` : undefined
+  const coverProcessedAt = coverDerivedKey ? imageStatus[coverDerivedKey] : undefined
+
   const steps = Array.isArray(item.steps)
     ? item.steps.map((step) => {
-        const img = (step as { image?: { key?: string } }).image
-        if (!img?.key) return step
-        const processedAt = imageStatus[img.key]
-        return processedAt !== undefined ? { ...(step as object), image: { ...img, processedAt } } : step
+        const s = step as { stepId?: unknown; image?: Record<string, unknown> }
+        if (!slug || typeof s.stepId !== 'string' || !s.image) return step
+        const stepDerivedKey = `${PROCESSED_PREFIX}${slug}/step-${s.stepId}`
+        const processedAt = imageStatus[stepDerivedKey]
+        return processedAt !== undefined
+          ? { ...(step as object), image: { ...s.image, processedAt } }
+          : step
       })
     : item.steps
+
   const nextCover = coverImage && coverProcessedAt !== undefined
     ? { ...coverImage, processedAt: coverProcessedAt }
     : coverImage
@@ -340,40 +348,34 @@ async function handleCreateDraft(event: APIGatewayProxyEventV2): Promise<APIGate
   return json(201, { id, slug })
 }
 
-function imageKeyOf(obj: unknown): string | undefined {
-  if (!obj || typeof obj !== 'object') return undefined
-  const key = (obj as { key?: unknown }).key
-  return typeof key === 'string' ? key : undefined
-}
-
 function variantKeysFor(key: string): readonly string[] {
   return VARIANT_SUFFIXES.map((suffix) => `${key}-${suffix}.webp`)
 }
 
-function stepImageKeySet(steps: unknown): Set<string> {
-  const keys = new Set<string>()
-  if (!Array.isArray(steps)) return keys
-  for (const step of steps) {
-    const key = imageKeyOf((step as { image?: unknown }).image)
-    if (key) keys.add(key)
-  }
-  return keys
-}
-
 function droppedImageBaseKeys(oldItem: Record<string, unknown>, updates: Record<string, unknown>): string[] {
+  const slug = typeof oldItem.slug === 'string' ? oldItem.slug : undefined
+  if (!slug) return []
   const droppedKeys: string[] = []
 
   if ('coverImage' in updates) {
-    const oldKey = imageKeyOf(oldItem.coverImage)
-    const newKey = imageKeyOf(updates.coverImage)
-    if (oldKey && oldKey !== newKey) droppedKeys.push(oldKey)
+    const newCover = updates.coverImage
+    const coverRemoved = newCover === null || newCover === undefined
+    if (coverRemoved) {
+      droppedKeys.push(`${PROCESSED_PREFIX}${slug}/cover`)
+    }
   }
 
-  if ('steps' in updates) {
-    const oldKeys = stepImageKeySet(oldItem.steps)
-    const newKeys = stepImageKeySet(updates.steps)
-    for (const oldKey of oldKeys) {
-      if (!newKeys.has(oldKey)) droppedKeys.push(oldKey)
+  if ('steps' in updates && Array.isArray(updates.steps)) {
+    const newStepIds = new Set(
+      (updates.steps as Array<{ stepId?: unknown }>).flatMap((s) =>
+        typeof s.stepId === 'string' ? [s.stepId] : [],
+      ),
+    )
+    const oldSteps = (Array.isArray(oldItem.steps) ? oldItem.steps : []) as Array<{ stepId?: unknown }>
+    for (const oldStep of oldSteps) {
+      const oldStepId = typeof oldStep.stepId === 'string' ? oldStep.stepId : undefined
+      if (!oldStepId || newStepIds.has(oldStepId)) continue
+      droppedKeys.push(`${PROCESSED_PREFIX}${slug}/step-${oldStepId}`)
     }
   }
 
@@ -419,6 +421,21 @@ async function handleUpdateRecipe(event: APIGatewayProxyEventV2): Promise<APIGat
   delete updates.status
   delete updates.ttl
   stripProcessedAtFromBody(updates)
+
+  if ('steps' in updates && Array.isArray(updates.steps)) {
+    const STEP_ID_REGEX = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i
+    const seenStepIds = new Set<string>()
+    for (const step of updates.steps as Array<Record<string, unknown>>) {
+      const stepId = step.stepId
+      if (typeof stepId !== 'string' || !STEP_ID_REGEX.test(stepId)) {
+        return json(400, { error: 'invalid_stepId' })
+      }
+      if (seenStepIds.has(stepId)) {
+        return json(400, { error: 'duplicate_stepId' })
+      }
+      seenStepIds.add(stepId)
+    }
+  }
 
   const requestedSlug = typeof updates.slug === 'string' ? updates.slug : undefined
   const slugChanging = requestedSlug !== undefined && requestedSlug !== existing.slug
@@ -687,10 +704,11 @@ async function handleDeleteRecipe(event: APIGatewayProxyEventV2): Promise<APIGat
     return json(403, { error: 'Forbidden' })
   }
 
+  const slug = existing.slug as string
   const listResult = await s3Client.send(
     new ListObjectsV2Command({
       Bucket: IMAGE_BUCKET_NAME,
-      Prefix: `${PROCESSED_PREFIX}${id}/`,
+      Prefix: `${PROCESSED_PREFIX}${slug}/`,
     }),
   )
 

--- a/lambda/recipe-handler.ts
+++ b/lambda/recipe-handler.ts
@@ -1,13 +1,11 @@
 import { randomUUID } from 'node:crypto'
-import { ConditionalCheckFailedException, DynamoDBClient } from '@aws-sdk/client-dynamodb'
+import { ConditionalCheckFailedException } from '@aws-sdk/client-dynamodb'
 import { S3Client, ListObjectsV2Command, DeleteObjectsCommand } from '@aws-sdk/client-s3'
-import { DynamoDBDocumentClient, QueryCommand, PutCommand, UpdateCommand, DeleteCommand, ScanCommand } from '@aws-sdk/lib-dynamodb'
+import { QueryCommand, PutCommand, UpdateCommand, DeleteCommand, ScanCommand } from '@aws-sdk/lib-dynamodb'
 import type { APIGatewayProxyEventV2, APIGatewayProxyStructuredResultV2 } from 'aws-lambda'
 import { VARIANT_SUFFIXES, PROCESSED_PREFIX } from './image-variants'
-import { getRecipeById, queryRecipeIdsBySlug, STEP_ID_REGEX } from './recipe-store'
+import { docClient, getRecipeById, isValidStepId, queryRecipeIdsBySlug } from './recipe-store'
 
-const ddbClient = new DynamoDBClient({})
-const docClient = DynamoDBDocumentClient.from(ddbClient)
 const s3Client = new S3Client({})
 
 const TABLE_NAME = process.env.TABLE_NAME ?? ''
@@ -424,7 +422,7 @@ async function handleUpdateRecipe(event: APIGatewayProxyEventV2): Promise<APIGat
     const seenStepIds = new Set<string>()
     for (const step of updates.steps as Array<Record<string, unknown>>) {
       const stepId = step.stepId
-      if (typeof stepId !== 'string' || !STEP_ID_REGEX.test(stepId)) {
+      if (typeof stepId !== 'string' || !isValidStepId(stepId)) {
         return json(400, { error: 'invalid_stepId' })
       }
       if (seenStepIds.has(stepId)) {

--- a/lambda/recipe-image-handler.ts
+++ b/lambda/recipe-image-handler.ts
@@ -1,10 +1,17 @@
+import { DynamoDBClient } from '@aws-sdk/client-dynamodb'
 import { S3Client, PutObjectCommand } from '@aws-sdk/client-s3'
+import { DynamoDBDocumentClient, GetCommand } from '@aws-sdk/lib-dynamodb'
 import { getSignedUrl } from '@aws-sdk/s3-request-presigner'
 import type { APIGatewayProxyEventV2, APIGatewayProxyStructuredResultV2 } from 'aws-lambda'
-import { UPLOAD_PREFIX, toProcessedKey } from './image-variants'
+import { UPLOAD_PREFIX } from './image-variants'
 
 const s3 = new S3Client({})
+const ddbClient = new DynamoDBClient({})
+const docClient = DynamoDBDocumentClient.from(ddbClient)
 const IMAGE_BUCKET_NAME = process.env.IMAGE_BUCKET_NAME ?? ''
+const TABLE_NAME = process.env.TABLE_NAME ?? ''
+
+const UUID_REGEX = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i
 
 function json(statusCode: number, body: Record<string, unknown>): APIGatewayProxyStructuredResultV2 {
   return { statusCode, headers: { 'Content-Type': 'application/json' }, body: JSON.stringify(body) }
@@ -29,7 +36,11 @@ function decodeToken(event: APIGatewayProxyEventV2): Record<string, unknown> | u
 interface UploadUrlBody {
   readonly recipeId?: string
   readonly imageType?: string
-  readonly stepOrder?: number
+  readonly stepId?: string
+}
+
+interface RecipeStep {
+  readonly stepId?: string
 }
 
 export async function handler(event: APIGatewayProxyEventV2): Promise<APIGatewayProxyStructuredResultV2> {
@@ -49,13 +60,28 @@ async function handleUploadUrl(event: APIGatewayProxyEventV2): Promise<APIGatewa
   const payload = decodeToken(event)
   if (!payload) return json(401, { error: 'Unauthorised' })
 
-  const { recipeId, imageType, stepOrder } = JSON.parse(event.body ?? '{}') as UploadUrlBody
+  const { recipeId, imageType, stepId } = JSON.parse(event.body ?? '{}') as UploadUrlBody
   if (!recipeId || !imageType) return json(400, { error: 'recipeId and imageType are required' })
-  if (imageType !== 'cover' && !stepOrder) return json(400, { error: 'stepOrder is required for step images' })
 
-  const uploadKey = imageType === 'cover'
-    ? `${UPLOAD_PREFIX}${recipeId}/cover`
-    : `${UPLOAD_PREFIX}${recipeId}/step-${stepOrder}`
+  // Step uploads must validate stepId BEFORE issuing the GetItem — saves a DDB read on a clearly-bad request.
+  if (imageType !== 'cover') {
+    if (!stepId) return json(400, { error: 'stepId is required for step images' })
+    if (!UUID_REGEX.test(stepId)) return json(400, { error: 'invalid_stepId' })
+  }
+
+  const recipe = await docClient.send(new GetCommand({ TableName: TABLE_NAME, Key: { id: recipeId } }))
+  if (!recipe.Item) return json(404, { error: 'Recipe not found' })
+
+  const slug = recipe.Item.slug as string
+
+  let uploadKey: string
+  if (imageType === 'cover') {
+    uploadKey = `${UPLOAD_PREFIX}${slug}/cover`
+  } else {
+    const steps = (recipe.Item.steps as RecipeStep[] | undefined) ?? []
+    if (!steps.some((s) => s.stepId === stepId)) return json(404, { error: 'step_not_found' })
+    uploadKey = `${UPLOAD_PREFIX}${slug}/step-${stepId}`
+  }
 
   const uploadUrl = await getSignedUrl(
     s3,
@@ -63,10 +89,5 @@ async function handleUploadUrl(event: APIGatewayProxyEventV2): Promise<APIGatewa
     { expiresIn: 900 },
   )
 
-  // `key` is where the resizer writes variants (the caller stores this and
-  // constructs image URLs like `/images/<key>-<variant>.webp`). The presigned
-  // URL still targets the raw uploads prefix that triggers the resizer.
-  const key = toProcessedKey(uploadKey)
-
-  return json(200, { uploadUrl, key })
+  return json(200, { uploadUrl })
 }

--- a/lambda/recipe-image-handler.ts
+++ b/lambda/recipe-image-handler.ts
@@ -1,17 +1,11 @@
-import { DynamoDBClient } from '@aws-sdk/client-dynamodb'
 import { S3Client, PutObjectCommand } from '@aws-sdk/client-s3'
-import { DynamoDBDocumentClient, GetCommand } from '@aws-sdk/lib-dynamodb'
 import { getSignedUrl } from '@aws-sdk/s3-request-presigner'
 import type { APIGatewayProxyEventV2, APIGatewayProxyStructuredResultV2 } from 'aws-lambda'
 import { UPLOAD_PREFIX } from './image-variants'
+import { getRecipeById, isValidStepId } from './recipe-store'
 
 const s3 = new S3Client({})
-const ddbClient = new DynamoDBClient({})
-const docClient = DynamoDBDocumentClient.from(ddbClient)
 const IMAGE_BUCKET_NAME = process.env.IMAGE_BUCKET_NAME ?? ''
-const TABLE_NAME = process.env.TABLE_NAME ?? ''
-
-const UUID_REGEX = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i
 
 function json(statusCode: number, body: Record<string, unknown>): APIGatewayProxyStructuredResultV2 {
   return { statusCode, headers: { 'Content-Type': 'application/json' }, body: JSON.stringify(body) }
@@ -39,10 +33,6 @@ interface UploadUrlBody {
   readonly stepId?: string
 }
 
-interface RecipeStep {
-  readonly stepId?: string
-}
-
 export async function handler(event: APIGatewayProxyEventV2): Promise<APIGatewayProxyStructuredResultV2> {
   try {
     switch (event.routeKey) {
@@ -66,19 +56,19 @@ async function handleUploadUrl(event: APIGatewayProxyEventV2): Promise<APIGatewa
   // Step uploads must validate stepId BEFORE issuing the GetItem — saves a DDB read on a clearly-bad request.
   if (imageType !== 'cover') {
     if (!stepId) return json(400, { error: 'stepId is required for step images' })
-    if (!UUID_REGEX.test(stepId)) return json(400, { error: 'invalid_stepId' })
+    if (!isValidStepId(stepId)) return json(400, { error: 'invalid_stepId' })
   }
 
-  const recipe = await docClient.send(new GetCommand({ TableName: TABLE_NAME, Key: { id: recipeId } }))
-  if (!recipe.Item) return json(404, { error: 'Recipe not found' })
+  const recipe = await getRecipeById(recipeId)
+  if (!recipe) return json(404, { error: 'Recipe not found' })
 
-  const slug = recipe.Item.slug as string
+  const slug = recipe.slug
 
   let uploadKey: string
   if (imageType === 'cover') {
     uploadKey = `${UPLOAD_PREFIX}${slug}/cover`
   } else {
-    const steps = (recipe.Item.steps as RecipeStep[] | undefined) ?? []
+    const steps = recipe.steps ?? []
     if (!steps.some((s) => s.stepId === stepId)) return json(404, { error: 'step_not_found' })
     uploadKey = `${UPLOAD_PREFIX}${slug}/step-${stepId}`
   }

--- a/lambda/recipe-store.ts
+++ b/lambda/recipe-store.ts
@@ -1,12 +1,12 @@
 import { DynamoDBClient } from '@aws-sdk/client-dynamodb'
 import { DynamoDBDocumentClient, GetCommand, QueryCommand } from '@aws-sdk/lib-dynamodb'
 
-const docClient = DynamoDBDocumentClient.from(new DynamoDBClient({}))
+export const docClient = DynamoDBDocumentClient.from(new DynamoDBClient({}))
 const TABLE_NAME = process.env.TABLE_NAME ?? ''
 
 export const SLUG_INDEX_NAME = 'slug-index'
 
-export const STEP_ID_REGEX = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i
+const STEP_ID_REGEX = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i
 
 export function isValidStepId(stepId: string): boolean {
   return STEP_ID_REGEX.test(stepId)
@@ -20,7 +20,6 @@ export interface Recipe extends Record<string, unknown> {
   readonly id?: string
   readonly slug?: string
   readonly steps?: readonly RecipeStep[]
-  readonly imageStatus?: Record<string, number>
 }
 
 export async function getRecipeById(id: string): Promise<Recipe | undefined> {

--- a/lambda/recipe-store.ts
+++ b/lambda/recipe-store.ts
@@ -1,10 +1,23 @@
 import { DynamoDBClient } from '@aws-sdk/client-dynamodb'
-import { DynamoDBDocumentClient, GetCommand, QueryCommand } from '@aws-sdk/lib-dynamodb'
+import {
+  DynamoDBDocumentClient,
+  GetCommand,
+  QueryCommand,
+  PutCommand,
+  UpdateCommand,
+  DeleteCommand,
+  ScanCommand,
+  type UpdateCommandInput,
+  type UpdateCommandOutput,
+  type ScanCommandInput,
+} from '@aws-sdk/lib-dynamodb'
 
 export const docClient = DynamoDBDocumentClient.from(new DynamoDBClient({}))
 const TABLE_NAME = process.env.TABLE_NAME ?? ''
 
 export const SLUG_INDEX_NAME = 'slug-index'
+const STATUS_INDEX_NAME = 'status-createdAt-index'
+const AUTHOR_INDEX_NAME = 'authorId-createdAt-index'
 
 const STEP_ID_REGEX = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i
 
@@ -19,6 +32,10 @@ export interface RecipeStep {
 export interface Recipe extends Record<string, unknown> {
   readonly id?: string
   readonly slug?: string
+  readonly status?: string
+  readonly authorId?: string
+  readonly ttl?: number
+  readonly imageStatus?: Record<string, number>
   readonly steps?: readonly RecipeStep[]
 }
 
@@ -45,4 +62,50 @@ export async function queryRecipeIdsBySlug(slug: string): Promise<(string | unde
 export async function findIdBySlug(slug: string): Promise<string | undefined> {
   const [id] = await queryRecipeIdsBySlug(slug)
   return id
+}
+
+export async function queryRecipesByStatus(status: string): Promise<Recipe[]> {
+  const result = await docClient.send(
+    new QueryCommand({
+      TableName: TABLE_NAME,
+      IndexName: STATUS_INDEX_NAME,
+      KeyConditionExpression: '#status = :status',
+      ExpressionAttributeNames: { '#status': 'status' },
+      ExpressionAttributeValues: { ':status': status },
+      ScanIndexForward: false,
+    }),
+  )
+  return (result.Items ?? []) as Recipe[]
+}
+
+export async function queryRecipesByAuthor(authorId: string): Promise<Recipe[]> {
+  const result = await docClient.send(
+    new QueryCommand({
+      TableName: TABLE_NAME,
+      IndexName: AUTHOR_INDEX_NAME,
+      KeyConditionExpression: 'authorId = :authorId',
+      ExpressionAttributeValues: { ':authorId': authorId },
+      ScanIndexForward: false,
+    }),
+  )
+  return (result.Items ?? []) as Recipe[]
+}
+
+export async function scanRecipes(input: Omit<ScanCommandInput, 'TableName'>): Promise<Recipe[]> {
+  const result = await docClient.send(new ScanCommand({ TableName: TABLE_NAME, ...input }))
+  return (result.Items ?? []) as Recipe[]
+}
+
+export async function putRecipe(item: Record<string, unknown>): Promise<void> {
+  await docClient.send(new PutCommand({ TableName: TABLE_NAME, Item: item }))
+}
+
+export async function deleteRecipe(id: string): Promise<void> {
+  await docClient.send(new DeleteCommand({ TableName: TABLE_NAME, Key: { id } }))
+}
+
+// Update seam: owns the table name and client; callers supply the rest of the
+// UpdateCommand input (Key, expressions, ReturnValues, condition handling).
+export function updateRecipe(input: Omit<UpdateCommandInput, 'TableName'>): Promise<UpdateCommandOutput> {
+  return docClient.send(new UpdateCommand({ TableName: TABLE_NAME, ...input }))
 }

--- a/lambda/recipe-store.ts
+++ b/lambda/recipe-store.ts
@@ -1,0 +1,49 @@
+import { DynamoDBClient } from '@aws-sdk/client-dynamodb'
+import { DynamoDBDocumentClient, GetCommand, QueryCommand } from '@aws-sdk/lib-dynamodb'
+
+const docClient = DynamoDBDocumentClient.from(new DynamoDBClient({}))
+const TABLE_NAME = process.env.TABLE_NAME ?? ''
+
+export const SLUG_INDEX_NAME = 'slug-index'
+
+export const STEP_ID_REGEX = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i
+
+export function isValidStepId(stepId: string): boolean {
+  return STEP_ID_REGEX.test(stepId)
+}
+
+export interface RecipeStep {
+  readonly stepId?: string
+}
+
+export interface Recipe extends Record<string, unknown> {
+  readonly id?: string
+  readonly slug?: string
+  readonly steps?: readonly RecipeStep[]
+  readonly imageStatus?: Record<string, number>
+}
+
+export async function getRecipeById(id: string): Promise<Recipe | undefined> {
+  const result = await docClient.send(new GetCommand({ TableName: TABLE_NAME, Key: { id } }))
+  return result.Item as Recipe | undefined
+}
+
+// Returns the id of every recipe row matching the slug. The slug-index GSI tolerates
+// transient duplicate-slug rows, so callers that need exclude-self semantics inspect
+// the full list rather than the first hit.
+export async function queryRecipeIdsBySlug(slug: string): Promise<(string | undefined)[]> {
+  const result = await docClient.send(
+    new QueryCommand({
+      TableName: TABLE_NAME,
+      IndexName: SLUG_INDEX_NAME,
+      KeyConditionExpression: 'slug = :slug',
+      ExpressionAttributeValues: { ':slug': slug },
+    }),
+  )
+  return (result.Items ?? []).map((item) => (item as { id?: string }).id)
+}
+
+export async function findIdBySlug(slug: string): Promise<string | undefined> {
+  const [id] = await queryRecipeIdsBySlug(slug)
+  return id
+}

--- a/lib/recipe-stack.ts
+++ b/lib/recipe-stack.ts
@@ -49,6 +49,12 @@ export class RecipeStack extends Stack {
       sortKey: { name: 'createdAt', type: dynamodb.AttributeType.STRING },
     })
 
+    table.addGlobalSecondaryIndex({
+      indexName: 'slug-index',
+      partitionKey: { name: 'slug', type: dynamodb.AttributeType.STRING },
+      projectionType: dynamodb.ProjectionType.KEYS_ONLY,
+    })
+
     // S3 image bucket
     const imageBucket = new s3.Bucket(this, 'RecipeImagesBucket', {
       bucketName: `akli-recipe-images-${this.account}-${this.region}`,
@@ -115,10 +121,15 @@ export class RecipeStack extends Stack {
       functionName: 'akli-recipe-image-handler',
       environment: {
         IMAGE_BUCKET_NAME: imageBucket.bucketName,
+        TABLE_NAME: table.tableName,
       },
     })
 
     imageBucket.grantPut(recipeImageHandler)
+    recipeImageHandler.addToRolePolicy(new iam.PolicyStatement({
+      actions: ['dynamodb:GetItem'],
+      resources: [table.tableArn],
+    }))
 
     const imageResizer = new NodejsFunction(this, 'ImageResizer', {
       runtime: lambda.Runtime.NODEJS_22_X,
@@ -157,6 +168,10 @@ export class RecipeStack extends Stack {
     imageResizer.addToRolePolicy(new iam.PolicyStatement({
       actions: ['dynamodb:UpdateItem'],
       resources: [table.tableArn],
+    }))
+    imageResizer.addToRolePolicy(new iam.PolicyStatement({
+      actions: ['dynamodb:Query'],
+      resources: [`${table.tableArn}/index/slug-index`],
     }))
 
     // S3 event notification for image uploads

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "akli-infrastructure",
   "description": "Infrastructure as Code for akli.dev",
-  "version": "1.8.0",
+  "version": "1.9.0",
   "bin": {
     "akli-cdk": "bin/akli-cdk.js"
   },

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,3 +1,3 @@
-allowBuilds:
-  esbuild: true
-  sharp: true
+onlyBuiltDependencies:
+  - esbuild
+  - sharp

--- a/test/lambda/image-resizer.test.ts
+++ b/test/lambda/image-resizer.test.ts
@@ -287,6 +287,26 @@ describe('image-resizer handler', () => {
     infoSpy.mockRestore()
   })
 
+  it('logs unrecognised_key_shape and still deletes the source for a key with extra path segments', async () => {
+    const infoSpy = jest.spyOn(console, 'info').mockImplementation(() => {})
+
+    // Passes toProcessedKey's prefix guard but parseRecipeSlug rejects the 3-segment tail.
+    await expect(handler(makeS3Event('uploads/recipes/abc/cover/extra'))).resolves.toBeUndefined()
+
+    // No recipe resolution attempted.
+    expect(ddbMock.commandCalls(QueryCommand)).toHaveLength(0)
+    expect(ddbMock.commandCalls(UpdateCommand)).toHaveLength(0)
+
+    // A deliberate, logged skip still deletes the source.
+    expect(s3Mock.commandCalls(DeleteObjectCommand)).toHaveLength(1)
+
+    expect(infoSpy).toHaveBeenCalledWith(
+      expect.objectContaining({ event: 'resizer.writeback.skipped', reason: 'unrecognised_key_shape' }),
+    )
+
+    infoSpy.mockRestore()
+  })
+
   it('rethrows non-conditional DDB errors and leaves the source in place for retry', async () => {
     ddbMock.on(UpdateCommand).rejects(new Error('boom'))
 

--- a/test/lambda/image-resizer.test.ts
+++ b/test/lambda/image-resizer.test.ts
@@ -1,6 +1,6 @@
 import { ConditionalCheckFailedException } from '@aws-sdk/client-dynamodb'
 import { S3Client, GetObjectCommand, PutObjectCommand, DeleteObjectCommand } from '@aws-sdk/client-s3'
-import { DynamoDBDocumentClient, UpdateCommand } from '@aws-sdk/lib-dynamodb'
+import { DynamoDBDocumentClient, QueryCommand, UpdateCommand } from '@aws-sdk/lib-dynamodb'
 import type { S3Event } from 'aws-lambda'
 import { mockClient } from 'aws-sdk-client-mock'
 
@@ -17,7 +17,11 @@ jest.mock('sharp', () => jest.fn(() => mockSharp))
 process.env.IMAGE_BUCKET_NAME = 'test-image-bucket'
 process.env.TABLE_NAME = 'test-recipes-table'
 
-import { handler } from '../../lambda/image-resizer'
+import * as imageResizer from '../../lambda/image-resizer'
+
+const { handler } = imageResizer
+
+const RESOLVED_ID = 'recipe-id-resolved-by-gsi'
 
 function makeS3Event(key: string, bucket = 'test-image-bucket'): S3Event {
   return {
@@ -54,6 +58,37 @@ function makeS3Event(key: string, bucket = 'test-image-bucket'): S3Event {
   }
 }
 
+describe('parseRecipeSlug', () => {
+  type ParseRecipeSlug = (key: string) => string | undefined
+
+  function getParseRecipeSlug(): ParseRecipeSlug {
+    const exported = (imageResizer as unknown as Record<string, unknown>).parseRecipeSlug
+    if (typeof exported !== 'function') {
+      throw new Error('parseRecipeSlug is not exported from image-resizer.ts')
+    }
+    return exported as ParseRecipeSlug
+  }
+
+  it('returns the slug segment for a well-formed cover upload key', () => {
+    const parseRecipeSlug = getParseRecipeSlug()
+    expect(parseRecipeSlug('uploads/recipes/beans-on-toast/cover')).toBe('beans-on-toast')
+  })
+
+  it('returns undefined for a key that does not start with the upload prefix', () => {
+    const parseRecipeSlug = getParseRecipeSlug()
+    expect(parseRecipeSlug('uploads/something-else/beans-on-toast/cover')).toBeUndefined()
+  })
+
+  it('is the only key-parser exported from image-resizer.ts (no parseRecipeId)', () => {
+    expect(
+      (imageResizer as unknown as Record<string, unknown>).parseRecipeId,
+    ).toBeUndefined()
+    expect(
+      typeof (imageResizer as unknown as Record<string, unknown>).parseRecipeSlug,
+    ).toBe('function')
+  })
+})
+
 describe('image-resizer handler', () => {
   beforeEach(() => {
     s3Mock.reset()
@@ -67,6 +102,7 @@ describe('image-resizer handler', () => {
     })
     s3Mock.on(PutObjectCommand).resolves({})
     s3Mock.on(DeleteObjectCommand).resolves({})
+    ddbMock.on(QueryCommand).resolves({ Items: [{ id: RESOLVED_ID }] })
     ddbMock.on(UpdateCommand).resolves({})
   })
 
@@ -139,7 +175,20 @@ describe('image-resizer handler', () => {
     }
   })
 
-  it('writes back imageStatus to DynamoDB after variant PUTs for a cover image', async () => {
+  it('queries the slug-index GSI to resolve the parsed slug to a recipe id', async () => {
+    await handler(makeS3Event('uploads/recipes/beans-on-toast/cover'))
+
+    const queryCalls = ddbMock.commandCalls(QueryCommand)
+    expect(queryCalls).toHaveLength(1)
+
+    const input = queryCalls[0].args[0].input
+    expect(input.TableName).toBe('test-recipes-table')
+    expect(input.IndexName).toBe('slug-index')
+    expect(input.KeyConditionExpression).toBe('slug = :slug')
+    expect(input.ExpressionAttributeValues).toEqual({ ':slug': 'beans-on-toast' })
+  })
+
+  it('writes back imageStatus to DynamoDB after variant PUTs for a cover image, keyed by the GSI-resolved id', async () => {
     const before = Date.now()
     await handler(makeS3Event('uploads/recipes/abc/cover'))
     const after = Date.now()
@@ -149,7 +198,8 @@ describe('image-resizer handler', () => {
 
     const input = updateCalls[0].args[0].input
     expect(input.TableName).toBe('test-recipes-table')
-    expect(input.Key).toEqual({ id: 'abc' })
+    // The path segment 'abc' is the slug; the id used in the Key comes from the GSI lookup.
+    expect(input.Key).toEqual({ id: RESOLVED_ID })
     expect(input.UpdateExpression).toBe('SET imageStatus.#k = :ts')
     expect(input.ConditionExpression).toBe('attribute_exists(id)')
     expect(input.ExpressionAttributeNames).toEqual({ '#k': 'recipes/abc/cover' })
@@ -161,18 +211,52 @@ describe('image-resizer handler', () => {
     expect(ts).toBeLessThanOrEqual(after)
   })
 
-  it('writes back imageStatus to DynamoDB for a step image key', async () => {
-    await handler(makeS3Event('uploads/recipes/abc/step-2'))
+  it('writes back imageStatus to DynamoDB for a step image key, keyed by the GSI-resolved id', async () => {
+    await handler(makeS3Event('uploads/recipes/abc/step-9d904a59-e83f-43b8-9f40-fbdb3008974c'))
 
     const updateCalls = ddbMock.commandCalls(UpdateCommand)
     expect(updateCalls).toHaveLength(1)
 
     const input = updateCalls[0].args[0].input
-    expect(input.Key).toEqual({ id: 'abc' })
-    expect(input.ExpressionAttributeNames).toEqual({ '#k': 'recipes/abc/step-2' })
+    expect(input.Key).toEqual({ id: RESOLVED_ID })
+    expect(input.ExpressionAttributeNames).toEqual({
+      '#k': 'recipes/abc/step-9d904a59-e83f-43b8-9f40-fbdb3008974c',
+    })
   })
 
-  it('swallows ConditionalCheckFailedException, still deletes source, and logs skip event', async () => {
+  it('logs recipe_not_found and skips the DDB write when the GSI returns no items; variant PUTs and source delete still ran', async () => {
+    const infoSpy = jest.spyOn(console, 'info').mockImplementation(() => {})
+    ddbMock.on(QueryCommand).resolves({ Items: [] })
+
+    await expect(handler(makeS3Event('uploads/recipes/missing-slug/cover'))).resolves.toBeUndefined()
+
+    // Variant PUTs still ran.
+    expect(s3Mock.commandCalls(PutObjectCommand)).toHaveLength(3)
+
+    // Source delete still ran.
+    const deleteCalls = s3Mock.commandCalls(DeleteObjectCommand)
+    expect(deleteCalls).toHaveLength(1)
+    expect(deleteCalls[0].args[0].input).toEqual({
+      Bucket: 'test-image-bucket',
+      Key: 'uploads/recipes/missing-slug/cover',
+    })
+
+    // No UpdateCommand was issued.
+    expect(ddbMock.commandCalls(UpdateCommand)).toHaveLength(0)
+
+    // Structured info log emitted with the expected reason and key.
+    expect(infoSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        event: 'resizer.writeback.skipped',
+        reason: 'recipe_not_found',
+        key: 'uploads/recipes/missing-slug/cover',
+      }),
+    )
+
+    infoSpy.mockRestore()
+  })
+
+  it('swallows ConditionalCheckFailedException (recipe_deleted skip), with the source-delete already having fired before the UpdateCommand', async () => {
     const infoSpy = jest.spyOn(console, 'info').mockImplementation(() => {})
 
     const condFailed = new ConditionalCheckFailedException({
@@ -183,7 +267,7 @@ describe('image-resizer handler', () => {
 
     await expect(handler(makeS3Event('uploads/recipes/abc/cover'))).resolves.toBeUndefined()
 
-    // Source-delete still runs.
+    // Source-delete fired (earlier in the flow, before the UpdateCommand threw).
     const deleteCalls = s3Mock.commandCalls(DeleteObjectCommand)
     expect(deleteCalls).toHaveLength(1)
     expect(deleteCalls[0].args[0].input).toEqual({
@@ -208,21 +292,21 @@ describe('image-resizer handler', () => {
     await expect(handler(makeS3Event('uploads/recipes/abc/cover'))).rejects.toThrow('boom')
   })
 
-  it('throws and writes nothing for a malformed key that does not match uploads/recipes/<id>/...', async () => {
+  it('throws and writes nothing for a malformed key that does not match uploads/recipes/<slug>/...', async () => {
     // With UPLOAD_PREFIX = 'uploads/recipes/', this key fails the prefix guard
     // inside toProcessedKey and the handler now refuses to process it.
     await expect(handler(makeS3Event('uploads/not-recipes/x'))).rejects.toThrow(/uploads\/recipes\//)
 
+    expect(ddbMock.commandCalls(QueryCommand)).toHaveLength(0)
     expect(ddbMock.commandCalls(UpdateCommand)).toHaveLength(0)
     expect(s3Mock.commandCalls(PutObjectCommand)).toHaveLength(0)
     expect(s3Mock.commandCalls(DeleteObjectCommand)).toHaveLength(0)
   })
 
-  it('invokes DDB UpdateCommand before the source DeleteObjectCommand', async () => {
-    // Sequencing is enforced via the handler's error-propagation contract: if the
-    // UpdateCommand is issued BEFORE the source DeleteObjectCommand, rejecting the
-    // UpdateCommand with a generic error must prevent the source-delete from firing.
-    // If the delete were issued first, it would run regardless of the DDB outcome.
+  it('invokes the source DeleteObjectCommand BEFORE the UpdateCommand (variants -> delete source -> query GSI -> update DDB)', async () => {
+    // Sequencing-probe trick (mirrors the previous "Update before Delete" assertion, inverted):
+    // if the UpdateCommand is issued AFTER the source DeleteObjectCommand, rejecting the
+    // UpdateCommand with a generic error must NOT prevent the source-delete from having fired.
     ddbMock.on(UpdateCommand).rejects(new Error('sequencing-probe'))
 
     await expect(handler(makeS3Event('uploads/recipes/abc/cover'))).rejects.toThrow(
@@ -230,7 +314,44 @@ describe('image-resizer handler', () => {
     )
 
     expect(ddbMock.commandCalls(UpdateCommand)).toHaveLength(1)
-    // Source-delete never fires because the update threw first.
-    expect(s3Mock.commandCalls(DeleteObjectCommand)).toHaveLength(0)
+    // Source-delete fired earlier in the flow, before the UpdateCommand threw.
+    expect(s3Mock.commandCalls(DeleteObjectCommand)).toHaveLength(1)
+  })
+
+  it('orders the resizer flow as: write variants -> delete source -> query GSI -> update DDB', async () => {
+    // Track call order across both mocks via a shared sequence counter using jest.spyOn
+    // on the underlying send methods. aws-sdk-client-mock exposes per-mock call lists but
+    // not a cross-mock chronological one, so we tag calls as they happen.
+    const sequence: string[] = []
+
+    s3Mock.on(PutObjectCommand).callsFake(async () => {
+      sequence.push('s3:put')
+      return {}
+    })
+    s3Mock.on(DeleteObjectCommand).callsFake(async () => {
+      sequence.push('s3:delete')
+      return {}
+    })
+    ddbMock.on(QueryCommand).callsFake(async () => {
+      sequence.push('ddb:query')
+      return { Items: [{ id: RESOLVED_ID }] }
+    })
+    ddbMock.on(UpdateCommand).callsFake(async () => {
+      sequence.push('ddb:update')
+      return {}
+    })
+
+    await handler(makeS3Event('uploads/recipes/abc/cover'))
+
+    // Three variant PUTs first (in any order amongst themselves — they fire concurrently),
+    // then the source delete, then the GSI query, then the update.
+    expect(sequence.filter((step) => step === 's3:put')).toHaveLength(3)
+    const tail = sequence.filter((step) => step !== 's3:put')
+    expect(tail).toEqual(['s3:delete', 'ddb:query', 'ddb:update'])
+
+    // And every PUT preceded the source delete.
+    const lastPutIndex = sequence.lastIndexOf('s3:put')
+    const deleteIndex = sequence.indexOf('s3:delete')
+    expect(lastPutIndex).toBeLessThan(deleteIndex)
   })
 })

--- a/test/lambda/image-resizer.test.ts
+++ b/test/lambda/image-resizer.test.ts
@@ -256,7 +256,7 @@ describe('image-resizer handler', () => {
     infoSpy.mockRestore()
   })
 
-  it('swallows ConditionalCheckFailedException (recipe_deleted skip), with the source-delete already having fired before the UpdateCommand', async () => {
+  it('swallows ConditionalCheckFailedException (recipe_deleted skip) and still deletes the source after the skip', async () => {
     const infoSpy = jest.spyOn(console, 'info').mockImplementation(() => {})
 
     const condFailed = new ConditionalCheckFailedException({
@@ -267,7 +267,8 @@ describe('image-resizer handler', () => {
 
     await expect(handler(makeS3Event('uploads/recipes/abc/cover'))).resolves.toBeUndefined()
 
-    // Source-delete fired (earlier in the flow, before the UpdateCommand threw).
+    // recipe_deleted is a deliberate, logged skip, so the source-delete still fires
+    // (now at the end of the flow, after the swallowed UpdateCommand).
     const deleteCalls = s3Mock.commandCalls(DeleteObjectCommand)
     expect(deleteCalls).toHaveLength(1)
     expect(deleteCalls[0].args[0].input).toEqual({
@@ -286,10 +287,25 @@ describe('image-resizer handler', () => {
     infoSpy.mockRestore()
   })
 
-  it('rethrows non-conditional DDB errors', async () => {
+  it('rethrows non-conditional DDB errors and leaves the source in place for retry', async () => {
     ddbMock.on(UpdateCommand).rejects(new Error('boom'))
 
     await expect(handler(makeS3Event('uploads/recipes/abc/cover'))).rejects.toThrow('boom')
+
+    // Durability: a transient (non-conditional) writeback failure must NOT delete
+    // the source, so the Lambda retry can regenerate the variants and stamp
+    // imageStatus instead of hitting a 404 on the already-deleted source.
+    expect(s3Mock.commandCalls(DeleteObjectCommand)).toHaveLength(0)
+  })
+
+  it('rethrows a transient GSI-lookup failure and leaves the source in place for retry', async () => {
+    ddbMock.on(QueryCommand).rejects(new Error('throttled'))
+
+    await expect(handler(makeS3Event('uploads/recipes/abc/cover'))).rejects.toThrow('throttled')
+
+    // The lookup failed before the writeback; the source must survive the retry.
+    expect(ddbMock.commandCalls(UpdateCommand)).toHaveLength(0)
+    expect(s3Mock.commandCalls(DeleteObjectCommand)).toHaveLength(0)
   })
 
   it('throws and writes nothing for a malformed key that does not match uploads/recipes/<slug>/...', async () => {
@@ -303,10 +319,10 @@ describe('image-resizer handler', () => {
     expect(s3Mock.commandCalls(DeleteObjectCommand)).toHaveLength(0)
   })
 
-  it('invokes the source DeleteObjectCommand BEFORE the UpdateCommand (variants -> delete source -> query GSI -> update DDB)', async () => {
-    // Sequencing-probe trick (mirrors the previous "Update before Delete" assertion, inverted):
-    // if the UpdateCommand is issued AFTER the source DeleteObjectCommand, rejecting the
-    // UpdateCommand with a generic error must NOT prevent the source-delete from having fired.
+  it('does NOT delete the source when the UpdateCommand throws a transient error (writeback precedes delete)', async () => {
+    // Sequencing probe: the source-delete now fires LAST, after the writeback. So a
+    // generic (non-conditional) UpdateCommand rejection must prevent the source-delete
+    // from firing at all — the source survives for the Lambda retry.
     ddbMock.on(UpdateCommand).rejects(new Error('sequencing-probe'))
 
     await expect(handler(makeS3Event('uploads/recipes/abc/cover'))).rejects.toThrow(
@@ -314,11 +330,11 @@ describe('image-resizer handler', () => {
     )
 
     expect(ddbMock.commandCalls(UpdateCommand)).toHaveLength(1)
-    // Source-delete fired earlier in the flow, before the UpdateCommand threw.
-    expect(s3Mock.commandCalls(DeleteObjectCommand)).toHaveLength(1)
+    // Source-delete did NOT fire — it sits after the writeback that threw.
+    expect(s3Mock.commandCalls(DeleteObjectCommand)).toHaveLength(0)
   })
 
-  it('orders the resizer flow as: write variants -> delete source -> query GSI -> update DDB', async () => {
+  it('orders the resizer flow as: write variants -> query GSI -> update DDB -> delete source', async () => {
     // Track call order across both mocks via a shared sequence counter using jest.spyOn
     // on the underlying send methods. aws-sdk-client-mock exposes per-mock call lists but
     // not a cross-mock chronological one, so we tag calls as they happen.
@@ -344,10 +360,10 @@ describe('image-resizer handler', () => {
     await handler(makeS3Event('uploads/recipes/abc/cover'))
 
     // Three variant PUTs first (in any order amongst themselves — they fire concurrently),
-    // then the source delete, then the GSI query, then the update.
+    // then the GSI query, then the writeback, and the source delete fires LAST.
     expect(sequence.filter((step) => step === 's3:put')).toHaveLength(3)
     const tail = sequence.filter((step) => step !== 's3:put')
-    expect(tail).toEqual(['s3:delete', 'ddb:query', 'ddb:update'])
+    expect(tail).toEqual(['ddb:query', 'ddb:update', 's3:delete'])
 
     // And every PUT preceded the source delete.
     const lastPutIndex = sequence.lastIndexOf('s3:put')

--- a/test/lambda/recipe-handler.test.ts
+++ b/test/lambda/recipe-handler.test.ts
@@ -916,16 +916,19 @@ describe('Recipe Lambda handler', () => {
     })
 
     it('composes processedAt onto images and strips imageStatus from the response body', async () => {
-      const coverKey = 'recipes/recipe-uuid-1/cover'
-      const step1Key = 'recipes/recipe-uuid-1/step-1'
+      const slug = 'slow-cooked-lamb-ragu'
+      const stepId = 'a0000000-0000-4000-8000-000000000001'
+      const coverKey = `recipes/${slug}/cover`
+      const step1Key = `recipes/${slug}/step-${stepId}`
       const coverTs = 1_745_000_000_001
       const step1Ts = 1_745_000_000_002
 
       const item = publishedRecipeItem({
         id: 'recipe-uuid-1',
-        coverImage: { key: coverKey, alt: 'A bowl of lamb ragu' },
+        slug,
+        coverImage: { alt: 'A bowl of lamb ragu' },
         steps: [
-          { order: 1, text: 'Sear.', image: { key: step1Key, alt: 'seared lamb' } },
+          { stepId, order: 1, text: 'Sear.', image: { alt: 'seared lamb' } },
         ],
         imageStatus: { [coverKey]: coverTs, [step1Key]: step1Ts },
       })
@@ -944,8 +947,8 @@ describe('Recipe Lambda handler', () => {
       expect(result.body).not.toContain('imageStatus')
       const body = JSON.parse(result.body as string)
       expect(body).not.toHaveProperty('imageStatus')
-      expect(body.coverImage).toEqual({ key: coverKey, alt: 'A bowl of lamb ragu', processedAt: coverTs })
-      expect(body.steps[0].image).toEqual({ key: step1Key, alt: 'seared lamb', processedAt: step1Ts })
+      expect(body.coverImage).toEqual({ alt: 'A bowl of lamb ragu', processedAt: coverTs })
+      expect(body.steps[0].image).toEqual({ alt: 'seared lamb', processedAt: step1Ts })
     })
   })
 
@@ -1132,15 +1135,27 @@ describe('Recipe Lambda handler', () => {
       expect(updateCalls[0].args[0].input.ReturnValues).toBe('ALL_OLD')
     })
 
-    it('diffs image swap against the UpdateCommand ALL_OLD snapshot, not the pre-read', async () => {
+    it('diffs image-removal against the UpdateCommand ALL_OLD snapshot, not the pre-read', async () => {
+      // The pre-read has stepId-X but the atomic-old (the ALL_OLD snapshot) has stepId-Y.
+      // The PATCH body drops both, but the cleanup must target the keys present in the
+      // atomic-old snapshot — that's the source of truth for what was actually removed.
+      const stepIdX = 'a0000000-0000-4000-8000-00000000000a'
+      const stepIdY = 'a0000000-0000-4000-8000-00000000000b'
+      const slug = 'lamb-ragu'
+
       const preReadItem = publishedRecipeItem({
         id: 'recipe-uuid-1',
+        slug,
         authorId: 'contributor-user-id',
-        coverImage: { key: 'keyA', alt: 'Pre-read alt' },
+        steps: [
+          { stepId: stepIdX, order: 1, text: 'Pre-read step', image: { alt: 'pre-read alt' } },
+        ],
       })
       const atomicOldItem = {
         ...preReadItem,
-        coverImage: { key: 'keyB', alt: 'Atomic-old alt' },
+        steps: [
+          { stepId: stepIdY, order: 1, text: 'Atomic-old step', image: { alt: 'atomic-old alt' } },
+        ],
       }
       ddbMock.on(GetCommand).resolves({ Item: preReadItem })
       ddbMock.on(UpdateCommand).resolves({ Attributes: atomicOldItem })
@@ -1151,7 +1166,7 @@ describe('Recipe Lambda handler', () => {
         rawPath: '/recipes/recipe-uuid-1',
         pathParameters: { id: 'recipe-uuid-1' },
         headers: { authorization: `Bearer ${adminToken}` },
-        body: JSON.stringify({ coverImage: { key: 'keyC', alt: 'New alt' } }),
+        body: JSON.stringify({ steps: [] }),
       })
 
       const result = await handler(event)
@@ -1161,132 +1176,26 @@ describe('Recipe Lambda handler', () => {
       const deleteCalls = s3Mock.commandCalls(DeleteObjectsCommand)
       expect(deleteCalls).toHaveLength(1)
       const keys = (deleteCalls[0].args[0].input.Delete?.Objects ?? []).map((o) => o.Key)
-      // Diff must be against the atomic-old snapshot (keyB), not the pre-read (keyA).
-      expect(keys).toContain('keyB-thumb.webp')
-      expect(keys).toContain('keyB-medium.webp')
-      expect(keys).toContain('keyB-full.webp')
-      expect(keys).not.toContain('keyA-thumb.webp')
-      expect(keys).not.toContain('keyA-medium.webp')
-      expect(keys).not.toContain('keyA-full.webp')
+      // Diff must be against the atomic-old snapshot (stepIdY), not the pre-read (stepIdX).
+      expect(keys).toContain(`recipes/${slug}/step-${stepIdY}-thumb.webp`)
+      expect(keys).toContain(`recipes/${slug}/step-${stepIdY}-medium.webp`)
+      expect(keys).toContain(`recipes/${slug}/step-${stepIdY}-full.webp`)
+      expect(keys).not.toContain(`recipes/${slug}/step-${stepIdX}-thumb.webp`)
+      expect(keys).not.toContain(`recipes/${slug}/step-${stepIdX}-medium.webp`)
+      expect(keys).not.toContain(`recipes/${slug}/step-${stepIdX}-full.webp`)
       expect(keys).toHaveLength(3)
     })
 
-    it('cover-image swap deletes the three old variants from S3', async () => {
+    it('PATCH that does not drop any cover or step image triggers no S3 delete', async () => {
+      const stepIdA = 'a0000000-0000-4000-8000-000000000001'
+      const slug = 'lamb-ragu'
       const oldItem = publishedRecipeItem({
         id: 'recipe-uuid-1',
+        slug,
         authorId: 'contributor-user-id',
-        coverImage: { key: 'recipes/images/recipe-1/cover', alt: 'Old alt' },
-      })
-      ddbMock.on(GetCommand).resolves({ Item: oldItem })
-      ddbMock.on(UpdateCommand).resolves({ Attributes: oldItem })
-      s3Mock.on(DeleteObjectsCommand).resolves({})
-
-      const event = makeEvent({
-        routeKey: 'PATCH /recipes/{id}',
-        rawPath: '/recipes/recipe-uuid-1',
-        pathParameters: { id: 'recipe-uuid-1' },
-        headers: { authorization: `Bearer ${adminToken}` },
-        body: JSON.stringify({ coverImage: { key: 'recipes/images/recipe-1/cover-v2', alt: 'New alt' } }),
-      })
-
-      const result = await handler(event)
-
-      expect(result.statusCode).toBe(200)
-
-      const deleteCalls = s3Mock.commandCalls(DeleteObjectsCommand)
-      expect(deleteCalls).toHaveLength(1)
-      const deleteInput = deleteCalls[0].args[0].input
-      const keys = (deleteInput.Delete?.Objects ?? []).map((o) => o.Key)
-      expect(keys).toContain('recipes/images/recipe-1/cover-thumb.webp')
-      expect(keys).toContain('recipes/images/recipe-1/cover-medium.webp')
-      expect(keys).toContain('recipes/images/recipe-1/cover-full.webp')
-      expect(keys).toHaveLength(3)
-    })
-
-    it('same cover-image key triggers no S3 delete', async () => {
-      const oldItem = publishedRecipeItem({
-        id: 'recipe-uuid-1',
-        authorId: 'contributor-user-id',
-        coverImage: { key: 'recipes/images/recipe-1/cover', alt: 'Old alt' },
-      })
-      ddbMock.on(GetCommand).resolves({ Item: oldItem })
-      ddbMock.on(UpdateCommand).resolves({ Attributes: oldItem })
-
-      const event = makeEvent({
-        routeKey: 'PATCH /recipes/{id}',
-        rawPath: '/recipes/recipe-uuid-1',
-        pathParameters: { id: 'recipe-uuid-1' },
-        headers: { authorization: `Bearer ${adminToken}` },
-        body: JSON.stringify({ coverImage: { key: 'recipes/images/recipe-1/cover', alt: 'Same key' } }),
-      })
-
-      const result = await handler(event)
-
-      expect(result.statusCode).toBe(200)
-      expect(s3Mock.commandCalls(DeleteObjectsCommand)).toHaveLength(0)
-    })
-
-    it('step-image swap deletes old variants by key-set (reorder-safe)', async () => {
-      const oldItem = publishedRecipeItem({
-        id: 'recipe-uuid-1',
-        authorId: 'contributor-user-id',
+        coverImage: { alt: 'Old alt' },
         steps: [
-          { order: 1, text: 'A', image: { key: 'step-a', alt: 'a' } },
-          { order: 2, text: 'B', image: { key: 'step-b', alt: 'b' } },
-          { order: 3, text: 'C', image: { key: 'step-c', alt: 'c' } },
-        ],
-      })
-      ddbMock.on(GetCommand).resolves({ Item: oldItem })
-      ddbMock.on(UpdateCommand).resolves({ Attributes: oldItem })
-      s3Mock.on(DeleteObjectsCommand).resolves({})
-
-      const event = makeEvent({
-        routeKey: 'PATCH /recipes/{id}',
-        rawPath: '/recipes/recipe-uuid-1',
-        pathParameters: { id: 'recipe-uuid-1' },
-        headers: { authorization: `Bearer ${adminToken}` },
-        body: JSON.stringify({
-          steps: [
-            { order: 1, text: 'C', image: { key: 'step-c', alt: 'c' } },
-            { order: 2, text: 'D', image: { key: 'step-d', alt: 'd' } },
-          ],
-        }),
-      })
-
-      const result = await handler(event)
-
-      expect(result.statusCode).toBe(200)
-
-      const deleteCalls = s3Mock.commandCalls(DeleteObjectsCommand)
-      expect(deleteCalls).toHaveLength(1)
-      const keys = (deleteCalls[0].args[0].input.Delete?.Objects ?? []).map((o) => o.Key)
-      // step-a variants must be scheduled for deletion
-      expect(keys).toContain('step-a-thumb.webp')
-      expect(keys).toContain('step-a-medium.webp')
-      expect(keys).toContain('step-a-full.webp')
-      // step-b variants must be scheduled for deletion
-      expect(keys).toContain('step-b-thumb.webp')
-      expect(keys).toContain('step-b-medium.webp')
-      expect(keys).toContain('step-b-full.webp')
-      // step-c is still referenced — its variants must NOT be deleted
-      expect(keys).not.toContain('step-c-thumb.webp')
-      expect(keys).not.toContain('step-c-medium.webp')
-      expect(keys).not.toContain('step-c-full.webp')
-      // step-d is newly added — its variants must NOT be deleted
-      expect(keys).not.toContain('step-d-thumb.webp')
-      expect(keys).not.toContain('step-d-medium.webp')
-      expect(keys).not.toContain('step-d-full.webp')
-      expect(keys).toHaveLength(6)
-    })
-
-    it('pure step reorder (same key-set) triggers no S3 delete', async () => {
-      const oldItem = publishedRecipeItem({
-        id: 'recipe-uuid-1',
-        authorId: 'contributor-user-id',
-        steps: [
-          { order: 1, text: 'A', image: { key: 'step-a', alt: 'a' } },
-          { order: 2, text: 'B', image: { key: 'step-b', alt: 'b' } },
-          { order: 3, text: 'C', image: { key: 'step-c', alt: 'c' } },
+          { stepId: stepIdA, order: 1, text: 'A', image: { alt: 'a' } },
         ],
       })
       ddbMock.on(GetCommand).resolves({ Item: oldItem })
@@ -1297,11 +1206,11 @@ describe('Recipe Lambda handler', () => {
         rawPath: '/recipes/recipe-uuid-1',
         pathParameters: { id: 'recipe-uuid-1' },
         headers: { authorization: `Bearer ${adminToken}` },
+        // Updating only the cover alt and step text — no images dropped.
         body: JSON.stringify({
+          coverImage: { alt: 'New alt' },
           steps: [
-            { order: 1, text: 'C', image: { key: 'step-c', alt: 'c' } },
-            { order: 2, text: 'A', image: { key: 'step-a', alt: 'a' } },
-            { order: 3, text: 'B', image: { key: 'step-b', alt: 'b' } },
+            { stepId: stepIdA, order: 1, text: 'A updated', image: { alt: 'a updated' } },
           ],
         }),
       })
@@ -1313,10 +1222,12 @@ describe('Recipe Lambda handler', () => {
     })
 
     it('invokes UpdateCommand before DeleteObjectsCommand', async () => {
+      const slug = 'lamb-ragu'
       const oldItem = publishedRecipeItem({
         id: 'recipe-uuid-1',
+        slug,
         authorId: 'contributor-user-id',
-        coverImage: { key: 'recipes/images/recipe-1/cover', alt: 'Old alt' },
+        coverImage: { alt: 'Old alt' },
       })
       ddbMock.on(GetCommand).resolves({ Item: oldItem })
 
@@ -1335,7 +1246,8 @@ describe('Recipe Lambda handler', () => {
         rawPath: '/recipes/recipe-uuid-1',
         pathParameters: { id: 'recipe-uuid-1' },
         headers: { authorization: `Bearer ${adminToken}` },
-        body: JSON.stringify({ coverImage: { key: 'recipes/images/recipe-1/cover-v2', alt: 'New alt' } }),
+        // Cover removal triggers the S3 delete under the new model.
+        body: JSON.stringify({ coverImage: null }),
       })
 
       const result = await handler(event)
@@ -1350,15 +1262,17 @@ describe('Recipe Lambda handler', () => {
       const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {})
       const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {})
       try {
+        const slug = 'lamb-ragu'
         const oldItem = publishedRecipeItem({
           id: 'recipe-uuid-1',
+          slug,
           authorId: 'contributor-user-id',
-          coverImage: { key: 'recipes/images/recipe-1/cover', alt: 'Old alt' },
+          coverImage: { alt: 'Old alt' },
         })
         ddbMock.on(GetCommand).resolves({ Item: oldItem })
         ddbMock.on(UpdateCommand).resolves({ Attributes: oldItem })
         s3Mock.on(DeleteObjectsCommand).resolves({
-          Errors: [{ Key: 'recipes/images/recipe-1/cover-thumb.webp', Code: 'AccessDenied', Message: 'nope' }],
+          Errors: [{ Key: `recipes/${slug}/cover-thumb.webp`, Code: 'AccessDenied', Message: 'nope' }],
         })
 
         const event = makeEvent({
@@ -1366,7 +1280,7 @@ describe('Recipe Lambda handler', () => {
           rawPath: '/recipes/recipe-uuid-1',
           pathParameters: { id: 'recipe-uuid-1' },
           headers: { authorization: `Bearer ${adminToken}` },
-          body: JSON.stringify({ coverImage: { key: 'recipes/images/recipe-1/cover-v2', alt: 'New alt' } }),
+          body: JSON.stringify({ coverImage: null }),
         })
 
         const result = await handler(event)
@@ -1374,7 +1288,6 @@ describe('Recipe Lambda handler', () => {
         expect(result.statusCode).toBe(200)
         const body = JSON.parse(result.body as string)
         expect(body.id).toBe('recipe-uuid-1')
-        expect(body.coverImage).toEqual({ key: 'recipes/images/recipe-1/cover-v2', alt: 'New alt' })
 
         // Must have logged the partial failure somewhere observable.
         const logged = errorSpy.mock.calls.length + warnSpy.mock.calls.length
@@ -2282,7 +2195,7 @@ describe('Recipe Lambda handler', () => {
       expect(s3Mock.commandCalls(DeleteObjectsCommand)).toHaveLength(1)
     })
 
-    it('lists S3 objects under the new "recipes/<id>/" prefix (not the old "processed/recipes/...")', async () => {
+    it('lists S3 objects under the slug-derived "recipes/<slug>/" prefix', async () => {
       ddbMock.on(GetCommand).resolves({
         Item: publishedRecipeItem({ authorId: 'contributor-user-id' }),
       })
@@ -2301,7 +2214,8 @@ describe('Recipe Lambda handler', () => {
       expect(result.statusCode).toBe(200)
       const listCalls = s3Mock.commandCalls(ListObjectsV2Command)
       expect(listCalls).toHaveLength(1)
-      expect(listCalls[0].args[0].input.Prefix).toBe('recipes/recipe-uuid-1/')
+      // publishedRecipeItem default slug is 'slow-cooked-lamb-ragu'.
+      expect(listCalls[0].args[0].input.Prefix).toBe('recipes/slow-cooked-lamb-ragu/')
     })
 
     it('returns 403 when contributor deletes another user\'s recipe', async () => {
@@ -2472,19 +2386,23 @@ describe('Recipe Lambda handler', () => {
   describe('Response composition — processedAt + imageStatus stripping', () => {
     // A published recipe whose cover image and one step image both have matching
     // imageStatus entries, plus one step image without a matching entry.
-    const coverKey = 'recipes/recipe-uuid-1/cover'
-    const step1Key = 'recipes/recipe-uuid-1/step-1'
-    const step2Key = 'recipes/recipe-uuid-1/step-2'
+    // Keys are derived from (slug, imageType[, stepId]).
+    const composeSlug = 'slow-cooked-lamb-ragu'
+    const stepId1 = 'a0000000-0000-4000-8000-000000000001'
+    const stepId2 = 'a0000000-0000-4000-8000-000000000002'
+    const coverKey = `recipes/${composeSlug}/cover`
+    const step1Key = `recipes/${composeSlug}/step-${stepId1}`
     const coverTs = 1_745_000_000_001
     const step1Ts = 1_745_000_000_002
 
     function recipeWithImageStatus(overrides: Record<string, unknown> = {}): Record<string, unknown> {
       return publishedRecipeItem({
         id: 'recipe-uuid-1',
-        coverImage: { key: coverKey, alt: 'A bowl of lamb ragu' },
+        slug: composeSlug,
+        coverImage: { alt: 'A bowl of lamb ragu' },
         steps: [
-          { order: 1, text: 'Sear.', image: { key: step1Key, alt: 'seared lamb' } },
-          { order: 2, text: 'Simmer.', image: { key: step2Key, alt: 'simmering' } },
+          { stepId: stepId1, order: 1, text: 'Sear.', image: { alt: 'seared lamb' } },
+          { stepId: stepId2, order: 2, text: 'Simmer.', image: { alt: 'simmering' } },
         ],
         imageStatus: { [coverKey]: coverTs, [step1Key]: step1Ts },
         ...overrides,
@@ -2499,7 +2417,7 @@ describe('Recipe Lambda handler', () => {
 
       expect(result.statusCode).toBe(200)
       const body = JSON.parse(result.body as string)
-      expect(body[0].coverImage).toEqual({ key: coverKey, alt: 'A bowl of lamb ragu', processedAt: coverTs })
+      expect(body[0].coverImage).toEqual({ alt: 'A bowl of lamb ragu', processedAt: coverTs })
     })
 
     // AC 2: GET /recipes/{slug} composes onto cover AND each step.image.
@@ -2508,17 +2426,17 @@ describe('Recipe Lambda handler', () => {
 
       const result = await handler(makeEvent({
         routeKey: 'GET /recipes/{slug}',
-        rawPath: '/recipes/slow-cooked-lamb-ragu',
-        pathParameters: { slug: 'slow-cooked-lamb-ragu' },
+        rawPath: `/recipes/${composeSlug}`,
+        pathParameters: { slug: composeSlug },
       }))
 
       expect(result.statusCode).toBe(200)
       const body = JSON.parse(result.body as string)
-      expect(body.coverImage).toEqual({ key: coverKey, alt: 'A bowl of lamb ragu', processedAt: coverTs })
+      expect(body.coverImage).toEqual({ alt: 'A bowl of lamb ragu', processedAt: coverTs })
       // step 1 has a matching imageStatus entry → processedAt composed
-      expect(body.steps[0].image).toEqual({ key: step1Key, alt: 'seared lamb', processedAt: step1Ts })
+      expect(body.steps[0].image).toEqual({ alt: 'seared lamb', processedAt: step1Ts })
       // step 2 has no matching entry → processedAt absent (not null, not undefined-serialised)
-      expect(body.steps[1].image).toEqual({ key: step2Key, alt: 'simmering' })
+      expect(body.steps[1].image).toEqual({ alt: 'simmering' })
       expect(body.steps[1].image).not.toHaveProperty('processedAt')
     })
 
@@ -2535,7 +2453,7 @@ describe('Recipe Lambda handler', () => {
       expect(result.statusCode).toBe(200)
       const body = JSON.parse(result.body as string)
       expect(body).toHaveLength(1)
-      expect(body[0].coverImage).toEqual({ key: coverKey, alt: 'A bowl of lamb ragu', processedAt: coverTs })
+      expect(body[0].coverImage).toEqual({ alt: 'A bowl of lamb ragu', processedAt: coverTs })
     })
 
     // AC 4: GET /recipes/admin composes processedAt on returned items.
@@ -2553,7 +2471,7 @@ describe('Recipe Lambda handler', () => {
       expect(result.statusCode).toBe(200)
       const body = JSON.parse(result.body as string)
       expect(body).toHaveLength(1)
-      expect(body[0].coverImage).toEqual({ key: coverKey, alt: 'A bowl of lamb ragu', processedAt: coverTs })
+      expect(body[0].coverImage).toEqual({ alt: 'A bowl of lamb ragu', processedAt: coverTs })
     })
 
     // AC 5: PATCH /recipes/{id} response composes processedAt.
@@ -2572,24 +2490,27 @@ describe('Recipe Lambda handler', () => {
 
       expect(result.statusCode).toBe(200)
       const body = JSON.parse(result.body as string)
-      expect(body.coverImage).toEqual({ key: coverKey, alt: 'A bowl of lamb ragu', processedAt: coverTs })
-      expect(body.steps[0].image).toEqual({ key: step1Key, alt: 'seared lamb', processedAt: step1Ts })
+      expect(body.coverImage).toEqual({ alt: 'A bowl of lamb ragu', processedAt: coverTs })
+      expect(body.steps[0].image).toEqual({ alt: 'seared lamb', processedAt: step1Ts })
     })
 
     // AC 6: PATCH /recipes/{id}/publish response composes processedAt.
     it('PATCH /recipes/{id}/publish response composes processedAt onto the returned recipe', async () => {
       // Draft we read for validation passes all existing checks AND has readiness on every image.
+      // Note: validatePublishInput still reads `coverImage.key` / `step.image.key` (not in scope
+      // for this issue) — keep those literal keys present in the validation fixture so it passes.
       const fullyReadyDraft = recipeWithImageStatus({
         status: 'draft',
         authorId: 'contributor-user-id',
+        coverImage: { key: coverKey, alt: 'A bowl of lamb ragu' },
         steps: [
-          { order: 1, text: 'Sear.', image: { key: step1Key, alt: 'seared lamb' } },
+          { stepId: stepId1, order: 1, text: 'Sear.', image: { key: step1Key, alt: 'seared lamb' } },
         ],
         imageStatus: { [coverKey]: coverTs, [step1Key]: step1Ts },
       })
       ddbMock.on(GetCommand).resolves({ Item: fullyReadyDraft })
       ddbMock.on(UpdateCommand).resolves({
-        Attributes: { ...fullyReadyDraft, status: 'published' },
+        Attributes: { ...fullyReadyDraft, status: 'published', coverImage: { alt: 'A bowl of lamb ragu' }, steps: [{ stepId: stepId1, order: 1, text: 'Sear.', image: { alt: 'seared lamb' } }] },
       })
 
       const result = await handler(makeEvent({
@@ -2601,8 +2522,8 @@ describe('Recipe Lambda handler', () => {
 
       expect(result.statusCode).toBe(200)
       const body = JSON.parse(result.body as string)
-      expect(body.coverImage).toEqual({ key: coverKey, alt: 'A bowl of lamb ragu', processedAt: coverTs })
-      expect(body.steps[0].image).toEqual({ key: step1Key, alt: 'seared lamb', processedAt: step1Ts })
+      expect(body.coverImage).toEqual({ alt: 'A bowl of lamb ragu', processedAt: coverTs })
+      expect(body.steps[0].image).toEqual({ alt: 'seared lamb', processedAt: step1Ts })
     })
 
     // AC 7: PATCH /recipes/{id}/unpublish response composes processedAt.
@@ -2622,7 +2543,7 @@ describe('Recipe Lambda handler', () => {
 
       expect(result.statusCode).toBe(200)
       const body = JSON.parse(result.body as string)
-      expect(body.coverImage).toEqual({ key: coverKey, alt: 'A bowl of lamb ragu', processedAt: coverTs })
+      expect(body.coverImage).toEqual({ alt: 'A bowl of lamb ragu', processedAt: coverTs })
     })
 
     // AC 8: imageStatus is stripped from every response body.
@@ -2705,10 +2626,12 @@ describe('Recipe Lambda handler', () => {
       })
 
       it('PATCH /recipes/{id}/publish strips imageStatus', async () => {
+        // Validation still uses coverImage.key/step.image.key — keep them populated for this fixture.
         const fullyReadyDraft = recipeWithImageStatus({
           status: 'draft',
           authorId: 'contributor-user-id',
-          steps: [{ order: 1, text: 'Sear.', image: { key: step1Key, alt: 'seared lamb' } }],
+          coverImage: { key: coverKey, alt: 'A bowl of lamb ragu' },
+          steps: [{ stepId: stepId1, order: 1, text: 'Sear.', image: { key: step1Key, alt: 'seared lamb' } }],
           imageStatus: { [coverKey]: coverTs, [step1Key]: step1Ts },
         })
         ddbMock.on(GetCommand).resolves({ Item: fullyReadyDraft })
@@ -2747,20 +2670,21 @@ describe('Recipe Lambda handler', () => {
     })
 
     // AC 9: No processedAt added when imageStatus entry missing.
-    it('GET /recipes/{slug} omits processedAt when imageStatus has no entry for the cover key', async () => {
+    it('GET /recipes/{slug} omits processedAt when imageStatus has no entry for the slug-derived cover key', async () => {
       const item = publishedRecipeItem({
         id: 'recipe-uuid-1',
-        coverImage: { key: coverKey, alt: 'no-entry alt' },
-        steps: [{ order: 1, text: 'step', image: { key: step1Key, alt: 'step alt' } }],
-        // imageStatus is an empty map — no entries for either key.
+        slug: composeSlug,
+        coverImage: { alt: 'no-entry alt' },
+        steps: [{ stepId: stepId1, order: 1, text: 'step', image: { alt: 'step alt' } }],
+        // imageStatus is an empty map — no entries for either derived key.
         imageStatus: {},
       })
       ddbMock.on(ScanCommand).resolves({ Items: [item] })
 
       const result = await handler(makeEvent({
         routeKey: 'GET /recipes/{slug}',
-        rawPath: '/recipes/slow-cooked-lamb-ragu',
-        pathParameters: { slug: 'slow-cooked-lamb-ragu' },
+        rawPath: `/recipes/${composeSlug}`,
+        pathParameters: { slug: composeSlug },
       }))
 
       expect(result.statusCode).toBe(200)
@@ -2769,9 +2693,9 @@ describe('Recipe Lambda handler', () => {
       expect(result.body).not.toContain('processedAt')
       const body = JSON.parse(result.body as string)
       expect(body.coverImage).not.toHaveProperty('processedAt')
-      expect(body.coverImage).toEqual({ key: coverKey, alt: 'no-entry alt' })
+      expect(body.coverImage).toEqual({ alt: 'no-entry alt' })
       expect(body.steps[0].image).not.toHaveProperty('processedAt')
-      expect(body.steps[0].image).toEqual({ key: step1Key, alt: 'step alt' })
+      expect(body.steps[0].image).toEqual({ alt: 'step alt' })
     })
 
     it('preserves processedAt: 0 when imageStatus records a falsy-but-valid timestamp', async () => {
@@ -2779,7 +2703,8 @@ describe('Recipe Lambda handler', () => {
       // must keep the `!== undefined` check so 0 is treated as "ready", not "missing".
       const item = publishedRecipeItem({
         id: 'recipe-uuid-1',
-        coverImage: { key: coverKey, alt: 'cover alt' },
+        slug: composeSlug,
+        coverImage: { alt: 'cover alt' },
         steps: [],
         imageStatus: { [coverKey]: 0 },
       })
@@ -2787,101 +2712,67 @@ describe('Recipe Lambda handler', () => {
 
       const result = await handler(makeEvent({
         routeKey: 'GET /recipes/{slug}',
-        rawPath: '/recipes/slow-cooked-lamb-ragu',
-        pathParameters: { slug: 'slow-cooked-lamb-ragu' },
+        rawPath: `/recipes/${composeSlug}`,
+        pathParameters: { slug: composeSlug },
       }))
 
       expect(result.statusCode).toBe(200)
       const body = JSON.parse(result.body as string)
-      expect(body.coverImage).toEqual({ key: coverKey, alt: 'cover alt', processedAt: 0 })
+      expect(body.coverImage).toEqual({ alt: 'cover alt', processedAt: 0 })
     })
 
-    it('omits processedAt when imageStatus keys do not match coverImage.key', async () => {
-      const newCoverKey = 'recipes/recipe-uuid-1/cover'
-      const staleCoverKey = 'processed/recipes/recipe-uuid-1/cover'
+    it('omits processedAt when imageStatus has no entry for the slug-derived cover key (stale legacy entries are ignored)', async () => {
+      // Replaces the obsolete "imageStatus keys do not match coverImage.key" test —
+      // composeImageProcessedAt no longer reads `coverImage.key`, so the analog under
+      // the new model is "imageStatus has no entry for `recipes/<slug>/cover`".
+      const staleLegacyKey = 'recipes/recipe-uuid-1/cover'
       const item = publishedRecipeItem({
         id: 'recipe-uuid-1',
-        coverImage: { key: newCoverKey, alt: 'cover alt' },
+        slug: composeSlug,
+        coverImage: { alt: 'cover alt' },
         steps: [],
-        imageStatus: { [staleCoverKey]: 1_745_000_000_001 },
+        // Stale entry under a non-derived key — must NOT be picked up.
+        imageStatus: { [staleLegacyKey]: 1_745_000_000_001 },
       })
       ddbMock.on(ScanCommand).resolves({ Items: [item] })
 
       const result = await handler(makeEvent({
         routeKey: 'GET /recipes/{slug}',
-        rawPath: '/recipes/slow-cooked-lamb-ragu',
-        pathParameters: { slug: 'slow-cooked-lamb-ragu' },
+        rawPath: `/recipes/${composeSlug}`,
+        pathParameters: { slug: composeSlug },
       }))
 
       expect(result.statusCode).toBe(200)
       expect(result.body).not.toContain('processedAt')
       const body = JSON.parse(result.body as string)
       expect(body.coverImage).not.toHaveProperty('processedAt')
-      expect(body.coverImage).toEqual({ key: newCoverKey, alt: 'cover alt' })
+      expect(body.coverImage).toEqual({ alt: 'cover alt' })
     })
   })
 
   describe('PATCH /recipes/{id} — imageStatus REMOVE on swap and processedAt body strip', () => {
-    const oldCoverKey = 'recipes/recipe-uuid-1/cover'
-    const newCoverKey = 'recipes/recipe-uuid-1/cover-v2'
-    const stepAKey = 'recipes/recipe-uuid-1/step-1'
-    const stepBKey = 'recipes/recipe-uuid-1/step-2'
-    const stepCKey = 'recipes/recipe-uuid-1/step-3'
+    const slug = 'recipe-slug'
+    const stepIdA = 'a0000000-0000-4000-8000-000000000001'
+    const stepIdB = 'a0000000-0000-4000-8000-000000000002'
+    const stepIdC = 'a0000000-0000-4000-8000-000000000003'
+    const coverKey = `recipes/${slug}/cover`
+    const stepAKey = `recipes/${slug}/step-${stepIdA}`
+    const stepBKey = `recipes/${slug}/step-${stepIdB}`
+    const stepCKey = `recipes/${slug}/step-${stepIdC}`
 
-    it('cover-image swap includes REMOVE imageStatus.#<oldKey> in the same UpdateCommand as SET', async () => {
+    it('step-image drop REMOVEs imageStatus entries for dropped stepIds only, preserving kept stepIds', async () => {
       const oldItem = publishedRecipeItem({
         id: 'recipe-uuid-1',
+        slug,
         authorId: 'contributor-user-id',
-        coverImage: { key: oldCoverKey, alt: 'Old alt' },
-        imageStatus: { [oldCoverKey]: 1_745_000_000_001 },
-      })
-      ddbMock.on(GetCommand).resolves({ Item: oldItem })
-      ddbMock.on(UpdateCommand).resolves({ Attributes: oldItem })
-      s3Mock.on(DeleteObjectsCommand).resolves({})
-
-      const event = makeEvent({
-        routeKey: 'PATCH /recipes/{id}',
-        rawPath: '/recipes/recipe-uuid-1',
-        pathParameters: { id: 'recipe-uuid-1' },
-        headers: { authorization: `Bearer ${adminToken}` },
-        body: JSON.stringify({ coverImage: { key: newCoverKey, alt: 'New alt' } }),
-      })
-
-      const result = await handler(event)
-
-      expect(result.statusCode).toBe(200)
-
-      const updateCalls = ddbMock.commandCalls(UpdateCommand)
-      expect(updateCalls).toHaveLength(1)
-      const input = updateCalls[0].args[0].input
-      const expr = input.UpdateExpression as string
-
-      expect(expr).toMatch(/\bSET\b/)
-      expect(expr).toMatch(/\bREMOVE\b/)
-      expect(expr).toMatch(/REMOVE\s+imageStatus\.#/)
-
-      const names = input.ExpressionAttributeNames as Record<string, string>
-      const nameValues = Object.values(names)
-      expect(nameValues).toContain(oldCoverKey)
-
-      const removeMatch = expr.match(/REMOVE\s+imageStatus\.(#[a-zA-Z0-9_]+)/)
-      expect(removeMatch).not.toBeNull()
-      const removePlaceholder = removeMatch![1]
-      expect(names[removePlaceholder]).toBe(oldCoverKey)
-    })
-
-    it('step-image swap REMOVEs imageStatus entries for dropped keys only, preserving kept keys', async () => {
-      const oldItem = publishedRecipeItem({
-        id: 'recipe-uuid-1',
-        authorId: 'contributor-user-id',
-        coverImage: { key: oldCoverKey, alt: 'Cover alt' },
+        coverImage: { alt: 'Cover alt' },
         steps: [
-          { order: 1, text: 'A', image: { key: stepAKey, alt: 'a' } },
-          { order: 2, text: 'B', image: { key: stepBKey, alt: 'b' } },
-          { order: 3, text: 'C', image: { key: stepCKey, alt: 'c' } },
+          { stepId: stepIdA, order: 1, text: 'A', image: { alt: 'a' } },
+          { stepId: stepIdB, order: 2, text: 'B', image: { alt: 'b' } },
+          { stepId: stepIdC, order: 3, text: 'C', image: { alt: 'c' } },
         ],
         imageStatus: {
-          [oldCoverKey]: 1_745_000_000_000,
+          [coverKey]: 1_745_000_000_000,
           [stepAKey]: 1_745_000_000_001,
           [stepBKey]: 1_745_000_000_002,
           [stepCKey]: 1_745_000_000_003,
@@ -2898,7 +2789,7 @@ describe('Recipe Lambda handler', () => {
         headers: { authorization: `Bearer ${adminToken}` },
         body: JSON.stringify({
           steps: [
-            { order: 1, text: 'C', image: { key: stepCKey, alt: 'c' } },
+            { stepId: stepIdC, order: 1, text: 'C', image: { alt: 'c' } },
           ],
         }),
       })
@@ -2924,17 +2815,18 @@ describe('Recipe Lambda handler', () => {
       expect(removedKeys).toContain(stepAKey)
       expect(removedKeys).toContain(stepBKey)
       expect(removedKeys).not.toContain(stepCKey)
-      expect(removedKeys).not.toContain(oldCoverKey)
+      expect(removedKeys).not.toContain(coverKey)
       expect(removedKeys).toHaveLength(2)
     })
 
     it('strips client-supplied processedAt from coverImage and step.image before the UpdateCommand runs', async () => {
       const oldItem = publishedRecipeItem({
         id: 'recipe-uuid-1',
+        slug,
         authorId: 'contributor-user-id',
-        coverImage: { key: oldCoverKey, alt: 'Old cover alt' },
-        steps: [{ order: 1, text: 'A', image: { key: stepAKey, alt: 'a' } }],
-        imageStatus: { [oldCoverKey]: 1_745_000_000_000, [stepAKey]: 1_745_000_000_001 },
+        coverImage: { alt: 'Old cover alt' },
+        steps: [{ stepId: stepIdA, order: 1, text: 'A', image: { alt: 'a' } }],
+        imageStatus: { [coverKey]: 1_745_000_000_000, [stepAKey]: 1_745_000_000_001 },
       })
       ddbMock.on(GetCommand).resolves({ Item: oldItem })
       ddbMock.on(UpdateCommand).resolves({ Attributes: oldItem })
@@ -2945,9 +2837,9 @@ describe('Recipe Lambda handler', () => {
         pathParameters: { id: 'recipe-uuid-1' },
         headers: { authorization: `Bearer ${adminToken}` },
         body: JSON.stringify({
-          coverImage: { key: oldCoverKey, alt: 'Cover alt', processedAt: 9_999_999_999_999 },
+          coverImage: { alt: 'Cover alt', processedAt: 9_999_999_999_999 },
           steps: [
-            { order: 1, text: 'A', image: { key: stepAKey, alt: 'a', processedAt: 9_999_999_999_998 } },
+            { stepId: stepIdA, order: 1, text: 'A', image: { alt: 'a', processedAt: 9_999_999_999_998 } },
           ],
         }),
       })
@@ -2966,7 +2858,7 @@ describe('Recipe Lambda handler', () => {
       const coverValue = values[':coverImage'] as Record<string, unknown> | undefined
       expect(coverValue).toBeDefined()
       expect(coverValue).not.toHaveProperty('processedAt')
-      expect(coverValue).toEqual({ key: oldCoverKey, alt: 'Cover alt' })
+      expect(coverValue).toEqual({ alt: 'Cover alt' })
 
       const stepsValue = values[':steps'] as Array<{ image?: Record<string, unknown> }> | undefined
       expect(stepsValue).toBeDefined()
@@ -2974,7 +2866,385 @@ describe('Recipe Lambda handler', () => {
       const stepImage = stepsValue![0].image
       expect(stepImage).toBeDefined()
       expect(stepImage).not.toHaveProperty('processedAt')
-      expect(stepImage).toEqual({ key: stepAKey, alt: 'a' })
+      expect(stepImage).toEqual({ alt: 'a' })
+    })
+  })
+
+  // ─── Issue #151: derive image keys from slug + stepId ───────────────
+  describe('composeImageProcessedAt — derives keys from (slug, imageType[, stepId])', () => {
+    it('composes coverImage.processedAt from imageStatus[recipes/<slug>/cover] when coverImage has no .key field', async () => {
+      const slug = 'beans-on-toast'
+      const coverKey = `recipes/${slug}/cover`
+      const ts = 1_745_000_000_000
+
+      ddbMock.on(ScanCommand).resolves({
+        Items: [
+          publishedRecipeItem({
+            id: 'recipe-uuid-1',
+            slug,
+            // No `.key` on coverImage.
+            coverImage: { alt: 'Beans on toast' },
+            steps: [],
+            imageStatus: { [coverKey]: ts },
+          }),
+        ],
+      })
+
+      const result = await handler(makeEvent({
+        routeKey: 'GET /recipes/{slug}',
+        rawPath: `/recipes/${slug}`,
+        pathParameters: { slug },
+      }))
+
+      expect(result.statusCode).toBe(200)
+      const body = JSON.parse(result.body as string)
+      expect(body.coverImage).toEqual({ alt: 'Beans on toast', processedAt: ts })
+    })
+
+    it('composes step.image.processedAt from imageStatus[recipes/<slug>/step-<stepId>] when step.image has no .key field', async () => {
+      const slug = 'beans-on-toast'
+      const stepId = '9d904a59-e83f-43b8-9f40-fbdb3008974c'
+      const stepKey = `recipes/${slug}/step-${stepId}`
+      const ts = 1_745_000_000_000
+
+      ddbMock.on(ScanCommand).resolves({
+        Items: [
+          publishedRecipeItem({
+            id: 'recipe-uuid-1',
+            slug,
+            coverImage: { alt: 'cover alt' },
+            steps: [
+              // No `.key` on step.image.
+              { stepId, order: 1, text: 'Boil water', image: { alt: 'water boiling' } },
+            ],
+            imageStatus: { [stepKey]: ts },
+          }),
+        ],
+      })
+
+      const result = await handler(makeEvent({
+        routeKey: 'GET /recipes/{slug}',
+        rawPath: `/recipes/${slug}`,
+        pathParameters: { slug },
+      }))
+
+      expect(result.statusCode).toBe(200)
+      const body = JSON.parse(result.body as string)
+      expect(body.steps).toHaveLength(1)
+      expect(body.steps[0].image).toEqual({ alt: 'water boiling', processedAt: ts })
+    })
+
+    it('ignores legacy coverImage.key when the matching imageStatus entry is under the derived (slug-based) key', async () => {
+      // Half-migrated item: the legacy `.key` field is still present on the recipe object,
+      // but only the new slug-derived imageStatus entry exists. Composition must use the
+      // derived key — the function MUST NOT read `.key` even when populated.
+      const slug = 'beans-on-toast'
+      const legacyKey = 'recipes/recipe-uuid-1/cover'
+      const derivedKey = `recipes/${slug}/cover`
+      const ts = 1_745_000_000_000
+
+      ddbMock.on(ScanCommand).resolves({
+        Items: [
+          publishedRecipeItem({
+            id: 'recipe-uuid-1',
+            slug,
+            // Legacy .key field present — must be ignored by composeImageProcessedAt.
+            coverImage: { key: legacyKey, alt: 'cover alt' },
+            steps: [],
+            // No entry under the legacy key, only under the derived key.
+            imageStatus: { [derivedKey]: ts },
+          }),
+        ],
+      })
+
+      const result = await handler(makeEvent({
+        routeKey: 'GET /recipes/{slug}',
+        rawPath: `/recipes/${slug}`,
+        pathParameters: { slug },
+      }))
+
+      expect(result.statusCode).toBe(200)
+      const body = JSON.parse(result.body as string)
+      expect(body.coverImage.processedAt).toBe(ts)
+    })
+  })
+
+  describe('DELETE /recipes/{id} — slug-derived prefix', () => {
+    it('lists S3 objects under "recipes/<slug>/" using the recipe.slug (not recipe.id)', async () => {
+      ddbMock.on(GetCommand).resolves({
+        Item: publishedRecipeItem({
+          id: 'recipe-uuid-1',
+          slug: 'beans-on-toast',
+          authorId: 'contributor-user-id',
+        }),
+      })
+      ddbMock.on(DeleteCommand).resolves({})
+      s3Mock.on(ListObjectsV2Command).resolves({ Contents: [] })
+
+      const event = makeEvent({
+        routeKey: 'DELETE /recipes/{id}',
+        rawPath: '/recipes/recipe-uuid-1',
+        pathParameters: { id: 'recipe-uuid-1' },
+        headers: { authorization: `Bearer ${contributorToken}` },
+      })
+
+      const result = await handler(event)
+
+      expect(result.statusCode).toBe(200)
+      const listCalls = s3Mock.commandCalls(ListObjectsV2Command)
+      expect(listCalls).toHaveLength(1)
+      expect(listCalls[0].args[0].input.Prefix).toBe('recipes/beans-on-toast/')
+    })
+  })
+
+  describe('PATCH /recipes/{id} — cover-image removal cleanup', () => {
+    it('PATCH coverImage: null deletes the three slug-derived cover variants and REMOVEs the matching imageStatus entry', async () => {
+      const slug = 'beans-on-toast'
+      const coverKey = `recipes/${slug}/cover`
+
+      const oldItem = publishedRecipeItem({
+        id: 'recipe-uuid-1',
+        slug,
+        authorId: 'contributor-user-id',
+        coverImage: { alt: 'Beans on toast' },
+        imageStatus: { [coverKey]: 1_745_000_000_000 },
+      })
+      ddbMock.on(GetCommand).resolves({ Item: oldItem })
+      ddbMock.on(UpdateCommand).resolves({ Attributes: oldItem })
+      s3Mock.on(DeleteObjectsCommand).resolves({})
+
+      const event = makeEvent({
+        routeKey: 'PATCH /recipes/{id}',
+        rawPath: '/recipes/recipe-uuid-1',
+        pathParameters: { id: 'recipe-uuid-1' },
+        headers: { authorization: `Bearer ${adminToken}` },
+        body: JSON.stringify({ coverImage: null }),
+      })
+
+      const result = await handler(event)
+
+      expect(result.statusCode).toBe(200)
+
+      // S3: the three cover variants must be scheduled for deletion under the slug-derived key.
+      const deleteCalls = s3Mock.commandCalls(DeleteObjectsCommand)
+      expect(deleteCalls).toHaveLength(1)
+      const deletedKeys = (deleteCalls[0].args[0].input.Delete?.Objects ?? []).map((o) => o.Key)
+      expect(deletedKeys).toEqual(expect.arrayContaining([
+        `recipes/${slug}/cover-thumb.webp`,
+        `recipes/${slug}/cover-medium.webp`,
+        `recipes/${slug}/cover-full.webp`,
+      ]))
+      expect(deletedKeys).toHaveLength(3)
+
+      // DDB: the UpdateExpression must REMOVE imageStatus.#<key> for the cover key.
+      const updateCalls = ddbMock.commandCalls(UpdateCommand)
+      expect(updateCalls).toHaveLength(1)
+      const input = updateCalls[0].args[0].input
+      const expr = input.UpdateExpression as string
+      const names = input.ExpressionAttributeNames as Record<string, string>
+
+      expect(expr).toMatch(/\bREMOVE\b/)
+      const removeMatch = expr.match(/REMOVE\s+imageStatus\.(#[a-zA-Z0-9_]+)/)
+      expect(removeMatch).not.toBeNull()
+      const placeholder = removeMatch![1]
+      expect(names[placeholder]).toBe(coverKey)
+    })
+  })
+
+  describe('PATCH /recipes/{id} — step drop and reorder cleanup', () => {
+    it('PATCH that drops a step deletes that step\'s slug+stepId-derived variants and REMOVEs the matching imageStatus entry', async () => {
+      const slug = 'beans-on-toast'
+      const stepIdA = 'a0000000-0000-4000-8000-000000000001'
+      const stepIdB = 'a0000000-0000-4000-8000-000000000002'
+      const stepAKey = `recipes/${slug}/step-${stepIdA}`
+      const stepBKey = `recipes/${slug}/step-${stepIdB}`
+
+      const oldItem = publishedRecipeItem({
+        id: 'recipe-uuid-1',
+        slug,
+        authorId: 'contributor-user-id',
+        steps: [
+          { stepId: stepIdA, order: 1, text: 'A', image: { alt: 'a' } },
+          { stepId: stepIdB, order: 2, text: 'B', image: { alt: 'b' } },
+        ],
+        imageStatus: {
+          [stepAKey]: 1_745_000_000_001,
+          [stepBKey]: 1_745_000_000_002,
+        },
+      })
+      ddbMock.on(GetCommand).resolves({ Item: oldItem })
+      ddbMock.on(UpdateCommand).resolves({ Attributes: oldItem })
+      s3Mock.on(DeleteObjectsCommand).resolves({})
+
+      const event = makeEvent({
+        routeKey: 'PATCH /recipes/{id}',
+        rawPath: '/recipes/recipe-uuid-1',
+        pathParameters: { id: 'recipe-uuid-1' },
+        headers: { authorization: `Bearer ${adminToken}` },
+        // Drop stepIdB; keep stepIdA.
+        body: JSON.stringify({
+          steps: [
+            { stepId: stepIdA, order: 1, text: 'A', image: { alt: 'a' } },
+          ],
+        }),
+      })
+
+      const result = await handler(event)
+
+      expect(result.statusCode).toBe(200)
+
+      // S3: only stepB variants are deleted; stepA variants are preserved.
+      const deleteCalls = s3Mock.commandCalls(DeleteObjectsCommand)
+      expect(deleteCalls).toHaveLength(1)
+      const deletedKeys = (deleteCalls[0].args[0].input.Delete?.Objects ?? []).map((o) => o.Key)
+      expect(deletedKeys).toEqual(expect.arrayContaining([
+        `recipes/${slug}/step-${stepIdB}-thumb.webp`,
+        `recipes/${slug}/step-${stepIdB}-medium.webp`,
+        `recipes/${slug}/step-${stepIdB}-full.webp`,
+      ]))
+      expect(deletedKeys).not.toEqual(expect.arrayContaining([
+        `recipes/${slug}/step-${stepIdA}-thumb.webp`,
+      ]))
+      expect(deletedKeys).toHaveLength(3)
+
+      // DDB: REMOVE imageStatus entry for stepB only.
+      const updateCalls = ddbMock.commandCalls(UpdateCommand)
+      expect(updateCalls).toHaveLength(1)
+      const input = updateCalls[0].args[0].input
+      const expr = input.UpdateExpression as string
+      const names = input.ExpressionAttributeNames as Record<string, string>
+
+      expect(expr).toMatch(/\bREMOVE\b/)
+      const removeSegmentMatch = expr.match(/REMOVE\s+(.+)$/)
+      expect(removeSegmentMatch).not.toBeNull()
+      const placeholderMatches = Array.from(removeSegmentMatch![1].matchAll(/imageStatus\.(#[a-zA-Z0-9_]+)/g))
+      const removedKeys = placeholderMatches.map((m) => names[m[1]])
+      expect(removedKeys).toEqual([stepBKey])
+    })
+
+    it('PATCH that reorders steps (same stepIds, different order) fires no S3 delete and no imageStatus REMOVE', async () => {
+      const slug = 'beans-on-toast'
+      const stepIdA = 'a0000000-0000-4000-8000-000000000001'
+      const stepIdB = 'a0000000-0000-4000-8000-000000000002'
+      const stepAKey = `recipes/${slug}/step-${stepIdA}`
+      const stepBKey = `recipes/${slug}/step-${stepIdB}`
+
+      const oldItem = publishedRecipeItem({
+        id: 'recipe-uuid-1',
+        slug,
+        authorId: 'contributor-user-id',
+        steps: [
+          { stepId: stepIdA, order: 1, text: 'A', image: { alt: 'a' } },
+          { stepId: stepIdB, order: 2, text: 'B', image: { alt: 'b' } },
+        ],
+        imageStatus: {
+          [stepAKey]: 1_745_000_000_001,
+          [stepBKey]: 1_745_000_000_002,
+        },
+      })
+      ddbMock.on(GetCommand).resolves({ Item: oldItem })
+      ddbMock.on(UpdateCommand).resolves({ Attributes: oldItem })
+
+      const event = makeEvent({
+        routeKey: 'PATCH /recipes/{id}',
+        rawPath: '/recipes/recipe-uuid-1',
+        pathParameters: { id: 'recipe-uuid-1' },
+        headers: { authorization: `Bearer ${adminToken}` },
+        // Same stepIds, swapped order — pure reorder.
+        body: JSON.stringify({
+          steps: [
+            { stepId: stepIdB, order: 1, text: 'B', image: { alt: 'b' } },
+            { stepId: stepIdA, order: 2, text: 'A', image: { alt: 'a' } },
+          ],
+        }),
+      })
+
+      const result = await handler(event)
+
+      expect(result.statusCode).toBe(200)
+
+      expect(s3Mock.commandCalls(DeleteObjectsCommand)).toHaveLength(0)
+
+      const updateCalls = ddbMock.commandCalls(UpdateCommand)
+      expect(updateCalls).toHaveLength(1)
+      const expr = updateCalls[0].args[0].input.UpdateExpression as string
+      // Must NOT contain a REMOVE clause targeting any imageStatus entry.
+      expect(expr).not.toMatch(/REMOVE\s+[^]*imageStatus\./)
+    })
+  })
+
+  describe('PATCH /recipes/{id} — stepId validation', () => {
+    function patchEvent(body: unknown) {
+      return makeEvent({
+        routeKey: 'PATCH /recipes/{id}',
+        rawPath: '/recipes/recipe-uuid-1',
+        pathParameters: { id: 'recipe-uuid-1' },
+        headers: { authorization: `Bearer ${adminToken}` },
+        body: JSON.stringify(body),
+      })
+    }
+
+    it('returns 400 invalid_stepId when a step in the patch body has no stepId', async () => {
+      ddbMock.on(GetCommand).resolves({
+        Item: publishedRecipeItem({
+          id: 'recipe-uuid-1',
+          slug: 'beans-on-toast',
+          authorId: 'contributor-user-id',
+        }),
+      })
+
+      const result = await handler(patchEvent({
+        steps: [{ instructions: 'Boil water', order: 1 }],
+      }))
+
+      expect(result.statusCode).toBe(400)
+      const body = JSON.parse(result.body as string)
+      expect(body.error).toBe('invalid_stepId')
+      // No write should happen on validation failure.
+      expect(ddbMock.commandCalls(UpdateCommand)).toHaveLength(0)
+    })
+
+    it('returns 400 invalid_stepId when a step has a stepId that is not a valid UUID', async () => {
+      ddbMock.on(GetCommand).resolves({
+        Item: publishedRecipeItem({
+          id: 'recipe-uuid-1',
+          slug: 'beans-on-toast',
+          authorId: 'contributor-user-id',
+        }),
+      })
+
+      const result = await handler(patchEvent({
+        steps: [{ stepId: 'not-a-uuid', order: 1, text: 'Boil water', image: { alt: 'a' } }],
+      }))
+
+      expect(result.statusCode).toBe(400)
+      const body = JSON.parse(result.body as string)
+      expect(body.error).toBe('invalid_stepId')
+      expect(ddbMock.commandCalls(UpdateCommand)).toHaveLength(0)
+    })
+
+    it('returns 400 duplicate_stepId when two steps in the patch body share the same stepId', async () => {
+      ddbMock.on(GetCommand).resolves({
+        Item: publishedRecipeItem({
+          id: 'recipe-uuid-1',
+          slug: 'beans-on-toast',
+          authorId: 'contributor-user-id',
+        }),
+      })
+
+      const sharedStepId = '9d904a59-e83f-43b8-9f40-fbdb3008974c'
+
+      const result = await handler(patchEvent({
+        steps: [
+          { stepId: sharedStepId, order: 1, text: 'Boil water', image: { alt: 'a' } },
+          { stepId: sharedStepId, order: 2, text: 'Add tea', image: { alt: 'b' } },
+        ],
+      }))
+
+      expect(result.statusCode).toBe(400)
+      const body = JSON.parse(result.body as string)
+      expect(body.error).toBe('duplicate_stepId')
+      expect(ddbMock.commandCalls(UpdateCommand)).toHaveLength(0)
     })
   })
 })

--- a/test/lambda/recipe-handler.test.ts
+++ b/test/lambda/recipe-handler.test.ts
@@ -62,9 +62,9 @@ function publishedRecipeItem(overrides: Record<string, unknown> = {}): Record<st
     slug: 'slow-cooked-lamb-ragu',
     title: 'Slow-Cooked Lamb Ragu',
     intro: 'A rich, hearty ragu.',
-    coverImage: { key: 'recipes/images/recipe-uuid-1/cover', alt: 'A bowl of lamb ragu' },
+    coverImage: { alt: 'A bowl of lamb ragu' },
     ingredients: [{ item: 'lamb shoulder', quantity: '1', unit: 'kg' }],
-    steps: [{ order: 1, text: 'Season the lamb and sear.' }],
+    steps: [{ stepId: 'a0000000-0000-4000-8000-000000000001', order: 1, text: 'Season the lamb and sear.' }],
     tags: new Set(['Italian', 'Slow Cook']),
     prepTime: 20,
     cookTime: 240,
@@ -111,7 +111,7 @@ describe('Recipe Lambda handler', () => {
         id: 'recipe-uuid-1',
         title: 'Slow-Cooked Lamb Ragu',
         slug: 'slow-cooked-lamb-ragu',
-        coverImage: { key: 'recipes/images/recipe-uuid-1/cover', alt: 'A bowl of lamb ragu' },
+        coverImage: { alt: 'A bowl of lamb ragu' },
         tags: ['Italian', 'Slow Cook'],
         prepTime: 20,
         cookTime: 240,
@@ -1657,7 +1657,7 @@ describe('Recipe Lambda handler', () => {
       ddbMock.on(GetCommand).resolves({
         Item: draftRecipeItem({
           authorId: 'contributor-user-id',
-          imageStatus: { 'recipes/images/recipe-uuid-1/cover': 1_745_000_000_000 },
+          imageStatus: { 'recipes/my-draft-recipe/cover': 1_745_000_000_000 },
         }),
       })
       ddbMock.on(UpdateCommand).resolves({
@@ -1682,7 +1682,7 @@ describe('Recipe Lambda handler', () => {
       ddbMock.on(GetCommand).resolves({
         Item: draftRecipeItem({
           authorId: 'contributor-user-id',
-          imageStatus: { 'recipes/images/recipe-uuid-1/cover': 1_745_000_000_000 },
+          imageStatus: { 'recipes/my-draft-recipe/cover': 1_745_000_000_000 },
         }),
       })
       ddbMock.on(UpdateCommand).resolves({
@@ -1745,11 +1745,11 @@ describe('Recipe Lambda handler', () => {
         expect(body.errors).toHaveProperty('intro')
       })
 
-      it('returns 400 with a `coverImage.key` error when cover key is missing', async () => {
+      it('returns 400 with a `coverImage.alt` error when alt is missing', async () => {
         ddbMock.on(GetCommand).resolves({
           Item: draftRecipeItem({
             authorId: 'contributor-user-id',
-            coverImage: { key: '', alt: 'alt' },
+            coverImage: {},
           }),
         })
 
@@ -1757,14 +1757,15 @@ describe('Recipe Lambda handler', () => {
 
         expect(result.statusCode).toBe(400)
         const body = JSON.parse(result.body as string)
-        expect(body.errors).toHaveProperty('coverImage.key')
+        expect(body.errors.coverImage).toBeDefined()
+        expect(body.errors.coverImage.alt).toBe('coverImage.alt is required')
       })
 
-      it('returns 400 with a `coverImage.alt` error when cover alt is missing', async () => {
+      it('returns 400 with a `coverImage.alt` error when cover alt is empty', async () => {
         ddbMock.on(GetCommand).resolves({
           Item: draftRecipeItem({
             authorId: 'contributor-user-id',
-            coverImage: { key: 'recipes/images/recipe-uuid-1/cover', alt: '' },
+            coverImage: { alt: '' },
           }),
         })
 
@@ -1772,7 +1773,8 @@ describe('Recipe Lambda handler', () => {
 
         expect(result.statusCode).toBe(400)
         const body = JSON.parse(result.body as string)
-        expect(body.errors).toHaveProperty('coverImage.alt')
+        expect(body.errors.coverImage).toBeDefined()
+        expect(body.errors.coverImage.alt).toBe('coverImage.alt is required')
       })
 
       it('returns 400 with an `ingredients` error when ingredients list is empty', async () => {
@@ -1816,9 +1818,13 @@ describe('Recipe Lambda handler', () => {
     })
 
     describe('readiness validation — rejects recipes with unready images', () => {
-      const coverKey = 'recipes/recipe-uuid-1/cover'
-      const step1Key = 'recipes/recipe-uuid-1/step-1'
-      const step2Key = 'recipes/recipe-uuid-1/step-2'
+      const draftSlug = 'my-draft-recipe'
+      const publishedSlug = 'slow-cooked-lamb-ragu'
+      const stepIdA = 'a0000000-0000-4000-8000-000000000001'
+      const stepIdB = 'a0000000-0000-4000-8000-000000000002'
+      const coverKey = `recipes/${draftSlug}/cover`
+      const step1Key = `recipes/${draftSlug}/step-${stepIdA}`
+      const step2Key = `recipes/${draftSlug}/step-${stepIdB}`
       const coverTs = 1_745_000_000_001
       const step1Ts = 1_745_000_000_002
       const step2Ts = 1_745_000_000_003
@@ -1836,9 +1842,9 @@ describe('Recipe Lambda handler', () => {
         ddbMock.on(GetCommand).resolves({
           Item: draftRecipeItem({
             authorId: 'contributor-user-id',
-            coverImage: { key: coverKey, alt: 'A bowl of lamb ragu' },
+            coverImage: { alt: 'A bowl of lamb ragu' },
             steps: [
-              { order: 1, text: 'Sear.', image: { key: step1Key, alt: 'seared' } },
+              { stepId: stepIdA, order: 1, text: 'Sear.', image: { alt: 'seared' } },
             ],
             imageStatus: { [step1Key]: step1Ts },
           }),
@@ -1857,14 +1863,14 @@ describe('Recipe Lambda handler', () => {
         expect(body.errors).not.toHaveProperty('stepImages')
       })
 
-      it('returns 400 with errors.stepImages for each step whose image key has no imageStatus entry (cover ready)', async () => {
+      it('returns 400 with errors.stepImages for each step whose image has no imageStatus entry (cover ready)', async () => {
         ddbMock.on(GetCommand).resolves({
           Item: draftRecipeItem({
             authorId: 'contributor-user-id',
-            coverImage: { key: coverKey, alt: 'A bowl of lamb ragu' },
+            coverImage: { alt: 'A bowl of lamb ragu' },
             steps: [
-              { order: 1, text: 'Sear.', image: { key: step1Key, alt: 'seared' } },
-              { order: 2, text: 'Simmer.', image: { key: step2Key, alt: 'simmering' } },
+              { stepId: stepIdA, order: 1, text: 'Sear.', image: { alt: 'seared' } },
+              { stepId: stepIdB, order: 2, text: 'Simmer.', image: { alt: 'simmering' } },
             ],
             imageStatus: { [coverKey]: coverTs, [step1Key]: step1Ts },
           }),
@@ -1888,10 +1894,10 @@ describe('Recipe Lambda handler', () => {
         ddbMock.on(GetCommand).resolves({
           Item: draftRecipeItem({
             authorId: 'contributor-user-id',
-            coverImage: { key: coverKey, alt: 'A bowl of lamb ragu' },
+            coverImage: { alt: 'A bowl of lamb ragu' },
             steps: [
-              { order: 1, text: 'Sear.', image: { key: step1Key, alt: 'seared' } },
-              { order: 2, text: 'Simmer.', image: { key: step2Key, alt: 'simmering' } },
+              { stepId: stepIdA, order: 1, text: 'Sear.', image: { alt: 'seared' } },
+              { stepId: stepIdB, order: 2, text: 'Simmer.', image: { alt: 'simmering' } },
             ],
             imageStatus: {},
           }),
@@ -1916,7 +1922,7 @@ describe('Recipe Lambda handler', () => {
           Item: draftRecipeItem({
             authorId: 'contributor-user-id',
             title: '',
-            coverImage: { key: coverKey, alt: 'A bowl of lamb ragu' },
+            coverImage: { alt: 'A bowl of lamb ragu' },
             imageStatus: {},
           }),
         })
@@ -1930,14 +1936,13 @@ describe('Recipe Lambda handler', () => {
         expect(body.errors.coverImage.processedAt).toBe('Cover image still processing')
       })
 
-      it('returns 400 when republishing a currently-published recipe whose cover was swapped to an unready new key', async () => {
-        const oldCoverKey = 'recipes/recipe-uuid-1/cover-old'
-        const newCoverKey = 'recipes/recipe-uuid-1/cover'
+      it('returns 400 when republishing a currently-published recipe whose cover has no imageStatus entry under the slug-derived key', async () => {
+        const staleLegacyKey = 'recipes/recipe-uuid-1/cover'
         ddbMock.on(GetCommand).resolves({
           Item: publishedRecipeItem({
             authorId: 'contributor-user-id',
-            coverImage: { key: newCoverKey, alt: 'New cover' },
-            imageStatus: { [oldCoverKey]: coverTs },
+            coverImage: { alt: 'New cover' },
+            imageStatus: { [staleLegacyKey]: coverTs },
           }),
         })
 
@@ -1954,8 +1959,11 @@ describe('Recipe Lambda handler', () => {
         ddbMock.on(GetCommand).resolves({
           Item: draftRecipeItem({
             authorId: 'contributor-user-id',
-            coverImage: { key: coverKey, alt: 'A bowl of lamb ragu' },
-            steps: [{ order: 1, text: '' }, { order: 2, text: '   ' }],
+            coverImage: { alt: 'A bowl of lamb ragu' },
+            steps: [
+              { stepId: stepIdA, order: 1, text: '' },
+              { stepId: stepIdB, order: 2, text: '   ' },
+            ],
             imageStatus: { [coverKey]: coverTs },
           }),
         })
@@ -1969,16 +1977,81 @@ describe('Recipe Lambda handler', () => {
         expect(body.errors.steps).not.toEqual(expect.any(Array))
       })
 
-      it('publishes successfully when every image key has a matching imageStatus entry', async () => {
+      it('publishes successfully when every image key has a matching slug-derived imageStatus entry', async () => {
         ddbMock.on(GetCommand).resolves({
           Item: draftRecipeItem({
             authorId: 'contributor-user-id',
-            coverImage: { key: coverKey, alt: 'A bowl of lamb ragu' },
+            coverImage: { alt: 'A bowl of lamb ragu' },
             steps: [
-              { order: 1, text: 'Sear.', image: { key: step1Key, alt: 'seared' } },
-              { order: 2, text: 'Simmer.', image: { key: step2Key, alt: 'simmering' } },
+              { stepId: stepIdA, order: 1, text: 'Sear.', image: { alt: 'seared' } },
+              { stepId: stepIdB, order: 2, text: 'Simmer.', image: { alt: 'simmering' } },
             ],
             imageStatus: { [coverKey]: coverTs, [step1Key]: step1Ts, [step2Key]: step2Ts },
+          }),
+        })
+        ddbMock.on(UpdateCommand).resolves({
+          Attributes: publishedRecipeItem({ authorId: 'contributor-user-id' }),
+        })
+
+        const result = await handler(publishEvent())
+
+        expect(result.statusCode).toBe(200)
+      })
+
+      it('publishes successfully when steps have no images and only the cover is ready (no stepImages errors emitted)', async () => {
+        ddbMock.on(GetCommand).resolves({
+          Item: draftRecipeItem({
+            authorId: 'contributor-user-id',
+            coverImage: { alt: 'A bowl of lamb ragu' },
+            steps: [
+              { stepId: stepIdA, order: 1, text: 'Sear.' },
+              { stepId: stepIdB, order: 2, text: 'Simmer.' },
+            ],
+            imageStatus: { [coverKey]: coverTs },
+          }),
+        })
+        ddbMock.on(UpdateCommand).resolves({
+          Attributes: publishedRecipeItem({ authorId: 'contributor-user-id' }),
+        })
+
+        const result = await handler(publishEvent())
+
+        expect(result.statusCode).toBe(200)
+      })
+
+      it('emits one stepImages entry per step with image but no slug+stepId imageStatus entry', async () => {
+        ddbMock.on(GetCommand).resolves({
+          Item: draftRecipeItem({
+            authorId: 'contributor-user-id',
+            coverImage: { alt: 'A bowl of lamb ragu' },
+            steps: [
+              { stepId: stepIdA, order: 1, text: 'Sear.', image: { alt: 'seared' } },
+              { stepId: stepIdB, order: 2, text: 'Simmer.', image: { alt: 'simmering' } },
+            ],
+            imageStatus: { [coverKey]: coverTs },
+          }),
+        })
+
+        const result = await handler(publishEvent())
+
+        expect(result.statusCode).toBe(400)
+        const body = JSON.parse(result.body as string)
+        expect(body.errors).not.toHaveProperty('coverImage')
+        expect(body.errors.stepImages).toEqual([
+          { order: 1, processedAt: 'Step image still processing' },
+          { order: 2, processedAt: 'Step image still processing' },
+        ])
+      })
+
+      // Reference to publishedSlug to keep the constant tied to documented intent
+      // (the slug-derived imageStatus key for published-state assertions lives elsewhere).
+      it('uses the published recipe\'s slug-derived key for republish readiness', async () => {
+        const publishedCoverKey = `recipes/${publishedSlug}/cover`
+        ddbMock.on(GetCommand).resolves({
+          Item: publishedRecipeItem({
+            authorId: 'contributor-user-id',
+            coverImage: { alt: 'A bowl of lamb ragu' },
+            imageStatus: { [publishedCoverKey]: coverTs },
           }),
         })
         ddbMock.on(UpdateCommand).resolves({
@@ -1995,7 +2068,7 @@ describe('Recipe Lambda handler', () => {
       ddbMock.on(GetCommand).resolves({
         Item: publishedRecipeItem({
           authorId: 'contributor-user-id',
-          imageStatus: { 'recipes/images/recipe-uuid-1/cover': 1_745_000_000_000 },
+          imageStatus: { 'recipes/slow-cooked-lamb-ragu/cover': 1_745_000_000_000 },
         }),
       })
       ddbMock.on(UpdateCommand).resolves({
@@ -2497,14 +2570,12 @@ describe('Recipe Lambda handler', () => {
     // AC 6: PATCH /recipes/{id}/publish response composes processedAt.
     it('PATCH /recipes/{id}/publish response composes processedAt onto the returned recipe', async () => {
       // Draft we read for validation passes all existing checks AND has readiness on every image.
-      // Note: validatePublishInput still reads `coverImage.key` / `step.image.key` (not in scope
-      // for this issue) — keep those literal keys present in the validation fixture so it passes.
       const fullyReadyDraft = recipeWithImageStatus({
         status: 'draft',
         authorId: 'contributor-user-id',
-        coverImage: { key: coverKey, alt: 'A bowl of lamb ragu' },
+        coverImage: { alt: 'A bowl of lamb ragu' },
         steps: [
-          { stepId: stepId1, order: 1, text: 'Sear.', image: { key: step1Key, alt: 'seared lamb' } },
+          { stepId: stepId1, order: 1, text: 'Sear.', image: { alt: 'seared lamb' } },
         ],
         imageStatus: { [coverKey]: coverTs, [step1Key]: step1Ts },
       })
@@ -2626,12 +2697,11 @@ describe('Recipe Lambda handler', () => {
       })
 
       it('PATCH /recipes/{id}/publish strips imageStatus', async () => {
-        // Validation still uses coverImage.key/step.image.key — keep them populated for this fixture.
         const fullyReadyDraft = recipeWithImageStatus({
           status: 'draft',
           authorId: 'contributor-user-id',
-          coverImage: { key: coverKey, alt: 'A bowl of lamb ragu' },
-          steps: [{ stepId: stepId1, order: 1, text: 'Sear.', image: { key: step1Key, alt: 'seared lamb' } }],
+          coverImage: { alt: 'A bowl of lamb ragu' },
+          steps: [{ stepId: stepId1, order: 1, text: 'Sear.', image: { alt: 'seared lamb' } }],
           imageStatus: { [coverKey]: coverTs, [step1Key]: step1Ts },
         })
         ddbMock.on(GetCommand).resolves({ Item: fullyReadyDraft })

--- a/test/lambda/recipe-handler.test.ts
+++ b/test/lambda/recipe-handler.test.ts
@@ -11,7 +11,7 @@ process.env.TABLE_NAME = 'test-recipes-table'
 process.env.IMAGE_BUCKET_NAME = 'test-recipe-images-bucket'
 
 // Import handler after mock setup
-import { handler } from '../../lambda/recipe-handler'
+import { handler, isValidSlug, RESERVED_SLUGS } from '../../lambda/recipe-handler'
 
 // Build a fake JWT with the given payload (header.payload.signature)
 function fakeJwt(payload: Record<string, unknown>): string {
@@ -335,6 +335,52 @@ describe('Recipe Lambda handler', () => {
     })
   })
 
+  // ─── isValidSlug helper (issue #147 AC1, AC2) ───────────────────────
+  describe('isValidSlug', () => {
+    it('accepts simple lowercase ASCII slugs', () => {
+      expect(isValidSlug('beans-on-toast')).toBe(true)
+      expect(isValidSlug('a')).toBe(true)
+      expect(isValidSlug('recipe-1')).toBe(true)
+      expect(isValidSlug('123')).toBe(true)
+    })
+
+    it('rejects uppercase letters', () => {
+      expect(isValidSlug('BEANS')).toBe(false)
+      expect(isValidSlug('Beans-On-Toast')).toBe(false)
+    })
+
+    it('rejects whitespace', () => {
+      expect(isValidSlug('  beans  ')).toBe(false)
+      expect(isValidSlug('beans on toast')).toBe(false)
+    })
+
+    it('rejects leading or trailing hyphens', () => {
+      expect(isValidSlug('-beans')).toBe(false)
+      expect(isValidSlug('beans-')).toBe(false)
+      expect(isValidSlug('-beans-')).toBe(false)
+    })
+
+    it('rejects non-ASCII characters and punctuation', () => {
+      expect(isValidSlug('beans!')).toBe(false)
+      expect(isValidSlug('beans/toast')).toBe(false)
+      expect(isValidSlug('café')).toBe(false)
+      expect(isValidSlug('beans_on_toast')).toBe(false)
+    })
+
+    it('rejects empty string and slugs longer than 100 characters', () => {
+      expect(isValidSlug('')).toBe(false)
+      expect(isValidSlug('a'.repeat(100))).toBe(true)
+      expect(isValidSlug('a'.repeat(101))).toBe(false)
+    })
+
+    it('rejects reserved slugs', () => {
+      expect(RESERVED_SLUGS).toEqual(expect.arrayContaining(['new', 'admin', 'drafts', 'images']))
+      for (const reserved of ['new', 'admin', 'drafts', 'images']) {
+        expect(isValidSlug(reserved)).toBe(false)
+      }
+    })
+  })
+
   // ─── POST /recipes/drafts — create draft ────────────────────────────
   describe('POST /recipes/drafts — create draft', () => {
     it('returns 401 without a valid token', async () => {
@@ -368,7 +414,7 @@ describe('Recipe Lambda handler', () => {
     })
 
     it('returns 201 with { id, slug } in the body on success', async () => {
-      ddbMock.on(ScanCommand).resolves({ Items: [] })
+      ddbMock.on(QueryCommand).resolves({ Items: [] })
       ddbMock.on(PutCommand).resolves({})
 
       const event = makeEvent({
@@ -390,7 +436,7 @@ describe('Recipe Lambda handler', () => {
     it('writes status=draft and ttl=now+30d to DynamoDB', async () => {
       jest.useFakeTimers().setSystemTime(new Date('2026-04-19T12:00:00Z'))
       try {
-        ddbMock.on(ScanCommand).resolves({ Items: [] })
+        ddbMock.on(QueryCommand).resolves({ Items: [] })
         ddbMock.on(PutCommand).resolves({})
 
         const event = makeEvent({
@@ -418,7 +464,7 @@ describe('Recipe Lambda handler', () => {
     })
 
     it('initialises imageStatus as an empty map on the new item', async () => {
-      ddbMock.on(ScanCommand).resolves({ Items: [] })
+      ddbMock.on(QueryCommand).resolves({ Items: [] })
       ddbMock.on(PutCommand).resolves({})
 
       const event = makeEvent({
@@ -439,8 +485,9 @@ describe('Recipe Lambda handler', () => {
       expect(item.imageStatus).toEqual({})
     })
 
-    it('defaults slug to draft-<uuid> when no title is provided', async () => {
-      ddbMock.on(ScanCommand).resolves({ Items: [] })
+    // AC4: server-generated default slug shape is `draft-<8 hex chars>`.
+    it('defaults slug to /^draft-[a-z0-9]{8}$/ when no slug is provided', async () => {
+      ddbMock.on(QueryCommand).resolves({ Items: [] })
       ddbMock.on(PutCommand).resolves({})
 
       const event = makeEvent({
@@ -454,25 +501,155 @@ describe('Recipe Lambda handler', () => {
 
       expect(result.statusCode).toBe(201)
       const body = JSON.parse(result.body as string)
-      expect(body.slug).toMatch(/^draft-/)
+      expect(body.slug).toMatch(/^draft-[a-z0-9]{8}$/)
+      // Default slug is derived from id.slice(0, 8) — first 8 chars of the UUID with hyphens stripped or sliced.
+      expect(typeof body.id).toBe('string')
+      expect(body.slug).toBe(`draft-${(body.id as string).slice(0, 8)}`)
     })
 
-    it('derives slug from the title when one is provided', async () => {
-      ddbMock.on(ScanCommand).resolves({ Items: [] })
+    // AC5: caller-supplied slug is echoed back when valid and unused.
+    it('returns 201 with the caller-supplied slug when it is valid and unused', async () => {
+      ddbMock.on(QueryCommand).resolves({ Items: [] })
       ddbMock.on(PutCommand).resolves({})
 
       const event = makeEvent({
         routeKey: 'POST /recipes/drafts',
         rawPath: '/recipes/drafts',
         headers: { authorization: `Bearer ${adminToken}` },
-        body: JSON.stringify({ title: 'My New Recipe' }),
+        body: JSON.stringify({ slug: 'beans-on-toast' }),
       })
 
       const result = await handler(event)
 
       expect(result.statusCode).toBe(201)
       const body = JSON.parse(result.body as string)
-      expect(body.slug).toBe('my-new-recipe')
+      expect(body.slug).toBe('beans-on-toast')
+
+      // Persisted item also has the caller-supplied slug
+      const putCalls = ddbMock.commandCalls(PutCommand)
+      expect(putCalls).toHaveLength(1)
+      const item = putCalls[0].args[0].input.Item as Record<string, unknown>
+      expect(item.slug).toBe('beans-on-toast')
+    })
+
+    // AC3: uniqueness lookup uses the slug-index GSI via QueryCommand (NOT ScanCommand).
+    it('checks slug uniqueness via QueryCommand against IndexName: slug-index', async () => {
+      ddbMock.on(QueryCommand).resolves({ Items: [] })
+      ddbMock.on(PutCommand).resolves({})
+
+      const event = makeEvent({
+        routeKey: 'POST /recipes/drafts',
+        rawPath: '/recipes/drafts',
+        headers: { authorization: `Bearer ${adminToken}` },
+        body: JSON.stringify({ slug: 'beans-on-toast' }),
+      })
+
+      const result = await handler(event)
+
+      expect(result.statusCode).toBe(201)
+
+      const queryCalls = ddbMock.commandCalls(QueryCommand)
+      expect(queryCalls).toHaveLength(1)
+      const input = queryCalls[0].args[0].input
+      expect(input.TableName).toBe('test-recipes-table')
+      expect(input.IndexName).toBe('slug-index')
+      expect(input.KeyConditionExpression).toBe('slug = :slug')
+      expect(input.ExpressionAttributeValues).toEqual({ ':slug': 'beans-on-toast' })
+
+      // Must NOT use a ScanCommand for uniqueness lookup.
+      expect(ddbMock.commandCalls(ScanCommand)).toHaveLength(0)
+    })
+
+    // AC6: lowercase enforcement via regex.
+    it('returns 400 for an uppercase slug', async () => {
+      const event = makeEvent({
+        routeKey: 'POST /recipes/drafts',
+        rawPath: '/recipes/drafts',
+        headers: { authorization: `Bearer ${adminToken}` },
+        body: JSON.stringify({ slug: 'BEANS' }),
+      })
+
+      const result = await handler(event)
+
+      expect(result.statusCode).toBe(400)
+      const body = JSON.parse(result.body as string)
+      expect(body).toHaveProperty('error')
+      // Must not have written the item.
+      expect(ddbMock.commandCalls(PutCommand)).toHaveLength(0)
+    })
+
+    // AC7: whitespace rejected by regex.
+    it('returns 400 for a slug containing whitespace', async () => {
+      const event = makeEvent({
+        routeKey: 'POST /recipes/drafts',
+        rawPath: '/recipes/drafts',
+        headers: { authorization: `Bearer ${adminToken}` },
+        body: JSON.stringify({ slug: '  beans  ' }),
+      })
+
+      const result = await handler(event)
+
+      expect(result.statusCode).toBe(400)
+      const body = JSON.parse(result.body as string)
+      expect(body).toHaveProperty('error')
+      expect(ddbMock.commandCalls(PutCommand)).toHaveLength(0)
+    })
+
+    // AC8: reserved word "admin" rejected.
+    it('returns 400 for the reserved slug "admin"', async () => {
+      const event = makeEvent({
+        routeKey: 'POST /recipes/drafts',
+        rawPath: '/recipes/drafts',
+        headers: { authorization: `Bearer ${adminToken}` },
+        body: JSON.stringify({ slug: 'admin' }),
+      })
+
+      const result = await handler(event)
+
+      expect(result.statusCode).toBe(400)
+      const body = JSON.parse(result.body as string)
+      expect(body).toHaveProperty('error')
+      expect(ddbMock.commandCalls(PutCommand)).toHaveLength(0)
+    })
+
+    // AC9: reserved word "drafts" rejected.
+    it('returns 400 for the reserved slug "drafts"', async () => {
+      const event = makeEvent({
+        routeKey: 'POST /recipes/drafts',
+        rawPath: '/recipes/drafts',
+        headers: { authorization: `Bearer ${adminToken}` },
+        body: JSON.stringify({ slug: 'drafts' }),
+      })
+
+      const result = await handler(event)
+
+      expect(result.statusCode).toBe(400)
+      const body = JSON.parse(result.body as string)
+      expect(body).toHaveProperty('error')
+      expect(ddbMock.commandCalls(PutCommand)).toHaveLength(0)
+    })
+
+    // AC10: collision returns 409 with the exact error body.
+    it('returns 409 slug_taken when the supplied slug is already in use', async () => {
+      ddbMock.on(QueryCommand).resolves({ Items: [{ id: 'some-other-recipe-id' }] })
+
+      const event = makeEvent({
+        routeKey: 'POST /recipes/drafts',
+        rawPath: '/recipes/drafts',
+        headers: { authorization: `Bearer ${adminToken}` },
+        body: JSON.stringify({ slug: 'beans-on-toast' }),
+      })
+
+      const result = await handler(event)
+
+      expect(result.statusCode).toBe(409)
+      const body = JSON.parse(result.body as string)
+      expect(body).toEqual({
+        error: 'slug_taken',
+        message: 'Slug "beans-on-toast" is already in use.',
+      })
+      // Must not persist the colliding draft.
+      expect(ddbMock.commandCalls(PutCommand)).toHaveLength(0)
     })
   })
 

--- a/test/lambda/recipe-handler.test.ts
+++ b/test/lambda/recipe-handler.test.ts
@@ -1,3 +1,4 @@
+import { ConditionalCheckFailedException } from '@aws-sdk/client-dynamodb'
 import { S3Client, ListObjectsV2Command, DeleteObjectsCommand } from '@aws-sdk/client-s3'
 import { DynamoDBDocumentClient, QueryCommand, GetCommand, PutCommand, UpdateCommand, DeleteCommand, ScanCommand } from '@aws-sdk/lib-dynamodb'
 import type { APIGatewayProxyEventV2 } from 'aws-lambda'
@@ -1429,6 +1430,311 @@ describe('Recipe Lambda handler', () => {
       // The user-supplied ttl value must not be present
       expect((input.ExpressionAttributeNames as Record<string, string>)['#ttl']).toBeUndefined()
       expect((input.ExpressionAttributeValues as Record<string, unknown>)[':ttl']).toBe(undefined)
+    })
+  })
+
+  // ─── PATCH /recipes/{id} — slug acceptance and lock ─────────────────
+  describe('PATCH /recipes/{id} — slug acceptance and lock', () => {
+    it('returns 200 and updates the slug when imageStatus is empty and the new slug is unique', async () => {
+      const oldItem = publishedRecipeItem({
+        id: 'recipe-uuid-1',
+        slug: 'old-slug',
+        authorId: 'contributor-user-id',
+        imageStatus: {},
+      })
+      ddbMock.on(GetCommand).resolves({ Item: oldItem })
+      ddbMock.on(QueryCommand).resolves({ Items: [] })
+      // Mock returns the OLD item — so the new slug only ends up in the response if the
+      // handler actually puts it into `updates` (rather than stripping it).
+      ddbMock.on(UpdateCommand).resolves({ Attributes: oldItem })
+
+      const event = makeEvent({
+        routeKey: 'PATCH /recipes/{id}',
+        rawPath: '/recipes/recipe-uuid-1',
+        pathParameters: { id: 'recipe-uuid-1' },
+        headers: { authorization: `Bearer ${contributorToken}` },
+        body: JSON.stringify({ slug: 'new-slug' }),
+      })
+
+      const result = await handler(event)
+
+      expect(result.statusCode).toBe(200)
+      const body = JSON.parse(result.body as string)
+      expect(body.slug).toBe('new-slug')
+
+      // The UpdateCommand should be invoked exactly once and must actually carry the new slug.
+      const updateCalls = ddbMock.commandCalls(UpdateCommand)
+      expect(updateCalls).toHaveLength(1)
+      const values = updateCalls[0].args[0].input.ExpressionAttributeValues as Record<string, unknown>
+      expect(values[':slug']).toBe('new-slug')
+    })
+
+    it('returns 409 slug_locked when imageStatus has at least one entry', async () => {
+      const oldItem = publishedRecipeItem({
+        id: 'recipe-uuid-1',
+        slug: 'old-slug',
+        authorId: 'contributor-user-id',
+        imageStatus: { 'recipes/old-slug/cover': 1_745_000_000_000 },
+      })
+      ddbMock.on(GetCommand).resolves({ Item: oldItem })
+
+      const event = makeEvent({
+        routeKey: 'PATCH /recipes/{id}',
+        rawPath: '/recipes/recipe-uuid-1',
+        pathParameters: { id: 'recipe-uuid-1' },
+        headers: { authorization: `Bearer ${contributorToken}` },
+        body: JSON.stringify({ slug: 'new-slug' }),
+      })
+
+      const result = await handler(event)
+
+      expect(result.statusCode).toBe(409)
+      const body = JSON.parse(result.body as string)
+      expect(body).toEqual({
+        error: 'slug_locked',
+        message: 'Cannot change slug after images have been uploaded. Delete uploaded images first.',
+      })
+
+      // In-memory check fails first — no UpdateCommand should be issued.
+      expect(ddbMock.commandCalls(UpdateCommand)).toHaveLength(0)
+    })
+
+    it('returns 400 when the supplied slug is invalid', async () => {
+      const oldItem = publishedRecipeItem({
+        id: 'recipe-uuid-1',
+        slug: 'old-slug',
+        authorId: 'contributor-user-id',
+        imageStatus: {},
+      })
+      ddbMock.on(GetCommand).resolves({ Item: oldItem })
+
+      const event = makeEvent({
+        routeKey: 'PATCH /recipes/{id}',
+        rawPath: '/recipes/recipe-uuid-1',
+        pathParameters: { id: 'recipe-uuid-1' },
+        headers: { authorization: `Bearer ${contributorToken}` },
+        body: JSON.stringify({ slug: 'INVALID' }),
+      })
+
+      const result = await handler(event)
+
+      expect(result.statusCode).toBe(400)
+      // Validation must happen before any write.
+      expect(ddbMock.commandCalls(UpdateCommand)).toHaveLength(0)
+    })
+
+    it('returns 409 slug_taken when the new slug is already in use by another recipe', async () => {
+      const oldItem = publishedRecipeItem({
+        id: 'recipe-uuid-1',
+        slug: 'old-slug',
+        authorId: 'contributor-user-id',
+        imageStatus: {},
+      })
+      ddbMock.on(GetCommand).resolves({ Item: oldItem })
+      // Slug-index returns a different recipe owning the desired slug.
+      ddbMock.on(QueryCommand).resolves({ Items: [{ id: 'some-other-recipe-id' }] })
+
+      const event = makeEvent({
+        routeKey: 'PATCH /recipes/{id}',
+        rawPath: '/recipes/recipe-uuid-1',
+        pathParameters: { id: 'recipe-uuid-1' },
+        headers: { authorization: `Bearer ${contributorToken}` },
+        body: JSON.stringify({ slug: 'taken-slug' }),
+      })
+
+      const result = await handler(event)
+
+      expect(result.statusCode).toBe(409)
+      const body = JSON.parse(result.body as string)
+      expect(body).toEqual({
+        error: 'slug_taken',
+        message: 'Slug "taken-slug" is already in use.',
+      })
+      expect(ddbMock.commandCalls(UpdateCommand)).toHaveLength(0)
+    })
+
+    it('returns 200 when the slug-index returns the recipe being patched (excludeId ignores self)', async () => {
+      const oldItem = publishedRecipeItem({
+        id: 'recipe-uuid-1',
+        slug: 'old-slug',
+        authorId: 'contributor-user-id',
+        imageStatus: {},
+      })
+      ddbMock.on(GetCommand).resolves({ Item: oldItem })
+      // Slug-index returns ONLY the recipe being patched — must not be treated as a collision.
+      ddbMock.on(QueryCommand).resolves({ Items: [{ id: 'recipe-uuid-1' }] })
+      ddbMock.on(UpdateCommand).resolves({ Attributes: oldItem })
+
+      const event = makeEvent({
+        routeKey: 'PATCH /recipes/{id}',
+        rawPath: '/recipes/recipe-uuid-1',
+        pathParameters: { id: 'recipe-uuid-1' },
+        headers: { authorization: `Bearer ${contributorToken}` },
+        body: JSON.stringify({ slug: 'new-slug' }),
+      })
+
+      const result = await handler(event)
+
+      expect(result.statusCode).toBe(200)
+      // The handler must have queried the slug-index (proving slugExists ran with excludeId).
+      const queryCalls = ddbMock.commandCalls(QueryCommand)
+      expect(queryCalls.length).toBeGreaterThanOrEqual(1)
+      const slugQuery = queryCalls.find((c) => c.args[0].input.IndexName === 'slug-index')
+      expect(slugQuery).toBeDefined()
+
+      const updateCalls = ddbMock.commandCalls(UpdateCommand)
+      expect(updateCalls).toHaveLength(1)
+      const values = updateCalls[0].args[0].input.ExpressionAttributeValues as Record<string, unknown>
+      expect(values[':slug']).toBe('new-slug')
+    })
+
+    it('UpdateCommand for a slug-changing PATCH includes a TOCTOU ConditionExpression with all three clauses', async () => {
+      const oldItem = publishedRecipeItem({
+        id: 'recipe-uuid-1',
+        slug: 'old-slug',
+        authorId: 'contributor-user-id',
+        imageStatus: {},
+      })
+      ddbMock.on(GetCommand).resolves({ Item: oldItem })
+      ddbMock.on(QueryCommand).resolves({ Items: [] })
+      ddbMock.on(UpdateCommand).resolves({
+        Attributes: { ...oldItem, slug: 'new-slug' },
+      })
+
+      const event = makeEvent({
+        routeKey: 'PATCH /recipes/{id}',
+        rawPath: '/recipes/recipe-uuid-1',
+        pathParameters: { id: 'recipe-uuid-1' },
+        headers: { authorization: `Bearer ${contributorToken}` },
+        body: JSON.stringify({ slug: 'new-slug' }),
+      })
+
+      const result = await handler(event)
+
+      expect(result.statusCode).toBe(200)
+
+      const updateCalls = ddbMock.commandCalls(UpdateCommand)
+      expect(updateCalls).toHaveLength(1)
+      const input = updateCalls[0].args[0].input
+      const condition = input.ConditionExpression
+      expect(typeof condition).toBe('string')
+      // attribute_exists(id) clause
+      expect(condition).toMatch(/attribute_exists\s*\(\s*id\s*\)/)
+      // imageStatus-empty clause: attribute_not_exists OR size = :zero
+      expect(condition).toMatch(/attribute_not_exists\s*\(\s*imageStatus\s*\)\s+OR\s+size\s*\(\s*imageStatus\s*\)\s*=\s*:zero/)
+      // expected old slug clause (PRD specifies :expectedOldSlug, but accept :oldSlug for flexibility).
+      expect(condition).toMatch(/slug\s*=\s*:(?:expectedOldSlug|oldSlug)/)
+
+      const values = input.ExpressionAttributeValues as Record<string, unknown>
+      expect(values[':zero']).toBe(0)
+      // The expected-old-slug binding must be present and match the existing slug.
+      const expectedOldSlugValue = values[':expectedOldSlug'] ?? values[':oldSlug']
+      expect(expectedOldSlugValue).toBe('old-slug')
+    })
+
+    it('maps ConditionalCheckFailedException to 409 slug_locked when re-read shows imageStatus has been populated', async () => {
+      const oldItem = publishedRecipeItem({
+        id: 'recipe-uuid-1',
+        slug: 'old-slug',
+        authorId: 'contributor-user-id',
+        imageStatus: {},
+      })
+      const reReadItem = {
+        ...oldItem,
+        imageStatus: { 'recipes/old-slug/cover': 1_745_000_000_000 },
+      }
+      // First Get is the pre-read; second Get is the re-read after the conditional failure.
+      ddbMock
+        .on(GetCommand)
+        .resolvesOnce({ Item: oldItem })
+        .resolvesOnce({ Item: reReadItem })
+      ddbMock.on(QueryCommand).resolves({ Items: [] })
+      ddbMock.on(UpdateCommand).rejects(
+        new ConditionalCheckFailedException({
+          $metadata: {},
+          message: 'The conditional request failed',
+        }),
+      )
+
+      const event = makeEvent({
+        routeKey: 'PATCH /recipes/{id}',
+        rawPath: '/recipes/recipe-uuid-1',
+        pathParameters: { id: 'recipe-uuid-1' },
+        headers: { authorization: `Bearer ${contributorToken}` },
+        body: JSON.stringify({ slug: 'new-slug' }),
+      })
+
+      const result = await handler(event)
+
+      expect(result.statusCode).toBe(409)
+      const body = JSON.parse(result.body as string)
+      expect(body.error).toBe('slug_locked')
+    })
+
+    it('maps ConditionalCheckFailedException to 409 conflict when re-read shows the slug changed underneath', async () => {
+      const oldItem = publishedRecipeItem({
+        id: 'recipe-uuid-1',
+        slug: 'old-slug',
+        authorId: 'contributor-user-id',
+        imageStatus: {},
+      })
+      const reReadItem = {
+        ...oldItem,
+        slug: 'someone-else-changed-it',
+        imageStatus: {},
+      }
+      ddbMock
+        .on(GetCommand)
+        .resolvesOnce({ Item: oldItem })
+        .resolvesOnce({ Item: reReadItem })
+      ddbMock.on(QueryCommand).resolves({ Items: [] })
+      ddbMock.on(UpdateCommand).rejects(
+        new ConditionalCheckFailedException({
+          $metadata: {},
+          message: 'The conditional request failed',
+        }),
+      )
+
+      const event = makeEvent({
+        routeKey: 'PATCH /recipes/{id}',
+        rawPath: '/recipes/recipe-uuid-1',
+        pathParameters: { id: 'recipe-uuid-1' },
+        headers: { authorization: `Bearer ${contributorToken}` },
+        body: JSON.stringify({ slug: 'new-slug' }),
+      })
+
+      const result = await handler(event)
+
+      expect(result.statusCode).toBe(409)
+      const body = JSON.parse(result.body as string)
+      expect(body.error).toBe('conflict')
+    })
+
+    it('does NOT add a ConditionExpression when slug is omitted from the patch body', async () => {
+      const oldItem = publishedRecipeItem({
+        id: 'recipe-uuid-1',
+        slug: 'old-slug',
+        authorId: 'contributor-user-id',
+        imageStatus: { 'recipes/old-slug/cover': 1_745_000_000_000 },
+      })
+      ddbMock.on(GetCommand).resolves({ Item: oldItem })
+      ddbMock.on(UpdateCommand).resolves({ Attributes: oldItem })
+
+      const event = makeEvent({
+        routeKey: 'PATCH /recipes/{id}',
+        rawPath: '/recipes/recipe-uuid-1',
+        pathParameters: { id: 'recipe-uuid-1' },
+        headers: { authorization: `Bearer ${contributorToken}` },
+        body: JSON.stringify({ title: 'Just a title change' }),
+      })
+
+      const result = await handler(event)
+
+      expect(result.statusCode).toBe(200)
+
+      const updateCalls = ddbMock.commandCalls(UpdateCommand)
+      expect(updateCalls).toHaveLength(1)
+      expect(updateCalls[0].args[0].input.ConditionExpression).toBeUndefined()
     })
   })
 

--- a/test/lambda/recipe-handler.test.ts
+++ b/test/lambda/recipe-handler.test.ts
@@ -1,6 +1,7 @@
 import { ConditionalCheckFailedException } from '@aws-sdk/client-dynamodb'
 import { S3Client, ListObjectsV2Command, DeleteObjectsCommand } from '@aws-sdk/client-s3'
 import { DynamoDBDocumentClient, QueryCommand, GetCommand, PutCommand, UpdateCommand, DeleteCommand, ScanCommand } from '@aws-sdk/lib-dynamodb'
+import { marshall } from '@aws-sdk/util-dynamodb'
 import type { APIGatewayProxyEventV2 } from 'aws-lambda'
 import { mockClient } from 'aws-sdk-client-mock'
 
@@ -1545,27 +1546,26 @@ describe('Recipe Lambda handler', () => {
       expect(expectedOldSlugValue).toBe('old-slug')
     })
 
-    it('maps ConditionalCheckFailedException to 409 slug_locked when re-read shows imageStatus has been populated', async () => {
+    it('maps ConditionalCheckFailedException to 409 slug_locked when the atomic snapshot shows imageStatus has been populated', async () => {
       const oldItem = publishedRecipeItem({
         id: 'recipe-uuid-1',
         slug: 'old-slug',
         authorId: 'contributor-user-id',
         imageStatus: {},
       })
-      const reReadItem = {
+      // The race-loss snapshot rides on err.Item as raw, marshalled AttributeValues —
+      // lib-dynamodb does not unmarshall a thrown exception's Item, so the handler must.
+      const atomicSnapshot = {
         ...oldItem,
         imageStatus: { 'recipes/old-slug/cover': 1_745_000_000_000 },
       }
-      // First Get is the pre-read; second Get is the re-read after the conditional failure.
-      ddbMock
-        .on(GetCommand)
-        .resolvesOnce({ Item: oldItem })
-        .resolvesOnce({ Item: reReadItem })
+      ddbMock.on(GetCommand).resolves({ Item: oldItem })
       ddbMock.on(QueryCommand).resolves({ Items: [] })
       ddbMock.on(UpdateCommand).rejects(
         new ConditionalCheckFailedException({
           $metadata: {},
           message: 'The conditional request failed',
+          Item: marshall(atomicSnapshot),
         }),
       )
 
@@ -1582,24 +1582,56 @@ describe('Recipe Lambda handler', () => {
       expect(result.statusCode).toBe(409)
       const body = JSON.parse(result.body as string)
       expect(body.error).toBe('slug_locked')
+      // Race-loss path must not issue a second Get — only the pre-read.
+      expect(ddbMock.commandCalls(GetCommand)).toHaveLength(1)
     })
 
-    it('maps ConditionalCheckFailedException to 409 conflict when re-read shows the slug changed underneath', async () => {
+    it('maps ConditionalCheckFailedException to 409 conflict when the atomic snapshot shows the slug changed underneath', async () => {
       const oldItem = publishedRecipeItem({
         id: 'recipe-uuid-1',
         slug: 'old-slug',
         authorId: 'contributor-user-id',
         imageStatus: {},
       })
-      const reReadItem = {
+      const atomicSnapshot = {
         ...oldItem,
         slug: 'someone-else-changed-it',
         imageStatus: {},
       }
-      ddbMock
-        .on(GetCommand)
-        .resolvesOnce({ Item: oldItem })
-        .resolvesOnce({ Item: reReadItem })
+      ddbMock.on(GetCommand).resolves({ Item: oldItem })
+      ddbMock.on(QueryCommand).resolves({ Items: [] })
+      ddbMock.on(UpdateCommand).rejects(
+        new ConditionalCheckFailedException({
+          $metadata: {},
+          message: 'The conditional request failed',
+          Item: marshall(atomicSnapshot),
+        }),
+      )
+
+      const event = makeEvent({
+        routeKey: 'PATCH /recipes/{id}',
+        rawPath: '/recipes/recipe-uuid-1',
+        pathParameters: { id: 'recipe-uuid-1' },
+        headers: { authorization: `Bearer ${contributorToken}` },
+        body: JSON.stringify({ slug: 'new-slug' }),
+      })
+
+      const result = await handler(event)
+
+      expect(result.statusCode).toBe(409)
+      const body = JSON.parse(result.body as string)
+      expect(body.error).toBe('conflict')
+      expect(ddbMock.commandCalls(GetCommand)).toHaveLength(1)
+    })
+
+    it('falls back to 409 conflict when the conditional failure carries no Item snapshot', async () => {
+      const oldItem = publishedRecipeItem({
+        id: 'recipe-uuid-1',
+        slug: 'old-slug',
+        authorId: 'contributor-user-id',
+        imageStatus: {},
+      })
+      ddbMock.on(GetCommand).resolves({ Item: oldItem })
       ddbMock.on(QueryCommand).resolves({ Items: [] })
       ddbMock.on(UpdateCommand).rejects(
         new ConditionalCheckFailedException({
@@ -1621,6 +1653,7 @@ describe('Recipe Lambda handler', () => {
       expect(result.statusCode).toBe(409)
       const body = JSON.parse(result.body as string)
       expect(body.error).toBe('conflict')
+      expect(ddbMock.commandCalls(GetCommand)).toHaveLength(1)
     })
 
     it('does NOT add a ConditionExpression when slug is omitted from the patch body', async () => {

--- a/test/lambda/recipe-image-handler.test.ts
+++ b/test/lambda/recipe-image-handler.test.ts
@@ -1,4 +1,6 @@
 import { S3Client } from '@aws-sdk/client-s3'
+import type { PutObjectCommand } from '@aws-sdk/client-s3'
+import { DynamoDBDocumentClient, GetCommand } from '@aws-sdk/lib-dynamodb'
 import { getSignedUrl } from '@aws-sdk/s3-request-presigner'
 import type { APIGatewayProxyEventV2 } from 'aws-lambda'
 import { mockClient } from 'aws-sdk-client-mock'
@@ -9,8 +11,10 @@ jest.mock('@aws-sdk/s3-request-presigner', () => ({
 }))
 
 const s3Mock = mockClient(S3Client)
+const ddbMock = mockClient(DynamoDBDocumentClient)
 
 process.env.IMAGE_BUCKET_NAME = 'test-recipe-images-bucket'
+process.env.TABLE_NAME = 'test-recipes-table'
 
 import { handler } from '../../lambda/recipe-image-handler'
 
@@ -23,6 +27,24 @@ function fakeJwt(payload: Record<string, unknown>): string {
 }
 
 const contributorToken = fakeJwt({ 'cognito:groups': ['contributor'], sub: 'contributor-user-id', email: 'contributor@example.com', name: 'Test Contributor' })
+
+const RECIPE_ID = 'recipe-uuid-1'
+const RECIPE_SLUG = 'beans-on-toast'
+const STEP_ID_A = '9d904a59-e83f-43b8-9f40-fbdb3008974c'
+const STEP_ID_B = 'b51ad2e3-2c3e-4b6e-9d3a-1f8e8b2a7c11'
+const STEP_ID_NOT_IN_RECIPE = 'cccccccc-cccc-4ccc-bccc-cccccccccccc'
+
+function recipeItem(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    id: RECIPE_ID,
+    slug: RECIPE_SLUG,
+    steps: [
+      { stepId: STEP_ID_A, order: 1, text: 'Toast the bread.' },
+      { stepId: STEP_ID_B, order: 2, text: 'Heat the beans.' },
+    ],
+    ...overrides,
+  }
+}
 
 function makeEvent(overrides: Partial<APIGatewayProxyEventV2> = {}): APIGatewayProxyEventV2 {
   return {
@@ -54,19 +76,28 @@ function makeEvent(overrides: Partial<APIGatewayProxyEventV2> = {}): APIGatewayP
   } as APIGatewayProxyEventV2
 }
 
+function lastPresignedKey(): string | undefined {
+  const calls = (getSignedUrl as jest.Mock).mock.calls
+  if (calls.length === 0) return undefined
+  const command = calls[calls.length - 1][1] as PutObjectCommand
+  return command.input.Key
+}
+
 describe('Recipe Image handler', () => {
   beforeEach(() => {
     s3Mock.reset()
+    ddbMock.reset()
     ;(getSignedUrl as jest.Mock).mockClear()
     ;(getSignedUrl as jest.Mock).mockResolvedValue('https://mock-presigned-url.s3.amazonaws.com/test')
   })
 
-  // ─── POST /recipes/images/upload-url — presigned URL generation ────
-  describe('POST /recipes/images/upload-url — presigned URL generation', () => {
-    it('returns 200 with uploadUrl and key', async () => {
+  // ─── POST /recipes/images/upload-url — response shape ───────────────
+  describe('POST /recipes/images/upload-url — response shape', () => {
+    it('returns 200 with uploadUrl and no key field', async () => {
+      ddbMock.on(GetCommand).resolves({ Item: recipeItem() })
       const event = makeEvent({
         headers: { authorization: `Bearer ${contributorToken}` },
-        body: JSON.stringify({ recipeId: 'abc', imageType: 'cover' }),
+        body: JSON.stringify({ recipeId: RECIPE_ID, imageType: 'cover' }),
       })
 
       const result = await handler(event)
@@ -74,40 +105,139 @@ describe('Recipe Image handler', () => {
       expect(result.statusCode).toBe(200)
       const body = JSON.parse(result.body as string)
       expect(typeof body.uploadUrl).toBe('string')
-      expect(typeof body.key).toBe('string')
-      expect(body.key).toMatch(/^recipes\/[^/]+\//)
+      expect(body).not.toHaveProperty('key')
     })
+  })
 
-    it('generates correct S3 key for cover image', async () => {
+  // ─── POST /recipes/images/upload-url — cover image ──────────────────
+  describe('POST /recipes/images/upload-url — cover image', () => {
+    it('builds the presigned key as uploads/recipes/<slug>/cover using the slug from the recipe item', async () => {
+      ddbMock.on(GetCommand).resolves({ Item: recipeItem() })
       const event = makeEvent({
         headers: { authorization: `Bearer ${contributorToken}` },
-        body: JSON.stringify({ recipeId: 'abc', imageType: 'cover' }),
+        body: JSON.stringify({ recipeId: RECIPE_ID, imageType: 'cover' }),
       })
 
       const result = await handler(event)
 
       expect(result.statusCode).toBe(200)
-      const body = JSON.parse(result.body as string)
-      expect(body.key).toBe('recipes/abc/cover')
+      expect(lastPresignedKey()).toBe(`uploads/recipes/${RECIPE_SLUG}/cover`)
     })
 
-    it('generates correct S3 key for step image', async () => {
+    it('ignores a stray stepId on a cover request (no 400) and still produces the cover key', async () => {
+      ddbMock.on(GetCommand).resolves({ Item: recipeItem() })
       const event = makeEvent({
         headers: { authorization: `Bearer ${contributorToken}` },
-        body: JSON.stringify({ recipeId: 'abc', imageType: 'step', stepOrder: 3 }),
+        body: JSON.stringify({ recipeId: RECIPE_ID, imageType: 'cover', stepId: STEP_ID_A }),
       })
 
       const result = await handler(event)
 
       expect(result.statusCode).toBe(200)
-      const body = JSON.parse(result.body as string)
-      expect(body.key).toBe('recipes/abc/step-3')
+      expect(lastPresignedKey()).toBe(`uploads/recipes/${RECIPE_SLUG}/cover`)
+    })
+  })
+
+  // ─── POST /recipes/images/upload-url — step image ───────────────────
+  describe('POST /recipes/images/upload-url — step image', () => {
+    it('builds the presigned key as uploads/recipes/<slug>/step-<stepId> using the slug from the recipe item', async () => {
+      ddbMock.on(GetCommand).resolves({ Item: recipeItem() })
+      const event = makeEvent({
+        headers: { authorization: `Bearer ${contributorToken}` },
+        body: JSON.stringify({ recipeId: RECIPE_ID, imageType: 'step', stepId: STEP_ID_A }),
+      })
+
+      const result = await handler(event)
+
+      expect(result.statusCode).toBe(200)
+      expect(lastPresignedKey()).toBe(`uploads/recipes/${RECIPE_SLUG}/step-${STEP_ID_A}`)
     })
 
+    it('returns 400 when a step upload arrives without a stepId', async () => {
+      ddbMock.on(GetCommand).resolves({ Item: recipeItem() })
+      const event = makeEvent({
+        headers: { authorization: `Bearer ${contributorToken}` },
+        body: JSON.stringify({ recipeId: RECIPE_ID, imageType: 'step' }),
+      })
+
+      const result = await handler(event)
+
+      expect(result.statusCode).toBe(400)
+      const body = JSON.parse(result.body as string)
+      expect(body).toHaveProperty('error')
+    })
+
+    it.each([
+      ['not-a-uuid'],
+      ['abc'],
+      ['12345'],
+      ['00000000-0000-0000-0000-000000000000'], // valid format-ish but not v1-5 (version nibble 0)
+    ])('returns 400 when stepId %s is not a valid UUID', async (badStepId) => {
+      ddbMock.on(GetCommand).resolves({ Item: recipeItem() })
+      const event = makeEvent({
+        headers: { authorization: `Bearer ${contributorToken}` },
+        body: JSON.stringify({ recipeId: RECIPE_ID, imageType: 'step', stepId: badStepId }),
+      })
+
+      const result = await handler(event)
+
+      expect(result.statusCode).toBe(400)
+      const body = JSON.parse(result.body as string)
+      expect(body).toHaveProperty('error')
+    })
+
+    it("returns 404 when stepId is a valid UUID but doesn't appear in the recipe's steps", async () => {
+      ddbMock.on(GetCommand).resolves({ Item: recipeItem() })
+      const event = makeEvent({
+        headers: { authorization: `Bearer ${contributorToken}` },
+        body: JSON.stringify({ recipeId: RECIPE_ID, imageType: 'step', stepId: STEP_ID_NOT_IN_RECIPE }),
+      })
+
+      const result = await handler(event)
+
+      expect(result.statusCode).toBe(404)
+      const body = JSON.parse(result.body as string)
+      expect(body).toHaveProperty('error')
+    })
+  })
+
+  // ─── POST /recipes/images/upload-url — recipe not found ─────────────
+  describe('POST /recipes/images/upload-url — recipe not found', () => {
+    it('returns 404 for a cover upload when GetItem returns no Item', async () => {
+      ddbMock.on(GetCommand).resolves({})
+      const event = makeEvent({
+        headers: { authorization: `Bearer ${contributorToken}` },
+        body: JSON.stringify({ recipeId: 'nonexistent-id', imageType: 'cover' }),
+      })
+
+      const result = await handler(event)
+
+      expect(result.statusCode).toBe(404)
+      const body = JSON.parse(result.body as string)
+      expect(body).toHaveProperty('error')
+    })
+
+    it('returns 404 for a step upload when GetItem returns no Item', async () => {
+      ddbMock.on(GetCommand).resolves({})
+      const event = makeEvent({
+        headers: { authorization: `Bearer ${contributorToken}` },
+        body: JSON.stringify({ recipeId: 'nonexistent-id', imageType: 'step', stepId: STEP_ID_A }),
+      })
+
+      const result = await handler(event)
+
+      expect(result.statusCode).toBe(404)
+      const body = JSON.parse(result.body as string)
+      expect(body).toHaveProperty('error')
+    })
+  })
+
+  // ─── POST /recipes/images/upload-url — auth + validation ────────────
+  describe('POST /recipes/images/upload-url — auth + validation', () => {
     it('returns 401 without bearer token', async () => {
       const event = makeEvent({
         headers: {},
-        body: JSON.stringify({ recipeId: 'abc', imageType: 'cover' }),
+        body: JSON.stringify({ recipeId: RECIPE_ID, imageType: 'cover' }),
       })
 
       const result = await handler(event)
@@ -133,7 +263,7 @@ describe('Recipe Image handler', () => {
     it('returns 400 for missing imageType', async () => {
       const event = makeEvent({
         headers: { authorization: `Bearer ${contributorToken}` },
-        body: JSON.stringify({ recipeId: 'abc' }),
+        body: JSON.stringify({ recipeId: RECIPE_ID }),
       })
 
       const result = await handler(event)

--- a/test/recipe-stack.test.ts
+++ b/test/recipe-stack.test.ts
@@ -172,6 +172,45 @@ describe('RecipeStack', () => {
     })
   })
 
+  describe('GSI slug-index', () => {
+    it('creates GSI with name slug-index', () => {
+      template.hasResourceProperties('AWS::DynamoDB::Table', {
+        GlobalSecondaryIndexes: Match.arrayWith([
+          Match.objectLike({
+            IndexName: 'slug-index',
+          }),
+        ]),
+      })
+    })
+
+    it('has partition key slug (String)', () => {
+      template.hasResourceProperties('AWS::DynamoDB::Table', {
+        GlobalSecondaryIndexes: Match.arrayWith([
+          Match.objectLike({
+            IndexName: 'slug-index',
+            KeySchema: [
+              { AttributeName: 'slug', KeyType: 'HASH' },
+            ],
+          }),
+        ]),
+        AttributeDefinitions: Match.arrayWith([
+          { AttributeName: 'slug', AttributeType: 'S' },
+        ]),
+      })
+    })
+
+    it('uses KEYS_ONLY projection', () => {
+      template.hasResourceProperties('AWS::DynamoDB::Table', {
+        GlobalSecondaryIndexes: Match.arrayWith([
+          Match.objectLike({
+            IndexName: 'slug-index',
+            Projection: { ProjectionType: 'KEYS_ONLY' },
+          }),
+        ]),
+      })
+    })
+  })
+
   describe('S3 image bucket', () => {
     it('creates an S3 bucket named akli-recipe-images-{account-id}-eu-west-2', () => {
       template.hasResourceProperties('AWS::S3::Bucket', {
@@ -421,6 +460,27 @@ describe('RecipeStack', () => {
       })
     })
 
+    it('grants dynamodb:Query on the slug-index GSI ARN', () => {
+      template.hasResourceProperties('AWS::IAM::Policy', {
+        Roles: Match.arrayWith([
+          { Ref: Match.stringLikeRegexp('^ImageResizerServiceRole.*') },
+        ]),
+        PolicyDocument: Match.objectLike({
+          Statement: Match.arrayWith([
+            Match.objectLike({
+              Action: 'dynamodb:Query',
+              Effect: 'Allow',
+              Resource: Match.objectLike({
+                'Fn::Join': Match.arrayWith([
+                  Match.arrayWith([Match.stringLikeRegexp('/index/slug-index$')]),
+                ]),
+              }),
+            }),
+          ]),
+        }),
+      })
+    })
+
     it('does not grant dynamodb:PutItem, dynamodb:DeleteItem, or dynamodb:Scan on the image-resizer role', () => {
       const assertResizerLacks = (action: string) => {
         // CDK consolidates actions into either a string or string[] — assert both forms.
@@ -441,6 +501,36 @@ describe('RecipeStack', () => {
       for (const action of ['dynamodb:PutItem', 'dynamodb:DeleteItem', 'dynamodb:Scan']) {
         assertResizerLacks(action)
       }
+    })
+  })
+
+  describe('IAM — recipe-image-handler role', () => {
+    it('recipe-image-handler Lambda environment includes TABLE_NAME set to the recipes table name', () => {
+      template.hasResourceProperties('AWS::Lambda::Function', Match.objectLike({
+        FunctionName: 'akli-recipe-image-handler',
+        Environment: {
+          Variables: Match.objectLike({
+            TABLE_NAME: { Ref: Match.stringLikeRegexp('^RecipesTable.*') },
+          }),
+        },
+      }))
+    })
+
+    it('grants dynamodb:GetItem on the recipes table ARN (table-level, not GSI)', () => {
+      template.hasResourceProperties('AWS::IAM::Policy', {
+        Roles: Match.arrayWith([
+          { Ref: Match.stringLikeRegexp('^RecipeImageHandlerServiceRole.*') },
+        ]),
+        PolicyDocument: Match.objectLike({
+          Statement: Match.arrayWith([
+            Match.objectLike({
+              Action: 'dynamodb:GetItem',
+              Effect: 'Allow',
+              Resource: { 'Fn::GetAtt': [Match.stringLikeRegexp('^RecipesTable.*'), 'Arn'] },
+            }),
+          ]),
+        }),
+      })
     })
   })
 


### PR DESCRIPTION
Epic merge for **Editable Recipe Slugs (Backend)** — closes #154. PRD: `docs/prds/editable-recipe-slugs.md`.

## ⚠️ Deploy coordination (read before merging)
Merging to `main` **deploys all stacks to production** (CI). This milestone changes recipe image S3 keys to slug-based and makes slugs user-editable; per the PRD it **deploys in lockstep with the sibling personal-website frontend epic**. Merge only when the frontend half is ready to ship together, to avoid a uuid-vs-slug key mismatch.

## What's in this epic (11 PRs)
**Setup / implementation**
- #155 — slug-index GSI + IAM grants for the resizer and image-handler
- #156 — slug validation + accept slug on `POST /recipes/drafts`
- #157 — `PATCH /recipes/{id}` accepts slug with a TOCTOU-safe ConditionExpression + server-side slug lock
- #160 — recipe-image-handler builds the upload key from the looked-up slug, drops `key` from the response
- #162 — image-resizer parses slug from the upload key, resolves id via the slug-index GSI
- #163 — `composeImageProcessedAt` + DELETE handler derive image keys from slug
- #164 — swept test fixtures: dropped `coverImage.key` / `step.image.key`

**Follow-up refactors / fix** (surfaced by `/simplify` during the epic)
- #167 — extracted shared `lambda/recipe-store.ts` (read path + DDB client)
- #168 — `PATCH` reads the CCFE snapshot from `err.Item` instead of a re-read (explicit unmarshall — lib-dynamodb doesn't unmarshall thrown-exception Items)
- #169 — `recipe-store` now owns **all** recipe DynamoDB access (write helpers + GSI-name constants)
- #170 — **durability fix**: resizer deletes the source last, so a transient writeback error retries instead of stranding the recipe as unprocessed

## Net change
38 commits · ~+2011/−588 across 11 files. Net new module `lambda/recipe-store.ts`; `recipe-stack.ts` gains the slug-index GSI + grants.

## Version
`1.8.0 → 1.9.0` (minor — milestone delivers new behaviour).

## Verification
- All lambda + stack tests green on the epic head; CI `cdk diff` on this PR previews the infra delta (slug-index GSI + IAM).
- **Post-deploy verification (#153)** is the remaining open issue — manual AWS-CLI + admin-UI checks that can only run after this deploys **and** the frontend ships. It stays open until then.

🤖 Generated with [Claude Code](https://claude.com/claude-code)