### PR TITLE
Remove legacy shared IAM user and Secrets Manager credential

### DIFF
--- a/lib/akli-infrastructure-stack.ts
+++ b/lib/akli-infrastructure-stack.ts
@@ -330,8 +330,7 @@ export class AkliInfrastructureStack extends Stack {
         resources: [`arn:aws:cloudfront::${this.account}:distribution/${distribution.distributionId}`],
       })
 
-    // Per-app GitHub Actions deploy Roles — OIDC-federated, replacing the legacy shared
-    // github-actions-deploy IAM User below (removed once all apps have migrated, see #194).
+    // Per-app GitHub Actions deploy Roles — OIDC-federated
     const personalWebsiteDeployRole = new iam.Role(this, 'PersonalWebsiteDeployRole', {
       roleName: 'personal-website-deploy',
       assumedBy: githubDeployPrincipal('personal-website'),
@@ -360,58 +359,6 @@ export class AkliInfrastructureStack extends Stack {
     })
     sandboxDeployRole.addToPolicy(s3AppAccessStatement(sandboxBucket))
     sandboxDeployRole.addToPolicy(cloudfrontInvalidationStatement())
-
-    // IAM user for GitHub Actions deployment
-    const deployUser = new iam.User(this, 'GitHubActionsUser', {
-      userName: 'github-actions-deploy',
-    })
-
-    // Access key for GitHub Actions - stored in Secrets Manager
-    const accessKey = new iam.AccessKey(this, 'GitHubActionsAccessKey', {
-      user: deployUser,
-    })
-
-    // Store GitHub Actions credentials in Secrets Manager
-    new secretsmanager.Secret(this, 'GitHubActionsCredentials', {
-      secretName: 'github-actions-credentials',
-      secretObjectValue: {
-        accessKeyId: SecretValue.unsafePlainText(accessKey.accessKeyId),
-        secretAccessKey: accessKey.secretAccessKey,
-      },
-      description: 'GitHub Actions deployment credentials',
-    })
-
-    // Policy for S3 and CloudFront access
-    const deployPolicy = new iam.Policy(this, 'GitHubActionsDeployPolicy', {
-      statements: [
-        new iam.PolicyStatement({
-          effect: iam.Effect.ALLOW,
-          actions: [
-            's3:GetObject',
-            's3:PutObject',
-            's3:DeleteObject',
-            's3:ListBucket',
-          ],
-          resources: [
-            siteBucket.bucketArn,
-            `${siteBucket.bucketArn}/*`,
-          ],
-        }),
-        new iam.PolicyStatement({
-          effect: iam.Effect.ALLOW,
-          actions: ['cloudfront:CreateInvalidation'],
-          resources: [`arn:aws:cloudfront::${this.account}:distribution/${distribution.distributionId}`],
-        }),
-        new iam.PolicyStatement({
-          effect: iam.Effect.ALLOW,
-          actions: ['lambda:UpdateFunctionCode', 'lambda:GetFunction'],
-          resources: [ssrFunction.functionArn],
-        }),
-      ],
-    })
-
-    // Attach policy to user
-    deployUser.attachInlinePolicy(deployPolicy)
 
     // IAM user for CDK GitHub Actions (separate user for infrastructure)
     const cdkUser = new iam.User(this, 'CDKGitHubActionsUser', {
@@ -469,11 +416,6 @@ export class AkliInfrastructureStack extends Stack {
     new CfnOutput(this, 'WWWWebsiteUrl', {
       value: `https://${WWW_DOMAIN_NAME}`,
       description: 'WWW Website URL',
-    })
-
-    new CfnOutput(this, 'GitHubActionsSecretsManagerName', {
-      value: 'github-actions-credentials',
-      description: 'Secrets Manager secret name for GitHub Actions credentials',
     })
 
     new CfnOutput(this, 'CDKGitHubActionsSecretsManagerName', {


### PR DESCRIPTION
Closes #194

## What changed
This is "Deploy C" — final cleanup. Removes the legacy `github-actions-deploy` IAM User, its access key, its `github-actions-credentials` Secrets Manager secret, its policy (`GitHubActionsDeployPolicy`), and the `GitHubActionsSecretsManagerName` CfnOutput (which only existed to name the secret being deleted here — kept would just point at a deleted resource).

## Why
Part of the **Per-App S3 Buckets & OIDC Deploy Credentials** milestone (PRD: `docs/prds/per-app-buckets-and-oidc-deploy.md`, epic tracker #197). This shared, over-privileged static-key credential is exactly what the whole migration exists to retire. Safe now: all four app repos (`akli-infrastructure`, `pokedex`, `sand-box`, `personal-website`) have completed their own OIDC migrations and no longer reference `AWS_ACCESS_KEY_ID`/`AWS_SECRET_ACCESS_KEY` secrets sourced from this credential — confirmed via real CI deploy runs in each repo before this issue was picked up.

## How to verify
- `pnpm test` (458/458), `pnpm lint`, `pnpm exec tsc --noEmit` all clean.
- Diff is confined to `lib/akli-infrastructure-stack.ts`, pure deletions (60 lines removed, 1 comment simplified) — no other resource touched.
- **Correction**: this PR's `pull_request` CI trigger only fires for PRs targeting `main` (this one targets the epic branch), so no `cdk diff` job actually ran here. I could not run `cdk diff` locally either (no AWS credentials/Docker in this dev sandbox). The real `cdk diff` confirmation will only happen once the epic branch itself opens a PR against `main` — check that CI diff output carefully before merging *that* PR, per this issue's own AC.

## Decisions made
- The separate `cdk-github-actions` IAM User (`cdkUser`) and its own Secrets Manager secret are **completely untouched** — explicitly out of scope per the PRD's Non-Goals (CDK's own bootstrap credential is a bigger, separate initiative). Verified via grep and a dedicated review pass — no accidental modification.
- Updated one stale comment (near the per-app deploy roles) that referenced "#194" and "removed once all apps have migrated" — would have dangled once this issue landed, since the code it described two lines below is now gone.

## Out of scope
No follow-ups filed — this is a pure, self-contained deletion.