### PR TITLE
Deploy A: GitHub OIDC provider, per-app IAM roles, Pokedex/Sandbox buckets

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Seven CDK stacks deployed across regions:
 | Stack | Region | Resources |
 |-------|--------|-----------|
 | CertificateStack | us-east-1 | Route 53 hosted zone, ACM certificates (required by CloudFront) |
-| AkliInfrastructureStack | eu-west-2 | S3 bucket, CloudFront distribution, Route 53 records, IAM users |
+| AkliInfrastructureStack | eu-west-2 | S3 buckets (site, Pokedex, Sandbox), CloudFront distribution, Route 53 records, IAM users, GitHub OIDC provider, per-app deploy roles |
 | PokedexStack | eu-west-2 | DynamoDB table, HTTP API Gateway, Lambda handlers |
 | AuthStack | eu-west-2 | Cognito user pool, HTTP API Gateway, Lambda handlers, JWT authoriser, CloudWatch alarms |
 | RecipeStack | eu-west-2 | DynamoDB table, S3 image bucket, HTTP API Gateway, Lambda handlers (CRUD, image upload, image resizer), JWT authoriser |
@@ -75,9 +75,14 @@ GitHub Actions workflow on `.github/workflows/deploy.yml`:
 - **PRs to main:** runs `cdk diff` to preview changes
 - **Push to main:** bootstraps, deploys all stacks, then invalidates the CloudFront cache
 
-Two IAM users with credentials stored in Secrets Manager:
+Two IAM users with credentials stored in Secrets Manager (legacy, being phased out per-app in favour of OIDC — see below):
 - `github-actions-deploy` — S3 sync and CloudFront invalidation
 - `cdk-github-actions` — CDK bootstrap and deploy
+
+A GitHub OIDC provider (`token.actions.githubusercontent.com`) and per-app IAM roles let `personal-website`, `pokedex`, and `sand-box` deploy without long-lived static credentials — each role trusts only its own repo on `main` and can only touch its own S3 bucket:
+- `personal-website-deploy`, `pokedex-deploy`, `sandbox-deploy`
+
+CloudFront still routes `apps/pokedex*`/`apps/sand-box*` to the shared site bucket until each app's own deploy migrates to OIDC and its dedicated bucket (in progress).
 
 ## Tags
 

--- a/lib/akli-infrastructure-stack.ts
+++ b/lib/akli-infrastructure-stack.ts
@@ -274,6 +274,78 @@ export class AkliInfrastructureStack extends Stack {
       target: route53.RecordTarget.fromAlias(new targets.CloudFrontTarget(distribution)),
     })
 
+    // GitHub OIDC provider — one per account, reused by every per-app deploy Role below.
+    // Uses the native AWS::IAM::OIDCProvider resource (iam.OidcProviderNative) rather than the
+    // legacy iam.OpenIdConnectProvider, which CDK's own docs mark backward-compatibility-only and
+    // which is backed by a Lambda custom resource holding a broad Resource: "*" IAM grant.
+    //
+    // Two intermediate CA thumbprints, both required — GitHub's OIDC token endpoint can present
+    // either one depending on which issued the current leaf cert, and AWS validates against
+    // whichever is configured. Confirmed current per GitHub's own OIDC changelog post:
+    // https://github.blog/changelog/2023-06-27-github-actions-update-on-oidc-integration-with-aws/
+    // ("either can be returned by our servers, requiring customers to trust both").
+    const githubOidcProvider = new iam.OidcProviderNative(this, 'GitHubOidcProvider', {
+      url: 'https://token.actions.githubusercontent.com',
+      clientIds: ['sts.amazonaws.com'],
+      thumbprints: [
+        '6938fd4d98bab03faadb97b34396831e3780aea1',
+        '1c58a3a8518e8759bf075b76b750d4f2df264fcd',
+      ],
+    })
+
+    const githubDeployPrincipal = (repo: string): iam.OpenIdConnectPrincipal =>
+      new iam.OpenIdConnectPrincipal(githubOidcProvider, {
+        StringEquals: {
+          'token.actions.githubusercontent.com:aud': 'sts.amazonaws.com',
+          'token.actions.githubusercontent.com:sub': `repo:vandelay87/${repo}:ref:refs/heads/main`,
+        },
+      })
+
+    const s3AppAccessStatement = (bucket: s3.IBucket): iam.PolicyStatement =>
+      new iam.PolicyStatement({
+        effect: iam.Effect.ALLOW,
+        actions: ['s3:GetObject', 's3:PutObject', 's3:DeleteObject', 's3:ListBucket'],
+        resources: [bucket.bucketArn, `${bucket.bucketArn}/*`],
+      })
+
+    const cloudfrontInvalidationStatement = (): iam.PolicyStatement =>
+      new iam.PolicyStatement({
+        effect: iam.Effect.ALLOW,
+        actions: ['cloudfront:CreateInvalidation'],
+        resources: [`arn:aws:cloudfront::${this.account}:distribution/${distribution.distributionId}`],
+      })
+
+    // Per-app GitHub Actions deploy Roles — OIDC-federated, replacing the legacy shared
+    // github-actions-deploy IAM User below (removed once all apps have migrated, see #194).
+    const personalWebsiteDeployRole = new iam.Role(this, 'PersonalWebsiteDeployRole', {
+      roleName: 'personal-website-deploy',
+      assumedBy: githubDeployPrincipal('personal-website'),
+      description: 'GitHub Actions OIDC deploy role for personal-website',
+    })
+    personalWebsiteDeployRole.addToPolicy(s3AppAccessStatement(siteBucket))
+    personalWebsiteDeployRole.addToPolicy(cloudfrontInvalidationStatement())
+    personalWebsiteDeployRole.addToPolicy(new iam.PolicyStatement({
+      effect: iam.Effect.ALLOW,
+      actions: ['lambda:UpdateFunctionCode', 'lambda:GetFunction'],
+      resources: [ssrFunction.functionArn],
+    }))
+
+    const pokedexDeployRole = new iam.Role(this, 'PokedexDeployRole', {
+      roleName: 'pokedex-deploy',
+      assumedBy: githubDeployPrincipal('pokedex'),
+      description: 'GitHub Actions OIDC deploy role for pokedex',
+    })
+    pokedexDeployRole.addToPolicy(s3AppAccessStatement(pokedexBucket))
+    pokedexDeployRole.addToPolicy(cloudfrontInvalidationStatement())
+
+    const sandboxDeployRole = new iam.Role(this, 'SandboxDeployRole', {
+      roleName: 'sandbox-deploy',
+      assumedBy: githubDeployPrincipal('sand-box'),
+      description: 'GitHub Actions OIDC deploy role for sand-box',
+    })
+    sandboxDeployRole.addToPolicy(s3AppAccessStatement(sandboxBucket))
+    sandboxDeployRole.addToPolicy(cloudfrontInvalidationStatement())
+
     // IAM user for GitHub Actions deployment
     const deployUser = new iam.User(this, 'GitHubActionsUser', {
       userName: 'github-actions-deploy',
@@ -392,6 +464,21 @@ export class AkliInfrastructureStack extends Stack {
     new CfnOutput(this, 'CDKGitHubActionsSecretsManagerName', {
       value: 'cdk-github-actions-credentials',
       description: 'Secrets Manager secret name for CDK GitHub Actions credentials',
+    })
+
+    new CfnOutput(this, 'PersonalWebsiteDeployRoleArn', {
+      value: personalWebsiteDeployRole.roleArn,
+      description: 'IAM Role ARN for personal-website GitHub Actions OIDC deploys',
+    })
+
+    new CfnOutput(this, 'PokedexDeployRoleArn', {
+      value: pokedexDeployRole.roleArn,
+      description: 'IAM Role ARN for pokedex GitHub Actions OIDC deploys',
+    })
+
+    new CfnOutput(this, 'SandboxDeployRoleArn', {
+      value: sandboxDeployRole.roleArn,
+      description: 'IAM Role ARN for sand-box GitHub Actions OIDC deploys',
     })
   }
 }

--- a/lib/akli-infrastructure-stack.ts
+++ b/lib/akli-infrastructure-stack.ts
@@ -51,6 +51,22 @@ export class AkliInfrastructureStack extends Stack {
       description: `OAC for ${DOMAIN_NAME}`,
     })
 
+    const pokedexBucket = new s3.Bucket(this, 'PokedexBucket', {
+      blockPublicAccess: s3.BlockPublicAccess.BLOCK_ALL,
+      removalPolicy: RemovalPolicy.DESTROY,
+      autoDeleteObjects: true,
+      encryption: s3.BucketEncryption.S3_MANAGED,
+      enforceSSL: true,
+    })
+
+    const sandboxBucket = new s3.Bucket(this, 'SandboxBucket', {
+      blockPublicAccess: s3.BlockPublicAccess.BLOCK_ALL,
+      removalPolicy: RemovalPolicy.DESTROY,
+      autoDeleteObjects: true,
+      encryption: s3.BucketEncryption.S3_MANAGED,
+      enforceSSL: true,
+    })
+
     const securityHeadersPolicy = createSecurityHeadersPolicy(this)
 
     const imageCachePolicy = createImageCachePolicy(this)
@@ -203,6 +219,40 @@ export class AkliInfrastructureStack extends Stack {
       resources: [
         siteBucket.bucketArn,
         `${siteBucket.bucketArn}/*`,
+      ],
+      conditions: {
+        StringEquals: {
+          'AWS:SourceArn': `arn:aws:cloudfront::${this.account}:distribution/${distribution.distributionId}`,
+        },
+      },
+    }))
+
+    // Grant CloudFront access to Pokedex S3 bucket
+    pokedexBucket.addToResourcePolicy(new iam.PolicyStatement({
+      sid: 'AllowCloudFrontServicePrincipal',
+      effect: iam.Effect.ALLOW,
+      principals: [new iam.ServicePrincipal('cloudfront.amazonaws.com')],
+      actions: ['s3:GetObject', 's3:ListBucket'],
+      resources: [
+        pokedexBucket.bucketArn,
+        `${pokedexBucket.bucketArn}/*`,
+      ],
+      conditions: {
+        StringEquals: {
+          'AWS:SourceArn': `arn:aws:cloudfront::${this.account}:distribution/${distribution.distributionId}`,
+        },
+      },
+    }))
+
+    // Grant CloudFront access to Sandbox S3 bucket
+    sandboxBucket.addToResourcePolicy(new iam.PolicyStatement({
+      sid: 'AllowCloudFrontServicePrincipal',
+      effect: iam.Effect.ALLOW,
+      principals: [new iam.ServicePrincipal('cloudfront.amazonaws.com')],
+      actions: ['s3:GetObject', 's3:ListBucket'],
+      resources: [
+        sandboxBucket.bucketArn,
+        `${sandboxBucket.bucketArn}/*`,
       ],
       conditions: {
         StringEquals: {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "akli-infrastructure",
   "description": "Infrastructure as Code for akli.dev",
-  "version": "1.9.0",
+  "version": "1.10.0",
   "packageManager": "pnpm@11.9.0",
   "engines": {
     "node": ">=24"

--- a/test/akli-infrastructure.test.ts
+++ b/test/akli-infrastructure.test.ts
@@ -4,15 +4,43 @@ import * as certificatemanager from 'aws-cdk-lib/aws-certificatemanager'
 import * as route53 from 'aws-cdk-lib/aws-route53'
 import { AkliInfrastructureStack } from '../lib/akli-infrastructure-stack'
 
-type CfnResource = { Type: string; Properties: Record<string, unknown> }
+type CfnResource = { Type: string; Properties: Record<string, unknown>; DeletionPolicy?: string; UpdateReplacePolicy?: string }
 type CfnOrigin = { Id: string; S3OriginConfig?: unknown; OriginAccessControlId?: unknown; DomainName?: Record<string, unknown>; CustomOriginConfig?: unknown }
 type CfnCacheBehavior = { PathPattern: string; TargetOriginId: string }
+type CfnPolicyStatement = { Sid?: string; Effect: string; Principal?: unknown; Action?: unknown; Resource?: unknown; Condition?: unknown }
 
 function cfnDistribution(template: Template): CfnResource {
   const resources = template.toJSON().Resources as Record<string, CfnResource>
   const dist = Object.values(resources).find((r) => r.Type === 'AWS::CloudFront::Distribution')
   if (!dist) throw new Error('CloudFront::Distribution not found in template')
   return dist
+}
+
+function distributionLogicalId(template: Template): string {
+  const resources = template.toJSON().Resources as Record<string, CfnResource>
+  const entry = Object.entries(resources).find(([, r]) => r.Type === 'AWS::CloudFront::Distribution')
+  if (!entry) throw new Error('CloudFront::Distribution not found in template')
+  return entry[0]
+}
+
+// Finds a resource of the given CFN type whose logical ID starts with idPrefix.
+// CDK appends an 8-character hash to the construct ID to form the logical ID
+// (e.g. construct ID 'PokedexBucket' -> logical ID 'PokedexBucketAB12CD34'), so an
+// exact-match lookup would never succeed.
+function findResourceByLogicalIdPrefix(template: Template, type: string, idPrefix: string): CfnResource {
+  const resources = template.toJSON().Resources as Record<string, CfnResource>
+  const entry = Object.entries(resources).find(
+    ([logicalId, r]) => r.Type === type && logicalId.startsWith(idPrefix),
+  )
+  if (!entry) throw new Error(`${type} with logical ID prefix "${idPrefix}" not found in template`)
+  return entry[1]
+}
+
+// True when a Condition value's AWS:SourceArn (or similar) references the given
+// distribution's logical ID via an Fn::Join/Ref, regardless of exact Fn::Join shape.
+function sourceArnReferencesDistribution(condition: unknown, distLogicalId: string): boolean {
+  const json = JSON.stringify(condition)
+  return json.includes(`"Ref":"${distLogicalId}"`) && json.includes(':distribution/')
 }
 
 function distributionConfig(dist: CfnResource): Record<string, unknown> {
@@ -88,6 +116,91 @@ describe('AkliInfrastructureStack', () => {
           RestrictPublicBuckets: true,
         },
       })
+    })
+  })
+
+  describe('Per-app dedicated S3 buckets (Pokedex, Sandbox)', () => {
+    const dedicatedBuckets = [
+      { app: 'Pokedex', idPrefix: 'PokedexBucket' },
+      { app: 'Sandbox', idPrefix: 'SandboxBucket' },
+    ]
+
+    it('creates exactly three S3 buckets in total (Site, Pokedex, Sandbox)', () => {
+      template.resourceCountIs('AWS::S3::Bucket', 3)
+    })
+
+    describe.each(dedicatedBuckets)('$app bucket', ({ idPrefix }) => {
+      it('is hardened the same way as SiteBucket: BLOCK_ALL, SSE-S3, DESTROY + autoDeleteObjects', () => {
+        const bucket = findResourceByLogicalIdPrefix(template, 'AWS::S3::Bucket', idPrefix)
+
+        expect(bucket.Properties.PublicAccessBlockConfiguration).toEqual({
+          BlockPublicAcls: true,
+          BlockPublicPolicy: true,
+          IgnorePublicAcls: true,
+          RestrictPublicBuckets: true,
+        })
+
+        expect(bucket.Properties.BucketEncryption).toEqual({
+          ServerSideEncryptionConfiguration: [
+            { ServerSideEncryptionByDefault: { SSEAlgorithm: 'AES256' } },
+          ],
+        })
+
+        // RemovalPolicy.DESTROY
+        expect(bucket.DeletionPolicy).toBe('Delete')
+        expect(bucket.UpdateReplacePolicy).toBe('Delete')
+
+        // autoDeleteObjects: true is implemented via this marker tag plus a
+        // Custom::S3AutoDeleteObjects resource wired up by the CDK framework.
+        expect(bucket.Properties.Tags).toEqual(
+          expect.arrayContaining([{ Key: 'aws-cdk:auto-delete-objects', Value: 'true' }]),
+        )
+      })
+
+      it('enforces SSL by denying non-HTTPS requests in its bucket policy', () => {
+        const policy = findResourceByLogicalIdPrefix(template, 'AWS::S3::BucketPolicy', `${idPrefix}Policy`)
+        const statements = (policy.Properties.PolicyDocument as { Statement: CfnPolicyStatement[] }).Statement
+
+        expect(statements).toEqual(
+          expect.arrayContaining([
+            expect.objectContaining({
+              Effect: 'Deny',
+              Principal: { AWS: '*' },
+              Action: 's3:*',
+              Condition: { Bool: { 'aws:SecureTransport': 'false' } },
+            }),
+          ]),
+        )
+      })
+
+      it('grants the shared OAC distribution s3:GetObject/s3:ListBucket, scoped via AWS:SourceArn', () => {
+        const policy = findResourceByLogicalIdPrefix(template, 'AWS::S3::BucketPolicy', `${idPrefix}Policy`)
+        const statements = (policy.Properties.PolicyDocument as { Statement: CfnPolicyStatement[] }).Statement
+        const bucketLogicalId = (policy.Properties.Bucket as { Ref: string }).Ref
+
+        const grant = statements.find((s) => s.Sid === 'AllowCloudFrontServicePrincipal')
+        expect(grant).toBeDefined()
+
+        expect(grant?.Effect).toBe('Allow')
+        expect(grant?.Principal).toEqual({ Service: 'cloudfront.amazonaws.com' })
+        expect(grant?.Action).toEqual(['s3:GetObject', 's3:ListBucket'])
+
+        // Resource must cover both the bucket ARN and the bucket ARN wildcard (objects),
+        // referencing this specific bucket (not some other bucket's policy).
+        const resourceJson = JSON.stringify(grant?.Resource)
+        expect(resourceJson).toContain(bucketLogicalId)
+        expect(resourceJson).toContain('/*')
+
+        // Scoped, via AWS:SourceArn, to the single shared CloudFront distribution.
+        const distId = distributionLogicalId(template)
+        expect(sourceArnReferencesDistribution(grant?.Condition, distId)).toBe(true)
+      })
+    })
+
+    it('gives Pokedex and Sandbox distinct buckets (not the same bucket twice)', () => {
+      const pokedexBucket = findResourceByLogicalIdPrefix(template, 'AWS::S3::Bucket', 'PokedexBucket')
+      const sandboxBucket = findResourceByLogicalIdPrefix(template, 'AWS::S3::Bucket', 'SandboxBucket')
+      expect(pokedexBucket).not.toBe(sandboxBucket)
     })
   })
 

--- a/test/akli-infrastructure.test.ts
+++ b/test/akli-infrastructure.test.ts
@@ -16,24 +16,25 @@ function cfnDistribution(template: Template): CfnResource {
   return dist
 }
 
-function distributionLogicalId(template: Template): string {
-  const resources = template.toJSON().Resources as Record<string, CfnResource>
-  const entry = Object.entries(resources).find(([, r]) => r.Type === 'AWS::CloudFront::Distribution')
-  if (!entry) throw new Error('CloudFront::Distribution not found in template')
-  return entry[0]
-}
-
-// Finds a resource of the given CFN type whose logical ID starts with idPrefix.
-// CDK appends an 8-character hash to the construct ID to form the logical ID
-// (e.g. construct ID 'PokedexBucket' -> logical ID 'PokedexBucketAB12CD34'), so an
-// exact-match lookup would never succeed.
-function findResourceByLogicalIdPrefix(template: Template, type: string, idPrefix: string): CfnResource {
+// Finds the [logicalId, resource] entry for the given CFN type whose logical ID starts
+// with idPrefix. CDK appends an 8-character hash to the construct ID to form the logical
+// ID (e.g. construct ID 'PokedexBucket' -> logical ID 'PokedexBucketAB12CD34'), so an
+// exact-match lookup would never succeed. Pass '' as idPrefix to match on type alone.
+function findResourceEntryByLogicalIdPrefix(template: Template, type: string, idPrefix: string): [string, CfnResource] {
   const resources = template.toJSON().Resources as Record<string, CfnResource>
   const entry = Object.entries(resources).find(
     ([logicalId, r]) => r.Type === type && logicalId.startsWith(idPrefix),
   )
   if (!entry) throw new Error(`${type} with logical ID prefix "${idPrefix}" not found in template`)
-  return entry[1]
+  return entry
+}
+
+function findResourceByLogicalIdPrefix(template: Template, type: string, idPrefix: string): CfnResource {
+  return findResourceEntryByLogicalIdPrefix(template, type, idPrefix)[1]
+}
+
+function distributionLogicalId(template: Template): string {
+  return findResourceEntryByLogicalIdPrefix(template, 'AWS::CloudFront::Distribution', '')[0]
 }
 
 // True when a Condition value's AWS:SourceArn (or similar) references the given

--- a/test/akli-infrastructure.test.ts
+++ b/test/akli-infrastructure.test.ts
@@ -65,14 +65,6 @@ function allResources(template: Template): Record<string, CfnResource> {
   return template.toJSON().Resources as Record<string, CfnResource>
 }
 
-/** Finds the single resource of `type` in the template. Throws if none or more than one exists. */
-function findSingleResource(template: Template, type: string): [string, CfnResource] {
-  const entries = Object.entries(allResources(template)).filter(([, r]) => r.Type === type)
-  if (entries.length === 0) throw new Error(`No resource of type "${type}" found in template`)
-  if (entries.length > 1) throw new Error(`Expected exactly one "${type}" resource, found ${entries.length}: ${entries.map(([id]) => id).join(', ')}`)
-  return entries[0]
-}
-
 /** Trust policy statements (AssumeRolePolicyDocument) for an AWS::IAM::Role resource. */
 function trustPolicyStatements(role: CfnResource): Record<string, unknown>[] {
   const doc = role.Properties.AssumeRolePolicyDocument as { Statement: Record<string, unknown>[] } | undefined
@@ -112,6 +104,13 @@ function policyStatementsForRole(template: Template, roleLogicalId: string): Rec
 /** True if `logicalId` appears anywhere inside the (Ref / Fn::GetAtt / Fn::Join / Fn::Sub) structure of `value`. */
 function referencesLogicalId(value: unknown, logicalId: string): boolean {
   return JSON.stringify(value).includes(logicalId)
+}
+
+function findLambdaStatement(statements: Record<string, unknown>[]): Record<string, unknown> | undefined {
+  return statements.find((s) => {
+    const actions = Array.isArray(s.Action) ? s.Action : [s.Action]
+    return actions.includes('lambda:UpdateFunctionCode')
+  })
 }
 
 function createTestStack(): Template {
@@ -478,15 +477,18 @@ describe('AkliInfrastructureStack', () => {
       })
     })
 
-    it('configures at least one 40-character hex thumbprint', () => {
-      const [, provider] = findSingleResource(template, 'AWS::IAM::OIDCProvider')
+    it('configures both required GitHub intermediate CA thumbprints', () => {
+      // GitHub's OIDC token endpoint can present either of two intermediate CA certs (per
+      // GitHub's 2023-06-27 OIDC changelog post), so both must be trusted — asserting the
+      // exact set (not just "at least one 40-char hex value") catches a future edit that
+      // accidentally drops one.
+      const [, provider] = findResourceEntryByLogicalIdPrefix(template, 'AWS::IAM::OIDCProvider', '')
       const thumbprints = provider.Properties.ThumbprintList as string[]
 
-      expect(Array.isArray(thumbprints)).toBe(true)
-      expect(thumbprints.length).toBeGreaterThan(0)
-      for (const thumbprint of thumbprints) {
-        expect(thumbprint).toMatch(/^[0-9a-fA-F]{40}$/)
-      }
+      expect(thumbprints).toEqual([
+        '6938fd4d98bab03faadb97b34396831e3780aea1',
+        '1c58a3a8518e8759bf075b76b750d4f2df264fcd',
+      ])
     })
 
     it('does not register the legacy Lambda-backed OpenIdConnectProvider custom resource', () => {
@@ -500,7 +502,7 @@ describe('AkliInfrastructureStack', () => {
     it('registers exactly one OIDC provider in the stack', () => {
       // Throws if there is more than one AWS::IAM::OIDCProvider resource — CloudFormation
       // hard-fails on duplicate provider URLs, so the stack must only ever declare one.
-      expect(() => findSingleResource(template, 'AWS::IAM::OIDCProvider')).not.toThrow()
+      expect(() => findResourceEntryByLogicalIdPrefix(template, 'AWS::IAM::OIDCProvider', '')).not.toThrow()
     })
   })
 
@@ -569,12 +571,7 @@ describe('AkliInfrastructureStack', () => {
       if (hasLambdaAccess) {
         it('grants lambda:UpdateFunctionCode/GetFunction scoped to the SSR function', () => {
           const [roleLogicalId] = findResourceEntryByLogicalIdPrefix(template, 'AWS::IAM::Role', roleLogicalIdPrefix)
-          const statements = policyStatementsForRole(template, roleLogicalId)
-
-          const lambdaStatement = statements.find((s) => {
-            const actions = Array.isArray(s.Action) ? s.Action : [s.Action]
-            return actions.includes('lambda:UpdateFunctionCode')
-          })
+          const lambdaStatement = findLambdaStatement(policyStatementsForRole(template, roleLogicalId))
 
           expect(lambdaStatement).toBeDefined()
           expect(lambdaStatement?.Effect).toBe('Allow')
@@ -585,12 +582,7 @@ describe('AkliInfrastructureStack', () => {
       } else {
         it('does not grant lambda:UpdateFunctionCode/GetFunction access', () => {
           const [roleLogicalId] = findResourceEntryByLogicalIdPrefix(template, 'AWS::IAM::Role', roleLogicalIdPrefix)
-          const statements = policyStatementsForRole(template, roleLogicalId)
-
-          const lambdaStatement = statements.find((s) => {
-            const actions = Array.isArray(s.Action) ? s.Action : [s.Action]
-            return actions.includes('lambda:UpdateFunctionCode')
-          })
+          const lambdaStatement = findLambdaStatement(policyStatementsForRole(template, roleLogicalId))
 
           expect(lambdaStatement).toBeUndefined()
         })
@@ -598,7 +590,7 @@ describe('AkliInfrastructureStack', () => {
 
       it('grants cloudfront:CreateInvalidation scoped to the one shared distribution', () => {
         const [roleLogicalId] = findResourceEntryByLogicalIdPrefix(template, 'AWS::IAM::Role', roleLogicalIdPrefix)
-        const [distributionLogicalId] = findSingleResource(template, 'AWS::CloudFront::Distribution')
+        const [distributionLogicalId] = findResourceEntryByLogicalIdPrefix(template, 'AWS::CloudFront::Distribution', '')
         const statements = policyStatementsForRole(template, roleLogicalId)
 
         const invalidationStatement = statements.find((s) => {

--- a/test/akli-infrastructure.test.ts
+++ b/test/akli-infrastructure.test.ts
@@ -22,11 +22,16 @@ function cfnDistribution(template: Template): CfnResource {
 // exact-match lookup would never succeed. Pass '' as idPrefix to match on type alone.
 function findResourceEntryByLogicalIdPrefix(template: Template, type: string, idPrefix: string): [string, CfnResource] {
   const resources = template.toJSON().Resources as Record<string, CfnResource>
-  const entry = Object.entries(resources).find(
+  const entries = Object.entries(resources).filter(
     ([logicalId, r]) => r.Type === type && logicalId.startsWith(idPrefix),
   )
-  if (!entry) throw new Error(`${type} with logical ID prefix "${idPrefix}" not found in template`)
-  return entry
+  if (entries.length === 0) throw new Error(`${type} with logical ID prefix "${idPrefix}" not found in template`)
+  if (entries.length > 1) {
+    throw new Error(
+      `Multiple ${type} resources match logical ID prefix "${idPrefix}": ${entries.map(([id]) => id).join(', ')}`,
+    )
+  }
+  return entries[0]
 }
 
 function findResourceByLogicalIdPrefix(template: Template, type: string, idPrefix: string): CfnResource {
@@ -52,6 +57,61 @@ function isFunctionUrlOrigin(origin: CfnOrigin): boolean {
   const fnSelect = origin.DomainName?.['Fn::Select'] as [number, { 'Fn::Split': [string, { 'Fn::GetAtt': [string, string] }] }] | undefined
   const fnGetAtt = fnSelect?.[1]?.['Fn::Split']?.[1]?.['Fn::GetAtt']
   return Boolean(fnGetAtt && /SsrFunctionFunctionUrl/.test(fnGetAtt[0]))
+}
+
+// --- helpers for per-logical-ID template walks (OIDC provider / per-app IAM roles) ---
+
+function allResources(template: Template): Record<string, CfnResource> {
+  return template.toJSON().Resources as Record<string, CfnResource>
+}
+
+/** Finds the single resource of `type` in the template. Throws if none or more than one exists. */
+function findSingleResource(template: Template, type: string): [string, CfnResource] {
+  const entries = Object.entries(allResources(template)).filter(([, r]) => r.Type === type)
+  if (entries.length === 0) throw new Error(`No resource of type "${type}" found in template`)
+  if (entries.length > 1) throw new Error(`Expected exactly one "${type}" resource, found ${entries.length}: ${entries.map(([id]) => id).join(', ')}`)
+  return entries[0]
+}
+
+/** Trust policy statements (AssumeRolePolicyDocument) for an AWS::IAM::Role resource. */
+function trustPolicyStatements(role: CfnResource): Record<string, unknown>[] {
+  const doc = role.Properties.AssumeRolePolicyDocument as { Statement: Record<string, unknown>[] } | undefined
+  if (!doc) throw new Error('Role has no AssumeRolePolicyDocument')
+  return doc.Statement
+}
+
+/**
+ * All inline policy statements that apply to a Role, regardless of whether they were attached
+ * as a separate AWS::IAM::Policy resource (role.attachInlinePolicy) or embedded directly on the
+ * Role resource itself (Properties.Policies).
+ */
+function policyStatementsForRole(template: Template, roleLogicalId: string): Record<string, unknown>[] {
+  const resources = allResources(template)
+  const statements: Record<string, unknown>[] = []
+
+  for (const resource of Object.values(resources)) {
+    if (resource.Type !== 'AWS::IAM::Policy') continue
+    const roles = resource.Properties.Roles as Array<{ Ref?: string }> | undefined
+    if (roles?.some((ref) => ref.Ref === roleLogicalId)) {
+      const doc = resource.Properties.PolicyDocument as { Statement: Record<string, unknown>[] }
+      statements.push(...doc.Statement)
+    }
+  }
+
+  const role = resources[roleLogicalId]
+  const inlinePolicies = role?.Properties.Policies as Array<{ PolicyDocument: { Statement: Record<string, unknown>[] } }> | undefined
+  if (inlinePolicies) {
+    for (const p of inlinePolicies) {
+      statements.push(...p.PolicyDocument.Statement)
+    }
+  }
+
+  return statements
+}
+
+/** True if `logicalId` appears anywhere inside the (Ref / Fn::GetAtt / Fn::Join / Fn::Sub) structure of `value`. */
+function referencesLogicalId(value: unknown, logicalId: string): boolean {
+  return JSON.stringify(value).includes(logicalId)
 }
 
 function createTestStack(): Template {
@@ -407,6 +467,167 @@ describe('AkliInfrastructureStack', () => {
           },
         },
       })
+    })
+  })
+
+  describe('GitHub OIDC provider', () => {
+    it('registers a native AWS::IAM::OIDCProvider for token.actions.githubusercontent.com with the sts.amazonaws.com audience', () => {
+      template.hasResourceProperties('AWS::IAM::OIDCProvider', {
+        Url: 'https://token.actions.githubusercontent.com',
+        ClientIdList: ['sts.amazonaws.com'],
+      })
+    })
+
+    it('configures at least one 40-character hex thumbprint', () => {
+      const [, provider] = findSingleResource(template, 'AWS::IAM::OIDCProvider')
+      const thumbprints = provider.Properties.ThumbprintList as string[]
+
+      expect(Array.isArray(thumbprints)).toBe(true)
+      expect(thumbprints.length).toBeGreaterThan(0)
+      for (const thumbprint of thumbprints) {
+        expect(thumbprint).toMatch(/^[0-9a-fA-F]{40}$/)
+      }
+    })
+
+    it('does not register the legacy Lambda-backed OpenIdConnectProvider custom resource', () => {
+      const resources = allResources(template)
+      const legacyProviderType = Object.values(resources).find(
+        (r) => r.Type === 'Custom::AWSCDKOpenIdConnectProvider',
+      )
+      expect(legacyProviderType).toBeUndefined()
+    })
+
+    it('registers exactly one OIDC provider in the stack', () => {
+      // Throws if there is more than one AWS::IAM::OIDCProvider resource — CloudFormation
+      // hard-fails on duplicate provider URLs, so the stack must only ever declare one.
+      expect(() => findSingleResource(template, 'AWS::IAM::OIDCProvider')).not.toThrow()
+    })
+  })
+
+  describe('Per-app GitHub Actions deploy roles', () => {
+    const DEPLOY_APPS = [
+      {
+        roleLogicalIdPrefix: 'PersonalWebsiteDeployRole',
+        repo: 'personal-website',
+        bucketLogicalIdPrefix: 'SiteBucket',
+        hasLambdaAccess: true,
+      },
+      {
+        roleLogicalIdPrefix: 'PokedexDeployRole',
+        repo: 'pokedex',
+        bucketLogicalIdPrefix: 'PokedexBucket',
+        hasLambdaAccess: false,
+      },
+      {
+        roleLogicalIdPrefix: 'SandboxDeployRole',
+        repo: 'sand-box',
+        bucketLogicalIdPrefix: 'SandboxBucket',
+        hasLambdaAccess: false,
+      },
+    ] as const
+
+    describe.each(DEPLOY_APPS)('$roleLogicalIdPrefix', ({ roleLogicalIdPrefix, repo, bucketLogicalIdPrefix, hasLambdaAccess }) => {
+      it(`trusts only repo:vandelay87/${repo}:ref:refs/heads/main via the GitHub OIDC provider`, () => {
+        const [, role] = findResourceEntryByLogicalIdPrefix(template, 'AWS::IAM::Role', roleLogicalIdPrefix)
+        const statements = trustPolicyStatements(role)
+
+        const webIdentityStatement = statements.find((s) => {
+          const actions = Array.isArray(s.Action) ? s.Action : [s.Action]
+          return actions.includes('sts:AssumeRoleWithWebIdentity')
+        })
+
+        expect(webIdentityStatement).toBeDefined()
+        expect(webIdentityStatement?.Effect).toBe('Allow')
+
+        const condition = webIdentityStatement?.Condition as Record<string, Record<string, unknown>> | undefined
+        const scopedConditions = { ...(condition?.StringEquals ?? {}), ...(condition?.StringLike ?? {}) }
+
+        expect(scopedConditions['token.actions.githubusercontent.com:aud']).toBe('sts.amazonaws.com')
+        expect(scopedConditions['token.actions.githubusercontent.com:sub']).toBe(`repo:vandelay87/${repo}:ref:refs/heads/main`)
+      })
+
+      it(`grants S3 access scoped only to its own bucket (${bucketLogicalIdPrefix})`, () => {
+        const [roleLogicalId] = findResourceEntryByLogicalIdPrefix(template, 'AWS::IAM::Role', roleLogicalIdPrefix)
+        const [bucketLogicalId] = findResourceEntryByLogicalIdPrefix(template, 'AWS::S3::Bucket', bucketLogicalIdPrefix)
+        const statements = policyStatementsForRole(template, roleLogicalId)
+
+        const s3Statement = statements.find((s) => {
+          const actions = (Array.isArray(s.Action) ? s.Action : [s.Action]) as string[]
+          return actions.some((a) => a.startsWith('s3:'))
+        })
+
+        expect(s3Statement).toBeDefined()
+        expect(s3Statement?.Effect).toBe('Allow')
+        expect(referencesLogicalId(s3Statement?.Resource, bucketLogicalId)).toBe(true)
+
+        const actions = (Array.isArray(s3Statement?.Action) ? s3Statement?.Action : [s3Statement?.Action]) as string[]
+        expect(actions).toEqual(
+          expect.arrayContaining(['s3:GetObject', 's3:PutObject', 's3:DeleteObject', 's3:ListBucket']),
+        )
+      })
+
+      if (hasLambdaAccess) {
+        it('grants lambda:UpdateFunctionCode/GetFunction scoped to the SSR function', () => {
+          const [roleLogicalId] = findResourceEntryByLogicalIdPrefix(template, 'AWS::IAM::Role', roleLogicalIdPrefix)
+          const statements = policyStatementsForRole(template, roleLogicalId)
+
+          const lambdaStatement = statements.find((s) => {
+            const actions = Array.isArray(s.Action) ? s.Action : [s.Action]
+            return actions.includes('lambda:UpdateFunctionCode')
+          })
+
+          expect(lambdaStatement).toBeDefined()
+          expect(lambdaStatement?.Effect).toBe('Allow')
+          const actions = lambdaStatement?.Action as string[]
+          expect(actions).toEqual(expect.arrayContaining(['lambda:UpdateFunctionCode', 'lambda:GetFunction']))
+          expect(referencesLogicalId(lambdaStatement?.Resource, 'SsrFunction')).toBe(true)
+        })
+      } else {
+        it('does not grant lambda:UpdateFunctionCode/GetFunction access', () => {
+          const [roleLogicalId] = findResourceEntryByLogicalIdPrefix(template, 'AWS::IAM::Role', roleLogicalIdPrefix)
+          const statements = policyStatementsForRole(template, roleLogicalId)
+
+          const lambdaStatement = statements.find((s) => {
+            const actions = Array.isArray(s.Action) ? s.Action : [s.Action]
+            return actions.includes('lambda:UpdateFunctionCode')
+          })
+
+          expect(lambdaStatement).toBeUndefined()
+        })
+      }
+
+      it('grants cloudfront:CreateInvalidation scoped to the one shared distribution', () => {
+        const [roleLogicalId] = findResourceEntryByLogicalIdPrefix(template, 'AWS::IAM::Role', roleLogicalIdPrefix)
+        const [distributionLogicalId] = findSingleResource(template, 'AWS::CloudFront::Distribution')
+        const statements = policyStatementsForRole(template, roleLogicalId)
+
+        const invalidationStatement = statements.find((s) => {
+          const actions = Array.isArray(s.Action) ? s.Action : [s.Action]
+          return actions.includes('cloudfront:CreateInvalidation')
+        })
+
+        expect(invalidationStatement).toBeDefined()
+        expect(invalidationStatement?.Effect).toBe('Allow')
+        expect(referencesLogicalId(invalidationStatement?.Resource, distributionLogicalId)).toBe(true)
+      })
+    })
+
+    it("no Role's policy references another app's bucket ARN (cross-app S3 isolation)", () => {
+      const bucketsByApp = DEPLOY_APPS.map((app) => ({
+        ...app,
+        bucketLogicalId: findResourceEntryByLogicalIdPrefix(template, 'AWS::S3::Bucket', app.bucketLogicalIdPrefix)[0],
+      }))
+
+      for (const app of bucketsByApp) {
+        const [roleLogicalId] = findResourceEntryByLogicalIdPrefix(template, 'AWS::IAM::Role', app.roleLogicalIdPrefix)
+        const statements = policyStatementsForRole(template, roleLogicalId)
+
+        const otherApps = bucketsByApp.filter((other) => other.bucketLogicalId !== app.bucketLogicalId)
+        for (const other of otherApps) {
+          const referencesOtherAppsBucket = statements.some((s) => referencesLogicalId(s, other.bucketLogicalId))
+          expect(referencesOtherAppsBucket).toBe(false)
+        }
+      }
     })
   })
 })


### PR DESCRIPTION
## What changed

This merges "Deploy A" of the **Per-App S3 Buckets & OIDC Deploy Credentials** milestone (PRD: `docs/prds/per-app-buckets-and-oidc-deploy.md`, epic tracker #197) into `main`. Merging this PR will trigger a real `cdk deploy --all` via CI/CD (per this repo's push-to-main workflow) — the following new resources will be created in the live AWS account:

- **#191** — GitHub OIDC provider (`token.actions.githubusercontent.com`) and three per-app deploy roles (`personal-website-deploy`, `pokedex-deploy`, `sandbox-deploy`), each scoped to its own repo/branch and own bucket.
- **#192** — `PokedexBucket` and `SandboxBucket`, hardened identically to the existing `SiteBucket`, each with a CloudFront OAC resource policy.

**Nothing else changes.** CloudFront `additionalBehaviors` still route `apps/pokedex*`/`apps/sand-box*` to the existing shared `SiteBucket`-backed origin — the repoint is Deploy B (#193), a separate future PR, blocked until the `pokedex`/`sand-box` repos have migrated onto these new buckets. The legacy `github-actions-deploy`/`cdk-github-actions` IAM users are untouched (removal is #194).

Also bumps `package.json` to `1.10.0` (minor — both landed issues are `type:feature`) and updates `README.md` to document the new buckets, OIDC provider, and per-app deploy roles.

## Pre-merge verification already done
- Manually confirmed via `aws iam list-open-id-connect-providers` that no `token.actions.githubusercontent.com` provider already exists in the account (CloudFormation hard-fails on a duplicate provider URL rather than importing it).
- `pnpm test` (458/458), `pnpm lint`, `pnpm exec tsc --noEmit` all clean on the epic branch.
- Both #191 and #192 diffs were confirmed source-level additive-only (no AWS credentials available in the dev sandbox to run a live `cdk diff`) — this PR's actual `cdk diff` will run in CI and should show only `[+]` resource creation, no changes to the existing CloudFront distribution.

## After merge
- Verify the CI deploy succeeds and the new resources (OIDC provider, 3 roles, 2 buckets) appear in the AWS console.
- Milestone's next step (#193, currently `status:blocked`) needs the `pokedex` and `sand-box` repos to complete their own `oidc-deploy-credentials` migrations and populate the new buckets before the CloudFront repoint can land.