### PR TITLE
Create dedicated S3 buckets for Pokedex and Sandbox

### DIFF
--- a/lib/akli-infrastructure-stack.ts
+++ b/lib/akli-infrastructure-stack.ts
@@ -51,6 +51,22 @@ export class AkliInfrastructureStack extends Stack {
       description: `OAC for ${DOMAIN_NAME}`,
     })
 
+    const pokedexBucket = new s3.Bucket(this, 'PokedexBucket', {
+      blockPublicAccess: s3.BlockPublicAccess.BLOCK_ALL,
+      removalPolicy: RemovalPolicy.DESTROY,
+      autoDeleteObjects: true,
+      encryption: s3.BucketEncryption.S3_MANAGED,
+      enforceSSL: true,
+    })
+
+    const sandboxBucket = new s3.Bucket(this, 'SandboxBucket', {
+      blockPublicAccess: s3.BlockPublicAccess.BLOCK_ALL,
+      removalPolicy: RemovalPolicy.DESTROY,
+      autoDeleteObjects: true,
+      encryption: s3.BucketEncryption.S3_MANAGED,
+      enforceSSL: true,
+    })
+
     const securityHeadersPolicy = createSecurityHeadersPolicy(this)
 
     const imageCachePolicy = createImageCachePolicy(this)
@@ -203,6 +219,40 @@ export class AkliInfrastructureStack extends Stack {
       resources: [
         siteBucket.bucketArn,
         `${siteBucket.bucketArn}/*`,
+      ],
+      conditions: {
+        StringEquals: {
+          'AWS:SourceArn': `arn:aws:cloudfront::${this.account}:distribution/${distribution.distributionId}`,
+        },
+      },
+    }))
+
+    // Grant CloudFront access to Pokedex S3 bucket
+    pokedexBucket.addToResourcePolicy(new iam.PolicyStatement({
+      sid: 'AllowCloudFrontServicePrincipal',
+      effect: iam.Effect.ALLOW,
+      principals: [new iam.ServicePrincipal('cloudfront.amazonaws.com')],
+      actions: ['s3:GetObject', 's3:ListBucket'],
+      resources: [
+        pokedexBucket.bucketArn,
+        `${pokedexBucket.bucketArn}/*`,
+      ],
+      conditions: {
+        StringEquals: {
+          'AWS:SourceArn': `arn:aws:cloudfront::${this.account}:distribution/${distribution.distributionId}`,
+        },
+      },
+    }))
+
+    // Grant CloudFront access to Sandbox S3 bucket
+    sandboxBucket.addToResourcePolicy(new iam.PolicyStatement({
+      sid: 'AllowCloudFrontServicePrincipal',
+      effect: iam.Effect.ALLOW,
+      principals: [new iam.ServicePrincipal('cloudfront.amazonaws.com')],
+      actions: ['s3:GetObject', 's3:ListBucket'],
+      resources: [
+        sandboxBucket.bucketArn,
+        `${sandboxBucket.bucketArn}/*`,
       ],
       conditions: {
         StringEquals: {

--- a/test/akli-infrastructure.test.ts
+++ b/test/akli-infrastructure.test.ts
@@ -4,15 +4,43 @@ import * as certificatemanager from 'aws-cdk-lib/aws-certificatemanager'
 import * as route53 from 'aws-cdk-lib/aws-route53'
 import { AkliInfrastructureStack } from '../lib/akli-infrastructure-stack'
 
-type CfnResource = { Type: string; Properties: Record<string, unknown> }
+type CfnResource = { Type: string; Properties: Record<string, unknown>; DeletionPolicy?: string; UpdateReplacePolicy?: string }
 type CfnOrigin = { Id: string; S3OriginConfig?: unknown; OriginAccessControlId?: unknown; DomainName?: Record<string, unknown>; CustomOriginConfig?: unknown }
 type CfnCacheBehavior = { PathPattern: string; TargetOriginId: string }
+type CfnPolicyStatement = { Sid?: string; Effect: string; Principal?: unknown; Action?: unknown; Resource?: unknown; Condition?: unknown }
 
 function cfnDistribution(template: Template): CfnResource {
   const resources = template.toJSON().Resources as Record<string, CfnResource>
   const dist = Object.values(resources).find((r) => r.Type === 'AWS::CloudFront::Distribution')
   if (!dist) throw new Error('CloudFront::Distribution not found in template')
   return dist
+}
+
+function distributionLogicalId(template: Template): string {
+  const resources = template.toJSON().Resources as Record<string, CfnResource>
+  const entry = Object.entries(resources).find(([, r]) => r.Type === 'AWS::CloudFront::Distribution')
+  if (!entry) throw new Error('CloudFront::Distribution not found in template')
+  return entry[0]
+}
+
+// Finds a resource of the given CFN type whose logical ID starts with idPrefix.
+// CDK appends an 8-character hash to the construct ID to form the logical ID
+// (e.g. construct ID 'PokedexBucket' -> logical ID 'PokedexBucketAB12CD34'), so an
+// exact-match lookup would never succeed.
+function findResourceByLogicalIdPrefix(template: Template, type: string, idPrefix: string): CfnResource {
+  const resources = template.toJSON().Resources as Record<string, CfnResource>
+  const entry = Object.entries(resources).find(
+    ([logicalId, r]) => r.Type === type && logicalId.startsWith(idPrefix),
+  )
+  if (!entry) throw new Error(`${type} with logical ID prefix "${idPrefix}" not found in template`)
+  return entry[1]
+}
+
+// True when a Condition value's AWS:SourceArn (or similar) references the given
+// distribution's logical ID via an Fn::Join/Ref, regardless of exact Fn::Join shape.
+function sourceArnReferencesDistribution(condition: unknown, distLogicalId: string): boolean {
+  const json = JSON.stringify(condition)
+  return json.includes(`"Ref":"${distLogicalId}"`) && json.includes(':distribution/')
 }
 
 function distributionConfig(dist: CfnResource): Record<string, unknown> {
@@ -88,6 +116,91 @@ describe('AkliInfrastructureStack', () => {
           RestrictPublicBuckets: true,
         },
       })
+    })
+  })
+
+  describe('Per-app dedicated S3 buckets (Pokedex, Sandbox)', () => {
+    const dedicatedBuckets = [
+      { app: 'Pokedex', idPrefix: 'PokedexBucket' },
+      { app: 'Sandbox', idPrefix: 'SandboxBucket' },
+    ]
+
+    it('creates exactly three S3 buckets in total (Site, Pokedex, Sandbox)', () => {
+      template.resourceCountIs('AWS::S3::Bucket', 3)
+    })
+
+    describe.each(dedicatedBuckets)('$app bucket', ({ idPrefix }) => {
+      it('is hardened the same way as SiteBucket: BLOCK_ALL, SSE-S3, DESTROY + autoDeleteObjects', () => {
+        const bucket = findResourceByLogicalIdPrefix(template, 'AWS::S3::Bucket', idPrefix)
+
+        expect(bucket.Properties.PublicAccessBlockConfiguration).toEqual({
+          BlockPublicAcls: true,
+          BlockPublicPolicy: true,
+          IgnorePublicAcls: true,
+          RestrictPublicBuckets: true,
+        })
+
+        expect(bucket.Properties.BucketEncryption).toEqual({
+          ServerSideEncryptionConfiguration: [
+            { ServerSideEncryptionByDefault: { SSEAlgorithm: 'AES256' } },
+          ],
+        })
+
+        // RemovalPolicy.DESTROY
+        expect(bucket.DeletionPolicy).toBe('Delete')
+        expect(bucket.UpdateReplacePolicy).toBe('Delete')
+
+        // autoDeleteObjects: true is implemented via this marker tag plus a
+        // Custom::S3AutoDeleteObjects resource wired up by the CDK framework.
+        expect(bucket.Properties.Tags).toEqual(
+          expect.arrayContaining([{ Key: 'aws-cdk:auto-delete-objects', Value: 'true' }]),
+        )
+      })
+
+      it('enforces SSL by denying non-HTTPS requests in its bucket policy', () => {
+        const policy = findResourceByLogicalIdPrefix(template, 'AWS::S3::BucketPolicy', `${idPrefix}Policy`)
+        const statements = (policy.Properties.PolicyDocument as { Statement: CfnPolicyStatement[] }).Statement
+
+        expect(statements).toEqual(
+          expect.arrayContaining([
+            expect.objectContaining({
+              Effect: 'Deny',
+              Principal: { AWS: '*' },
+              Action: 's3:*',
+              Condition: { Bool: { 'aws:SecureTransport': 'false' } },
+            }),
+          ]),
+        )
+      })
+
+      it('grants the shared OAC distribution s3:GetObject/s3:ListBucket, scoped via AWS:SourceArn', () => {
+        const policy = findResourceByLogicalIdPrefix(template, 'AWS::S3::BucketPolicy', `${idPrefix}Policy`)
+        const statements = (policy.Properties.PolicyDocument as { Statement: CfnPolicyStatement[] }).Statement
+        const bucketLogicalId = (policy.Properties.Bucket as { Ref: string }).Ref
+
+        const grant = statements.find((s) => s.Sid === 'AllowCloudFrontServicePrincipal')
+        expect(grant).toBeDefined()
+
+        expect(grant?.Effect).toBe('Allow')
+        expect(grant?.Principal).toEqual({ Service: 'cloudfront.amazonaws.com' })
+        expect(grant?.Action).toEqual(['s3:GetObject', 's3:ListBucket'])
+
+        // Resource must cover both the bucket ARN and the bucket ARN wildcard (objects),
+        // referencing this specific bucket (not some other bucket's policy).
+        const resourceJson = JSON.stringify(grant?.Resource)
+        expect(resourceJson).toContain(bucketLogicalId)
+        expect(resourceJson).toContain('/*')
+
+        // Scoped, via AWS:SourceArn, to the single shared CloudFront distribution.
+        const distId = distributionLogicalId(template)
+        expect(sourceArnReferencesDistribution(grant?.Condition, distId)).toBe(true)
+      })
+    })
+
+    it('gives Pokedex and Sandbox distinct buckets (not the same bucket twice)', () => {
+      const pokedexBucket = findResourceByLogicalIdPrefix(template, 'AWS::S3::Bucket', 'PokedexBucket')
+      const sandboxBucket = findResourceByLogicalIdPrefix(template, 'AWS::S3::Bucket', 'SandboxBucket')
+      expect(pokedexBucket).not.toBe(sandboxBucket)
     })
   })
 

--- a/test/akli-infrastructure.test.ts
+++ b/test/akli-infrastructure.test.ts
@@ -16,24 +16,25 @@ function cfnDistribution(template: Template): CfnResource {
   return dist
 }
 
-function distributionLogicalId(template: Template): string {
-  const resources = template.toJSON().Resources as Record<string, CfnResource>
-  const entry = Object.entries(resources).find(([, r]) => r.Type === 'AWS::CloudFront::Distribution')
-  if (!entry) throw new Error('CloudFront::Distribution not found in template')
-  return entry[0]
-}
-
-// Finds a resource of the given CFN type whose logical ID starts with idPrefix.
-// CDK appends an 8-character hash to the construct ID to form the logical ID
-// (e.g. construct ID 'PokedexBucket' -> logical ID 'PokedexBucketAB12CD34'), so an
-// exact-match lookup would never succeed.
-function findResourceByLogicalIdPrefix(template: Template, type: string, idPrefix: string): CfnResource {
+// Finds the [logicalId, resource] entry for the given CFN type whose logical ID starts
+// with idPrefix. CDK appends an 8-character hash to the construct ID to form the logical
+// ID (e.g. construct ID 'PokedexBucket' -> logical ID 'PokedexBucketAB12CD34'), so an
+// exact-match lookup would never succeed. Pass '' as idPrefix to match on type alone.
+function findResourceEntryByLogicalIdPrefix(template: Template, type: string, idPrefix: string): [string, CfnResource] {
   const resources = template.toJSON().Resources as Record<string, CfnResource>
   const entry = Object.entries(resources).find(
     ([logicalId, r]) => r.Type === type && logicalId.startsWith(idPrefix),
   )
   if (!entry) throw new Error(`${type} with logical ID prefix "${idPrefix}" not found in template`)
-  return entry[1]
+  return entry
+}
+
+function findResourceByLogicalIdPrefix(template: Template, type: string, idPrefix: string): CfnResource {
+  return findResourceEntryByLogicalIdPrefix(template, type, idPrefix)[1]
+}
+
+function distributionLogicalId(template: Template): string {
+  return findResourceEntryByLogicalIdPrefix(template, 'AWS::CloudFront::Distribution', '')[0]
 }
 
 // True when a Condition value's AWS:SourceArn (or similar) references the given


### PR DESCRIPTION
Closes #192

## What changed
Adds `PokedexBucket` and `SandboxBucket` to `AkliInfrastructureStack` with the same hardening as the existing `SiteBucket` (`BlockPublicAccess.BLOCK_ALL`, `RemovalPolicy.DESTROY` + `autoDeleteObjects: true`, `BucketEncryption.S3_MANAGED`, `enforceSSL: true`). Each new bucket gets its own CloudFront OAC resource-policy statement (`AllowCloudFrontServicePrincipal`), scoped via `AWS:SourceArn` to the shared distribution, reusing the existing `SiteOAC` construct — no second OAC created.

CloudFront `additionalBehaviors` are **untouched** — `apps/pokedex*`/`apps/sand-box*` still route to the existing `SiteBucket`-backed origin. Repointing to the new buckets is issue #193 (Deploy B), which lands separately once both apps have redeployed content onto these buckets.

## Why
Part of the **Per-App S3 Buckets & OIDC Deploy Credentials** milestone (PRD: `docs/prds/per-app-buckets-and-oidc-deploy.md`). This is "Deploy A" alongside the OIDC provider/IAM roles work (#191) — both create net-new resources with no visible change to visitors, ahead of the CloudFront cutover.

Sequencing note: #191's IAM role policies need these bucket ARNs to reference, so this PR was completed first even though the two issues were opened without a formal blocker relationship.

## How to verify
- `pnpm test` — 441/441 passing, including 8 new tests in `test/akli-infrastructure.test.ts` covering both buckets' hardening, SSL enforcement, and CloudFront resource-policy scoping independently.
- `pnpm lint` / `pnpm exec tsc --noEmit` — clean.
- `cdk diff --all` — could not run live (no AWS credentials in this environment); manually confirmed the diff is purely additive (two new bucket declarations + two new resource-policy statements) and the `cloudfront.Distribution` construction code is byte-identical to `main`.

## Decisions made
- Bucket construct IDs are exactly `PokedexBucket`/`SandboxBucket` (no hyphen for Sandbox, matching the PRD's anticipation of a future `sandbox.akli.dev` subdomain — the `sand-box` GitHub repo itself keeps its hyphenated name).
- Tagging: no per-resource tags added: this stack applies `Owner`/`CostCenter`/`Project`/`Environment`/`ManagedBy` globally via `Tags.of(app)` in `bin/akli-infrastructure.ts`, so the new buckets inherit those automatically, consistent with `SiteBucket`.

## Out of scope (filed as follow-up issues)
- **#198** — Extract a shared `createHardenedAppBucket`/`grantCloudFrontRead` factory to remove the now-3x duplicated bucket-hardening props and CloudFront resource-policy statement (Site/Pokedex/Sandbox). Deferred because it would also touch the pre-existing `SiteBucket` code, outside this issue's stated scope of "add two new buckets."