### PR TITLE
ci: verify Dependabot PRs without AWS credentials

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -30,7 +30,18 @@ jobs:
       - name: Install dependencies
         run: pnpm install --no-frozen-lockfile
 
+      - name: Build
+        run: pnpm build
+
+      - name: Test
+        run: pnpm test
+
+      # The steps below need AWS credentials, which GitHub does not expose to
+      # Dependabot-triggered runs (they only see the separate "Dependabot
+      # secrets" scope). Skip them for Dependabot so its PRs are still verified
+      # by Build + Test above instead of failing at credential loading.
       - name: Configure AWS credentials
+        if: github.actor != 'dependabot[bot]'
         uses: aws-actions/configure-aws-credentials@v6
         with:
           aws-access-key-id: ${{ secrets.CDK_AWS_ACCESS_KEY_ID }}
@@ -38,6 +49,7 @@ jobs:
           aws-region: eu-west-2
 
       - name: CDK Diff
+        if: github.actor != 'dependabot[bot]'
         run: pnpm cdk diff --all
 
   # 2. Deploy Job: Runs on Push to main to apply changes and clear cache


### PR DESCRIPTION
## Problem
Every Dependabot PR failed the `diff` check with "Could not load credentials from any providers". GitHub does not expose regular Actions secrets to Dependabot-triggered runs, so `configure-aws-credentials` got empty inputs and the job errored before `cdk diff`.

## Fix
- Add **Build** + **Test** steps to the `diff` job — they need no secrets, so they run for all PRs including Dependabot.
- Gate the **Configure AWS credentials** and **CDK Diff** steps to skip `dependabot[bot]`.

Dependabot PRs are now verified by build + test; human PRs still get the full infra diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)