### PR TITLE
Create GitHub OIDC provider and per-app IAM roles

### DIFF
--- a/lib/akli-infrastructure-stack.ts
+++ b/lib/akli-infrastructure-stack.ts
@@ -274,6 +274,78 @@ export class AkliInfrastructureStack extends Stack {
       target: route53.RecordTarget.fromAlias(new targets.CloudFrontTarget(distribution)),
     })
 
+    // GitHub OIDC provider — one per account, reused by every per-app deploy Role below.
+    // Uses the native AWS::IAM::OIDCProvider resource (iam.OidcProviderNative) rather than the
+    // legacy iam.OpenIdConnectProvider, which CDK's own docs mark backward-compatibility-only and
+    // which is backed by a Lambda custom resource holding a broad Resource: "*" IAM grant.
+    //
+    // Two intermediate CA thumbprints, both required — GitHub's OIDC token endpoint can present
+    // either one depending on which issued the current leaf cert, and AWS validates against
+    // whichever is configured. Confirmed current per GitHub's own OIDC changelog post:
+    // https://github.blog/changelog/2023-06-27-github-actions-update-on-oidc-integration-with-aws/
+    // ("either can be returned by our servers, requiring customers to trust both").
+    const githubOidcProvider = new iam.OidcProviderNative(this, 'GitHubOidcProvider', {
+      url: 'https://token.actions.githubusercontent.com',
+      clientIds: ['sts.amazonaws.com'],
+      thumbprints: [
+        '6938fd4d98bab03faadb97b34396831e3780aea1',
+        '1c58a3a8518e8759bf075b76b750d4f2df264fcd',
+      ],
+    })
+
+    const githubDeployPrincipal = (repo: string): iam.OpenIdConnectPrincipal =>
+      new iam.OpenIdConnectPrincipal(githubOidcProvider, {
+        StringEquals: {
+          'token.actions.githubusercontent.com:aud': 'sts.amazonaws.com',
+          'token.actions.githubusercontent.com:sub': `repo:vandelay87/${repo}:ref:refs/heads/main`,
+        },
+      })
+
+    const s3AppAccessStatement = (bucket: s3.IBucket): iam.PolicyStatement =>
+      new iam.PolicyStatement({
+        effect: iam.Effect.ALLOW,
+        actions: ['s3:GetObject', 's3:PutObject', 's3:DeleteObject', 's3:ListBucket'],
+        resources: [bucket.bucketArn, `${bucket.bucketArn}/*`],
+      })
+
+    const cloudfrontInvalidationStatement = (): iam.PolicyStatement =>
+      new iam.PolicyStatement({
+        effect: iam.Effect.ALLOW,
+        actions: ['cloudfront:CreateInvalidation'],
+        resources: [`arn:aws:cloudfront::${this.account}:distribution/${distribution.distributionId}`],
+      })
+
+    // Per-app GitHub Actions deploy Roles — OIDC-federated, replacing the legacy shared
+    // github-actions-deploy IAM User below (removed once all apps have migrated, see #194).
+    const personalWebsiteDeployRole = new iam.Role(this, 'PersonalWebsiteDeployRole', {
+      roleName: 'personal-website-deploy',
+      assumedBy: githubDeployPrincipal('personal-website'),
+      description: 'GitHub Actions OIDC deploy role for personal-website',
+    })
+    personalWebsiteDeployRole.addToPolicy(s3AppAccessStatement(siteBucket))
+    personalWebsiteDeployRole.addToPolicy(cloudfrontInvalidationStatement())
+    personalWebsiteDeployRole.addToPolicy(new iam.PolicyStatement({
+      effect: iam.Effect.ALLOW,
+      actions: ['lambda:UpdateFunctionCode', 'lambda:GetFunction'],
+      resources: [ssrFunction.functionArn],
+    }))
+
+    const pokedexDeployRole = new iam.Role(this, 'PokedexDeployRole', {
+      roleName: 'pokedex-deploy',
+      assumedBy: githubDeployPrincipal('pokedex'),
+      description: 'GitHub Actions OIDC deploy role for pokedex',
+    })
+    pokedexDeployRole.addToPolicy(s3AppAccessStatement(pokedexBucket))
+    pokedexDeployRole.addToPolicy(cloudfrontInvalidationStatement())
+
+    const sandboxDeployRole = new iam.Role(this, 'SandboxDeployRole', {
+      roleName: 'sandbox-deploy',
+      assumedBy: githubDeployPrincipal('sand-box'),
+      description: 'GitHub Actions OIDC deploy role for sand-box',
+    })
+    sandboxDeployRole.addToPolicy(s3AppAccessStatement(sandboxBucket))
+    sandboxDeployRole.addToPolicy(cloudfrontInvalidationStatement())
+
     // IAM user for GitHub Actions deployment
     const deployUser = new iam.User(this, 'GitHubActionsUser', {
       userName: 'github-actions-deploy',
@@ -392,6 +464,21 @@ export class AkliInfrastructureStack extends Stack {
     new CfnOutput(this, 'CDKGitHubActionsSecretsManagerName', {
       value: 'cdk-github-actions-credentials',
       description: 'Secrets Manager secret name for CDK GitHub Actions credentials',
+    })
+
+    new CfnOutput(this, 'PersonalWebsiteDeployRoleArn', {
+      value: personalWebsiteDeployRole.roleArn,
+      description: 'IAM Role ARN for personal-website GitHub Actions OIDC deploys',
+    })
+
+    new CfnOutput(this, 'PokedexDeployRoleArn', {
+      value: pokedexDeployRole.roleArn,
+      description: 'IAM Role ARN for pokedex GitHub Actions OIDC deploys',
+    })
+
+    new CfnOutput(this, 'SandboxDeployRoleArn', {
+      value: sandboxDeployRole.roleArn,
+      description: 'IAM Role ARN for sand-box GitHub Actions OIDC deploys',
     })
   }
 }

--- a/test/akli-infrastructure.test.ts
+++ b/test/akli-infrastructure.test.ts
@@ -65,14 +65,6 @@ function allResources(template: Template): Record<string, CfnResource> {
   return template.toJSON().Resources as Record<string, CfnResource>
 }
 
-/** Finds the single resource of `type` in the template. Throws if none or more than one exists. */
-function findSingleResource(template: Template, type: string): [string, CfnResource] {
-  const entries = Object.entries(allResources(template)).filter(([, r]) => r.Type === type)
-  if (entries.length === 0) throw new Error(`No resource of type "${type}" found in template`)
-  if (entries.length > 1) throw new Error(`Expected exactly one "${type}" resource, found ${entries.length}: ${entries.map(([id]) => id).join(', ')}`)
-  return entries[0]
-}
-
 /** Trust policy statements (AssumeRolePolicyDocument) for an AWS::IAM::Role resource. */
 function trustPolicyStatements(role: CfnResource): Record<string, unknown>[] {
   const doc = role.Properties.AssumeRolePolicyDocument as { Statement: Record<string, unknown>[] } | undefined
@@ -112,6 +104,13 @@ function policyStatementsForRole(template: Template, roleLogicalId: string): Rec
 /** True if `logicalId` appears anywhere inside the (Ref / Fn::GetAtt / Fn::Join / Fn::Sub) structure of `value`. */
 function referencesLogicalId(value: unknown, logicalId: string): boolean {
   return JSON.stringify(value).includes(logicalId)
+}
+
+function findLambdaStatement(statements: Record<string, unknown>[]): Record<string, unknown> | undefined {
+  return statements.find((s) => {
+    const actions = Array.isArray(s.Action) ? s.Action : [s.Action]
+    return actions.includes('lambda:UpdateFunctionCode')
+  })
 }
 
 function createTestStack(): Template {
@@ -478,15 +477,18 @@ describe('AkliInfrastructureStack', () => {
       })
     })
 
-    it('configures at least one 40-character hex thumbprint', () => {
-      const [, provider] = findSingleResource(template, 'AWS::IAM::OIDCProvider')
+    it('configures both required GitHub intermediate CA thumbprints', () => {
+      // GitHub's OIDC token endpoint can present either of two intermediate CA certs (per
+      // GitHub's 2023-06-27 OIDC changelog post), so both must be trusted — asserting the
+      // exact set (not just "at least one 40-char hex value") catches a future edit that
+      // accidentally drops one.
+      const [, provider] = findResourceEntryByLogicalIdPrefix(template, 'AWS::IAM::OIDCProvider', '')
       const thumbprints = provider.Properties.ThumbprintList as string[]
 
-      expect(Array.isArray(thumbprints)).toBe(true)
-      expect(thumbprints.length).toBeGreaterThan(0)
-      for (const thumbprint of thumbprints) {
-        expect(thumbprint).toMatch(/^[0-9a-fA-F]{40}$/)
-      }
+      expect(thumbprints).toEqual([
+        '6938fd4d98bab03faadb97b34396831e3780aea1',
+        '1c58a3a8518e8759bf075b76b750d4f2df264fcd',
+      ])
     })
 
     it('does not register the legacy Lambda-backed OpenIdConnectProvider custom resource', () => {
@@ -500,7 +502,7 @@ describe('AkliInfrastructureStack', () => {
     it('registers exactly one OIDC provider in the stack', () => {
       // Throws if there is more than one AWS::IAM::OIDCProvider resource — CloudFormation
       // hard-fails on duplicate provider URLs, so the stack must only ever declare one.
-      expect(() => findSingleResource(template, 'AWS::IAM::OIDCProvider')).not.toThrow()
+      expect(() => findResourceEntryByLogicalIdPrefix(template, 'AWS::IAM::OIDCProvider', '')).not.toThrow()
     })
   })
 
@@ -569,12 +571,7 @@ describe('AkliInfrastructureStack', () => {
       if (hasLambdaAccess) {
         it('grants lambda:UpdateFunctionCode/GetFunction scoped to the SSR function', () => {
           const [roleLogicalId] = findResourceEntryByLogicalIdPrefix(template, 'AWS::IAM::Role', roleLogicalIdPrefix)
-          const statements = policyStatementsForRole(template, roleLogicalId)
-
-          const lambdaStatement = statements.find((s) => {
-            const actions = Array.isArray(s.Action) ? s.Action : [s.Action]
-            return actions.includes('lambda:UpdateFunctionCode')
-          })
+          const lambdaStatement = findLambdaStatement(policyStatementsForRole(template, roleLogicalId))
 
           expect(lambdaStatement).toBeDefined()
           expect(lambdaStatement?.Effect).toBe('Allow')
@@ -585,12 +582,7 @@ describe('AkliInfrastructureStack', () => {
       } else {
         it('does not grant lambda:UpdateFunctionCode/GetFunction access', () => {
           const [roleLogicalId] = findResourceEntryByLogicalIdPrefix(template, 'AWS::IAM::Role', roleLogicalIdPrefix)
-          const statements = policyStatementsForRole(template, roleLogicalId)
-
-          const lambdaStatement = statements.find((s) => {
-            const actions = Array.isArray(s.Action) ? s.Action : [s.Action]
-            return actions.includes('lambda:UpdateFunctionCode')
-          })
+          const lambdaStatement = findLambdaStatement(policyStatementsForRole(template, roleLogicalId))
 
           expect(lambdaStatement).toBeUndefined()
         })
@@ -598,7 +590,7 @@ describe('AkliInfrastructureStack', () => {
 
       it('grants cloudfront:CreateInvalidation scoped to the one shared distribution', () => {
         const [roleLogicalId] = findResourceEntryByLogicalIdPrefix(template, 'AWS::IAM::Role', roleLogicalIdPrefix)
-        const [distributionLogicalId] = findSingleResource(template, 'AWS::CloudFront::Distribution')
+        const [distributionLogicalId] = findResourceEntryByLogicalIdPrefix(template, 'AWS::CloudFront::Distribution', '')
         const statements = policyStatementsForRole(template, roleLogicalId)
 
         const invalidationStatement = statements.find((s) => {

--- a/test/akli-infrastructure.test.ts
+++ b/test/akli-infrastructure.test.ts
@@ -22,11 +22,16 @@ function cfnDistribution(template: Template): CfnResource {
 // exact-match lookup would never succeed. Pass '' as idPrefix to match on type alone.
 function findResourceEntryByLogicalIdPrefix(template: Template, type: string, idPrefix: string): [string, CfnResource] {
   const resources = template.toJSON().Resources as Record<string, CfnResource>
-  const entry = Object.entries(resources).find(
+  const entries = Object.entries(resources).filter(
     ([logicalId, r]) => r.Type === type && logicalId.startsWith(idPrefix),
   )
-  if (!entry) throw new Error(`${type} with logical ID prefix "${idPrefix}" not found in template`)
-  return entry
+  if (entries.length === 0) throw new Error(`${type} with logical ID prefix "${idPrefix}" not found in template`)
+  if (entries.length > 1) {
+    throw new Error(
+      `Multiple ${type} resources match logical ID prefix "${idPrefix}": ${entries.map(([id]) => id).join(', ')}`,
+    )
+  }
+  return entries[0]
 }
 
 function findResourceByLogicalIdPrefix(template: Template, type: string, idPrefix: string): CfnResource {
@@ -52,6 +57,61 @@ function isFunctionUrlOrigin(origin: CfnOrigin): boolean {
   const fnSelect = origin.DomainName?.['Fn::Select'] as [number, { 'Fn::Split': [string, { 'Fn::GetAtt': [string, string] }] }] | undefined
   const fnGetAtt = fnSelect?.[1]?.['Fn::Split']?.[1]?.['Fn::GetAtt']
   return Boolean(fnGetAtt && /SsrFunctionFunctionUrl/.test(fnGetAtt[0]))
+}
+
+// --- helpers for per-logical-ID template walks (OIDC provider / per-app IAM roles) ---
+
+function allResources(template: Template): Record<string, CfnResource> {
+  return template.toJSON().Resources as Record<string, CfnResource>
+}
+
+/** Finds the single resource of `type` in the template. Throws if none or more than one exists. */
+function findSingleResource(template: Template, type: string): [string, CfnResource] {
+  const entries = Object.entries(allResources(template)).filter(([, r]) => r.Type === type)
+  if (entries.length === 0) throw new Error(`No resource of type "${type}" found in template`)
+  if (entries.length > 1) throw new Error(`Expected exactly one "${type}" resource, found ${entries.length}: ${entries.map(([id]) => id).join(', ')}`)
+  return entries[0]
+}
+
+/** Trust policy statements (AssumeRolePolicyDocument) for an AWS::IAM::Role resource. */
+function trustPolicyStatements(role: CfnResource): Record<string, unknown>[] {
+  const doc = role.Properties.AssumeRolePolicyDocument as { Statement: Record<string, unknown>[] } | undefined
+  if (!doc) throw new Error('Role has no AssumeRolePolicyDocument')
+  return doc.Statement
+}
+
+/**
+ * All inline policy statements that apply to a Role, regardless of whether they were attached
+ * as a separate AWS::IAM::Policy resource (role.attachInlinePolicy) or embedded directly on the
+ * Role resource itself (Properties.Policies).
+ */
+function policyStatementsForRole(template: Template, roleLogicalId: string): Record<string, unknown>[] {
+  const resources = allResources(template)
+  const statements: Record<string, unknown>[] = []
+
+  for (const resource of Object.values(resources)) {
+    if (resource.Type !== 'AWS::IAM::Policy') continue
+    const roles = resource.Properties.Roles as Array<{ Ref?: string }> | undefined
+    if (roles?.some((ref) => ref.Ref === roleLogicalId)) {
+      const doc = resource.Properties.PolicyDocument as { Statement: Record<string, unknown>[] }
+      statements.push(...doc.Statement)
+    }
+  }
+
+  const role = resources[roleLogicalId]
+  const inlinePolicies = role?.Properties.Policies as Array<{ PolicyDocument: { Statement: Record<string, unknown>[] } }> | undefined
+  if (inlinePolicies) {
+    for (const p of inlinePolicies) {
+      statements.push(...p.PolicyDocument.Statement)
+    }
+  }
+
+  return statements
+}
+
+/** True if `logicalId` appears anywhere inside the (Ref / Fn::GetAtt / Fn::Join / Fn::Sub) structure of `value`. */
+function referencesLogicalId(value: unknown, logicalId: string): boolean {
+  return JSON.stringify(value).includes(logicalId)
 }
 
 function createTestStack(): Template {
@@ -407,6 +467,167 @@ describe('AkliInfrastructureStack', () => {
           },
         },
       })
+    })
+  })
+
+  describe('GitHub OIDC provider', () => {
+    it('registers a native AWS::IAM::OIDCProvider for token.actions.githubusercontent.com with the sts.amazonaws.com audience', () => {
+      template.hasResourceProperties('AWS::IAM::OIDCProvider', {
+        Url: 'https://token.actions.githubusercontent.com',
+        ClientIdList: ['sts.amazonaws.com'],
+      })
+    })
+
+    it('configures at least one 40-character hex thumbprint', () => {
+      const [, provider] = findSingleResource(template, 'AWS::IAM::OIDCProvider')
+      const thumbprints = provider.Properties.ThumbprintList as string[]
+
+      expect(Array.isArray(thumbprints)).toBe(true)
+      expect(thumbprints.length).toBeGreaterThan(0)
+      for (const thumbprint of thumbprints) {
+        expect(thumbprint).toMatch(/^[0-9a-fA-F]{40}$/)
+      }
+    })
+
+    it('does not register the legacy Lambda-backed OpenIdConnectProvider custom resource', () => {
+      const resources = allResources(template)
+      const legacyProviderType = Object.values(resources).find(
+        (r) => r.Type === 'Custom::AWSCDKOpenIdConnectProvider',
+      )
+      expect(legacyProviderType).toBeUndefined()
+    })
+
+    it('registers exactly one OIDC provider in the stack', () => {
+      // Throws if there is more than one AWS::IAM::OIDCProvider resource — CloudFormation
+      // hard-fails on duplicate provider URLs, so the stack must only ever declare one.
+      expect(() => findSingleResource(template, 'AWS::IAM::OIDCProvider')).not.toThrow()
+    })
+  })
+
+  describe('Per-app GitHub Actions deploy roles', () => {
+    const DEPLOY_APPS = [
+      {
+        roleLogicalIdPrefix: 'PersonalWebsiteDeployRole',
+        repo: 'personal-website',
+        bucketLogicalIdPrefix: 'SiteBucket',
+        hasLambdaAccess: true,
+      },
+      {
+        roleLogicalIdPrefix: 'PokedexDeployRole',
+        repo: 'pokedex',
+        bucketLogicalIdPrefix: 'PokedexBucket',
+        hasLambdaAccess: false,
+      },
+      {
+        roleLogicalIdPrefix: 'SandboxDeployRole',
+        repo: 'sand-box',
+        bucketLogicalIdPrefix: 'SandboxBucket',
+        hasLambdaAccess: false,
+      },
+    ] as const
+
+    describe.each(DEPLOY_APPS)('$roleLogicalIdPrefix', ({ roleLogicalIdPrefix, repo, bucketLogicalIdPrefix, hasLambdaAccess }) => {
+      it(`trusts only repo:vandelay87/${repo}:ref:refs/heads/main via the GitHub OIDC provider`, () => {
+        const [, role] = findResourceEntryByLogicalIdPrefix(template, 'AWS::IAM::Role', roleLogicalIdPrefix)
+        const statements = trustPolicyStatements(role)
+
+        const webIdentityStatement = statements.find((s) => {
+          const actions = Array.isArray(s.Action) ? s.Action : [s.Action]
+          return actions.includes('sts:AssumeRoleWithWebIdentity')
+        })
+
+        expect(webIdentityStatement).toBeDefined()
+        expect(webIdentityStatement?.Effect).toBe('Allow')
+
+        const condition = webIdentityStatement?.Condition as Record<string, Record<string, unknown>> | undefined
+        const scopedConditions = { ...(condition?.StringEquals ?? {}), ...(condition?.StringLike ?? {}) }
+
+        expect(scopedConditions['token.actions.githubusercontent.com:aud']).toBe('sts.amazonaws.com')
+        expect(scopedConditions['token.actions.githubusercontent.com:sub']).toBe(`repo:vandelay87/${repo}:ref:refs/heads/main`)
+      })
+
+      it(`grants S3 access scoped only to its own bucket (${bucketLogicalIdPrefix})`, () => {
+        const [roleLogicalId] = findResourceEntryByLogicalIdPrefix(template, 'AWS::IAM::Role', roleLogicalIdPrefix)
+        const [bucketLogicalId] = findResourceEntryByLogicalIdPrefix(template, 'AWS::S3::Bucket', bucketLogicalIdPrefix)
+        const statements = policyStatementsForRole(template, roleLogicalId)
+
+        const s3Statement = statements.find((s) => {
+          const actions = (Array.isArray(s.Action) ? s.Action : [s.Action]) as string[]
+          return actions.some((a) => a.startsWith('s3:'))
+        })
+
+        expect(s3Statement).toBeDefined()
+        expect(s3Statement?.Effect).toBe('Allow')
+        expect(referencesLogicalId(s3Statement?.Resource, bucketLogicalId)).toBe(true)
+
+        const actions = (Array.isArray(s3Statement?.Action) ? s3Statement?.Action : [s3Statement?.Action]) as string[]
+        expect(actions).toEqual(
+          expect.arrayContaining(['s3:GetObject', 's3:PutObject', 's3:DeleteObject', 's3:ListBucket']),
+        )
+      })
+
+      if (hasLambdaAccess) {
+        it('grants lambda:UpdateFunctionCode/GetFunction scoped to the SSR function', () => {
+          const [roleLogicalId] = findResourceEntryByLogicalIdPrefix(template, 'AWS::IAM::Role', roleLogicalIdPrefix)
+          const statements = policyStatementsForRole(template, roleLogicalId)
+
+          const lambdaStatement = statements.find((s) => {
+            const actions = Array.isArray(s.Action) ? s.Action : [s.Action]
+            return actions.includes('lambda:UpdateFunctionCode')
+          })
+
+          expect(lambdaStatement).toBeDefined()
+          expect(lambdaStatement?.Effect).toBe('Allow')
+          const actions = lambdaStatement?.Action as string[]
+          expect(actions).toEqual(expect.arrayContaining(['lambda:UpdateFunctionCode', 'lambda:GetFunction']))
+          expect(referencesLogicalId(lambdaStatement?.Resource, 'SsrFunction')).toBe(true)
+        })
+      } else {
+        it('does not grant lambda:UpdateFunctionCode/GetFunction access', () => {
+          const [roleLogicalId] = findResourceEntryByLogicalIdPrefix(template, 'AWS::IAM::Role', roleLogicalIdPrefix)
+          const statements = policyStatementsForRole(template, roleLogicalId)
+
+          const lambdaStatement = statements.find((s) => {
+            const actions = Array.isArray(s.Action) ? s.Action : [s.Action]
+            return actions.includes('lambda:UpdateFunctionCode')
+          })
+
+          expect(lambdaStatement).toBeUndefined()
+        })
+      }
+
+      it('grants cloudfront:CreateInvalidation scoped to the one shared distribution', () => {
+        const [roleLogicalId] = findResourceEntryByLogicalIdPrefix(template, 'AWS::IAM::Role', roleLogicalIdPrefix)
+        const [distributionLogicalId] = findSingleResource(template, 'AWS::CloudFront::Distribution')
+        const statements = policyStatementsForRole(template, roleLogicalId)
+
+        const invalidationStatement = statements.find((s) => {
+          const actions = Array.isArray(s.Action) ? s.Action : [s.Action]
+          return actions.includes('cloudfront:CreateInvalidation')
+        })
+
+        expect(invalidationStatement).toBeDefined()
+        expect(invalidationStatement?.Effect).toBe('Allow')
+        expect(referencesLogicalId(invalidationStatement?.Resource, distributionLogicalId)).toBe(true)
+      })
+    })
+
+    it("no Role's policy references another app's bucket ARN (cross-app S3 isolation)", () => {
+      const bucketsByApp = DEPLOY_APPS.map((app) => ({
+        ...app,
+        bucketLogicalId: findResourceEntryByLogicalIdPrefix(template, 'AWS::S3::Bucket', app.bucketLogicalIdPrefix)[0],
+      }))
+
+      for (const app of bucketsByApp) {
+        const [roleLogicalId] = findResourceEntryByLogicalIdPrefix(template, 'AWS::IAM::Role', app.roleLogicalIdPrefix)
+        const statements = policyStatementsForRole(template, roleLogicalId)
+
+        const otherApps = bucketsByApp.filter((other) => other.bucketLogicalId !== app.bucketLogicalId)
+        for (const other of otherApps) {
+          const referencesOtherAppsBucket = statements.some((s) => referencesLogicalId(s, other.bucketLogicalId))
+          expect(referencesOtherAppsBucket).toBe(false)
+        }
+      }
     })
   })
 })


### PR DESCRIPTION
Closes #191

## What changed
Registers GitHub's OIDC provider (`token.actions.githubusercontent.com`) using `iam.OidcProviderNative` (not the legacy Lambda-backed construct), and adds three OIDC-federated deploy roles — `PersonalWebsiteDeployRole`, `PokedexDeployRole`, `SandboxDeployRole` — each trusting only its own repo (`vandelay87/<repo>`) on `ref:refs/heads/main`.

- `PersonalWebsiteDeployRole`: CRUD/List on `SiteBucket`, `cloudfront:CreateInvalidation` on the shared distribution, and `lambda:UpdateFunctionCode`/`GetFunction` on the SSR function.
- `PokedexDeployRole`/`SandboxDeployRole`: CRUD/List on their own bucket (`PokedexBucket`/`SandboxBucket`, from #192) and CloudFront invalidation only — no Lambda access.

Explicit `roleName`s (`personal-website-deploy`, `pokedex-deploy`, `sandbox-deploy`) and `CfnOutput`s for each role's ARN were added so the companion repos (`personal-website`, `pokedex`, `sand-box`) can reference them directly in their own `deploy.yml`, matching the PRD's stated workflow shape.

The legacy `github-actions-deploy` IAM User/Secrets Manager credential and CloudFront `additionalBehaviors`/origins are **untouched** — removal is #194, behavior repointing is #193, both separate future issues.

## Why
Part of the **Per-App S3 Buckets & OIDC Deploy Credentials** milestone (PRD: `docs/prds/per-app-buckets-and-oidc-deploy.md`). This is "Deploy A" alongside the new buckets (#192, merged first — this branch was rebased on top since the role policies need real bucket ARNs to reference).

## How to verify
- `pnpm test` — 458/458 passing, including 16 tests covering the OIDC provider (existence, thumbprints, no legacy resource) and all three roles independently (trust policy scoping, S3 isolation, conditional Lambda access, CloudFront invalidation, cross-app isolation).
- `pnpm lint` / `pnpm exec tsc --noEmit` — clean.
- `cdk diff --all` — could not run live (no AWS credentials in this environment); confirmed via source diff that the change is purely additive and the CloudFront distribution / legacy IAM user block are byte-identical to the epic branch.

## Decisions made
- **Thumbprint verified live, not copied blindly.** The PRD's documented thumbprint was actually 39 hex characters (one short of valid) due to a transcription error. I looked this up against GitHub's own 2023-06-27 OIDC changelog post and confirmed two intermediate CA thumbprints are both required (GitHub's token endpoint can present either): `6938fd4d98bab03faadb97b34396831e3780aea1` and `1c58a3a8518e8759bf075b76b750d4f2df264fcd`. Both are configured; a test asserts the exact pair rather than just "at least one 40-char value," so a future edit that drops one won't pass silently.
- **Manual pre-deploy check**: confirm no `token.actions.githubusercontent.com` OIDC provider already exists in the account before deploying — CloudFormation hard-fails on duplicate provider URLs rather than importing. Not unit-testable; flagging here per the issue's AC.
- **Skipped a couple of /simplify findings, noted rather than fixed**: (1) the new per-role policy-statement helpers duplicate shapes already inlined in the legacy `deployPolicy` a few lines down — not worth extracting a shared helper since that legacy block is deleted outright in #194; (2) a defensive dead-code branch in the test helper `policyStatementsForRole` (handling inline `Properties.Policies`, unreachable given current callers) was left in place as harmless forward-compatible coverage rather than trimmed.

## Out of scope
No follow-up issues filed for this PR — the /simplify findings above were either applied inline (helper dedup, thumbprint assertion) or are noted-and-skipped as above, not deferred work.