### PR TITLE
Deploy B: repoint CloudFront to per-app buckets

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Route 53 (akli.dev, www.akli.dev)
 - **Default (SSR):** Lambda Function URL origin with S3 failover (OriginGroup, 5xx), 60s TTL, query string forwarding
 - **Static assets (*.js, *.css, etc.):** S3 origin, optimised caching
 - **images/*:** S3 origin, 30-day default TTL, 365-day max, query string caching
-- **apps/sand-box*, apps/pokedex*:** S3 origin, CloudFront Function for subdirectory index rewriting
+- **apps/sand-box*, apps/pokedex*:** dedicated per-app S3 origins (`SandboxBucket`, `PokedexBucket`), CloudFront Function for subdirectory index rewriting
 
 ### Security
 

--- a/lib/akli-infrastructure-stack.ts
+++ b/lib/akli-infrastructure-stack.ts
@@ -117,6 +117,14 @@ export class AkliInfrastructureStack extends Stack {
       originAccessControl: originAccessControl,
     })
 
+    const pokedexOrigin = origins.S3BucketOrigin.withOriginAccessControl(pokedexBucket, {
+      originAccessControl: originAccessControl,
+    })
+
+    const sandboxOrigin = origins.S3BucketOrigin.withOriginAccessControl(sandboxBucket, {
+      originAccessControl: originAccessControl,
+    })
+
     // OAC for Lambda — CloudFront signs requests so AWS_IAM auth passes
     const lambdaOac = new cloudfront.CfnOriginAccessControl(this, 'LambdaOAC', {
       originAccessControlConfig: {
@@ -178,8 +186,12 @@ export class AkliInfrastructureStack extends Stack {
           responseHeadersPolicy: securityHeadersPolicy,
         },
         ...Object.fromEntries(
-          ['apps/sand-box*', 'apps/pokedex*'].map((pattern) => [pattern, {
+          ([
+            ['apps/sand-box*', sandboxOrigin],
+            ['apps/pokedex*', pokedexOrigin],
+          ] as const).map(([pattern, origin]) => [pattern, {
             ...staticAssetBehavior,
+            origin,
             functionAssociations: [{
               function: subdirectoryIndexHandler,
               eventType: cloudfront.FunctionEventType.VIEWER_REQUEST,

--- a/lib/akli-infrastructure-stack.ts
+++ b/lib/akli-infrastructure-stack.ts
@@ -185,19 +185,22 @@ export class AkliInfrastructureStack extends Stack {
           cachePolicy: imageCachePolicy,
           responseHeadersPolicy: securityHeadersPolicy,
         },
-        ...Object.fromEntries(
-          ([
-            ['apps/sand-box*', sandboxOrigin],
-            ['apps/pokedex*', pokedexOrigin],
-          ] as const).map(([pattern, origin]) => [pattern, {
-            ...staticAssetBehavior,
-            origin,
-            functionAssociations: [{
-              function: subdirectoryIndexHandler,
-              eventType: cloudfront.FunctionEventType.VIEWER_REQUEST,
-            }],
-          }]),
-        ),
+        'apps/sand-box*': {
+          ...staticAssetBehavior,
+          origin: sandboxOrigin,
+          functionAssociations: [{
+            function: subdirectoryIndexHandler,
+            eventType: cloudfront.FunctionEventType.VIEWER_REQUEST,
+          }],
+        },
+        'apps/pokedex*': {
+          ...staticAssetBehavior,
+          origin: pokedexOrigin,
+          functionAssociations: [{
+            function: subdirectoryIndexHandler,
+            eventType: cloudfront.FunctionEventType.VIEWER_REQUEST,
+          }],
+        },
       },
     })
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "akli-infrastructure",
   "description": "Infrastructure as Code for akli.dev",
-  "version": "1.10.0",
+  "version": "1.10.1",
   "packageManager": "pnpm@11.9.0",
   "engines": {
     "node": ">=24"


### PR DESCRIPTION
## What changed

Merges "Deploy B" of the **Per-App S3 Buckets & OIDC Deploy Credentials** milestone into `main` (PRD: `docs/prds/per-app-buckets-and-oidc-deploy.md`, epic tracker #197). Merging this PR triggers a real `cdk deploy --all` — the `SiteDistribution`'s `additionalBehaviors` for `apps/pokedex*`/`apps/sand-box*` will repoint from the shared `SiteBucket`-backed origin to the dedicated `PokedexBucket`/`SandboxBucket` origins added in Deploy A.

- **#193** — two new S3 origins, `apps/pokedex*`/`apps/sand-box*` behaviors repointed, `subdirectoryIndexHandler` and all other behavior properties unchanged.

Also bumps `package.json` to `1.10.1` (patch — `type:refactor`) and updates `README.md`'s CloudFront behaviours table to name the new per-app origins.

## Real-world consequence of merging
This is a live production cutover for two paths on `akli.dev`. Once this deploys:
- `akli.dev/apps/pokedex` and `akli.dev/apps/sand-box` will serve from their own dedicated buckets instead of the shared one.
- Both buckets were confirmed (via live `aws s3 ls`, before implementation started) to already contain the correct deployed content under the right `apps/<name>/` prefix, so this should be a clean cutover with no visible disruption — but it's still a real distribution config change, worth watching the deploy run rather than assuming success from a green checkmark.

## Pre-merge verification already done
- `pnpm test` (458/458), `pnpm lint`, `pnpm exec tsc --noEmit` all clean on the epic branch.
- Origin/pattern pairing specifically reviewed for the highest-risk failure mode (swapped buckets) — confirmed correct.
- `cdk diff` could not be run live in the dev sandbox (no Docker/AWS creds) — verified via CloudFormation's documented update semantics that this is an in-place `DistributionConfig` update, not a replacement. **Recommend a final `cdk diff --all` locally before merging**, per #193's own AC.

## After merge
- Confirm the CI deploy run succeeds, then spot-check `https://akli.dev/apps/pokedex` and `https://akli.dev/apps/sand-box` actually serve from the new origins (not 403/404, and ideally confirm via response headers/timestamps that content matches what's in the new buckets).
- Once verified, the milestone's remaining issues (#194 remove legacy IAM user, #195 delete stale content from `SiteBucket`, #196 add CDK assertion tests) become actionable — all were blocked on this landing first.