### PR TITLE
Repoint CloudFront behaviors to new bucket origins

### DIFF
--- a/lib/akli-infrastructure-stack.ts
+++ b/lib/akli-infrastructure-stack.ts
@@ -117,6 +117,14 @@ export class AkliInfrastructureStack extends Stack {
       originAccessControl: originAccessControl,
     })
 
+    const pokedexOrigin = origins.S3BucketOrigin.withOriginAccessControl(pokedexBucket, {
+      originAccessControl: originAccessControl,
+    })
+
+    const sandboxOrigin = origins.S3BucketOrigin.withOriginAccessControl(sandboxBucket, {
+      originAccessControl: originAccessControl,
+    })
+
     // OAC for Lambda — CloudFront signs requests so AWS_IAM auth passes
     const lambdaOac = new cloudfront.CfnOriginAccessControl(this, 'LambdaOAC', {
       originAccessControlConfig: {
@@ -178,8 +186,12 @@ export class AkliInfrastructureStack extends Stack {
           responseHeadersPolicy: securityHeadersPolicy,
         },
         ...Object.fromEntries(
-          ['apps/sand-box*', 'apps/pokedex*'].map((pattern) => [pattern, {
+          ([
+            ['apps/sand-box*', sandboxOrigin],
+            ['apps/pokedex*', pokedexOrigin],
+          ] as const).map(([pattern, origin]) => [pattern, {
             ...staticAssetBehavior,
+            origin,
             functionAssociations: [{
               function: subdirectoryIndexHandler,
               eventType: cloudfront.FunctionEventType.VIEWER_REQUEST,

--- a/lib/akli-infrastructure-stack.ts
+++ b/lib/akli-infrastructure-stack.ts
@@ -185,19 +185,22 @@ export class AkliInfrastructureStack extends Stack {
           cachePolicy: imageCachePolicy,
           responseHeadersPolicy: securityHeadersPolicy,
         },
-        ...Object.fromEntries(
-          ([
-            ['apps/sand-box*', sandboxOrigin],
-            ['apps/pokedex*', pokedexOrigin],
-          ] as const).map(([pattern, origin]) => [pattern, {
-            ...staticAssetBehavior,
-            origin,
-            functionAssociations: [{
-              function: subdirectoryIndexHandler,
-              eventType: cloudfront.FunctionEventType.VIEWER_REQUEST,
-            }],
-          }]),
-        ),
+        'apps/sand-box*': {
+          ...staticAssetBehavior,
+          origin: sandboxOrigin,
+          functionAssociations: [{
+            function: subdirectoryIndexHandler,
+            eventType: cloudfront.FunctionEventType.VIEWER_REQUEST,
+          }],
+        },
+        'apps/pokedex*': {
+          ...staticAssetBehavior,
+          origin: pokedexOrigin,
+          functionAssociations: [{
+            function: subdirectoryIndexHandler,
+            eventType: cloudfront.FunctionEventType.VIEWER_REQUEST,
+          }],
+        },
       },
     })
 


### PR DESCRIPTION
Closes #193

## What changed
This is "Deploy B" of the per-app-buckets-and-oidc-deploy migration. Adds two new S3 origins (`pokedexOrigin`, `sandboxOrigin`), reusing the single existing shared OAC (`SiteOAC` — no second OAC created, per the PRD's "one distribution, one OAC" guidance), and repoints the `apps/pokedex*`/`apps/sand-box*` CloudFront behaviors from the shared `SiteBucket`-backed origin to their own dedicated buckets. The `subdirectoryIndexHandler` CloudFront Function association and every other behavior property (cache policy, viewer protocol policy, response headers, compress) are unchanged.

## Why
Part of the **Per-App S3 Buckets & OIDC Deploy Credentials** milestone (PRD: `docs/prds/per-app-buckets-and-oidc-deploy.md`, epic tracker #197). Deploy A (#191, #192) is live; both `pokedex` and `sand-box` have completed their own OIDC migrations and have real deployed content in their new buckets.

## Pre-implementation verification (required before this could safely proceed)
Confirmed live via `aws s3 ls` that both buckets already contain real content under the correct `apps/<name>/` key prefix (not bucket root) — critical, since CloudFront forwards the full request path as the S3 object key without stripping the matched pattern:
- `s3://akliinfrastructurestack-pokedexbuckete987f38f-ma87rpuh86j4/apps/pokedex/` — `index.html`, JS/CSS assets, font — present
- `s3://akliinfrastructurestack-sandboxbucket298539ac-tm6oohrxtshh/apps/sand-box/` — `index.html`, JS/CSS assets — present

## How to verify
- `pnpm test` — 458/458 passing, `pnpm lint`/`pnpm exec tsc --noEmit` clean.
- `cdk diff --all` — could not run live (Docker/AWS creds unavailable in this environment, same limitation as prior sessions in this repo). Verified via source-level review instead: `AWS::CloudFront::Distribution`'s `DistributionConfig` (which contains both `Origins` and `CacheBehaviors`) has "Update requires: No interruption" in CloudFormation — adding origins and repointing a behavior's target origin are both in-place updates, not replacement-triggering. **Please confirm with a real `cdk diff` before merging** that it shows only `[~]` in-place updates, per this issue's own AC.
- **Cannot be fully verified without a real deploy** — `https://akli.dev/apps/pokedex` and `https://akli.dev/apps/sand-box` serving correctly from the new origins can only be confirmed after this actually deploys.

## Decisions made
- A review pass specifically scrutinized the origin/pattern pairing (the highest-risk failure mode for this kind of change — e.g. accidentally swapping which bucket backs which path pattern) and confirmed it's correct: `apps/sand-box*` → `sandboxOrigin`, `apps/pokedex*` → `pokedexOrigin`, not swapped.
- `/simplify` flagged the original tuple-array/`Object.fromEntries` implementation as more machinery than two entries warranted (needed an `as const` cast purely to stop TS type widening — a sign of a forced abstraction). Rewrote as two explicit object properties, matching the existing `images/*` behavior's style a few lines above. Applied inline, separate commit.
- No test coverage was added for the specific origin-per-pattern assertion — that's already tracked by the existing #196 ("Add CDK assertion tests for OIDC, roles, buckets, and behaviors"), not duplicated here.

## Out of scope
No new follow-up issues filed — the one simplify finding was applied inline, and the test-coverage gap was already tracked by #196 before this PR.