### PR TITLE
HOTFIX: fix CloudFront behavior precedence for apps/pokedex*/apps/sand-box*

### DIFF
--- a/lib/akli-infrastructure-stack.ts
+++ b/lib/akli-infrastructure-stack.ts
@@ -178,13 +178,6 @@ export class AkliInfrastructureStack extends Stack {
         compress: true,
       },
       additionalBehaviors: {
-        ...staticAssetBehaviors,
-        'images/*': {
-          origin: s3Origin,
-          viewerProtocolPolicy: cloudfront.ViewerProtocolPolicy.REDIRECT_TO_HTTPS,
-          cachePolicy: imageCachePolicy,
-          responseHeadersPolicy: securityHeadersPolicy,
-        },
         'apps/sand-box*': {
           ...staticAssetBehavior,
           origin: sandboxOrigin,
@@ -200,6 +193,13 @@ export class AkliInfrastructureStack extends Stack {
             function: subdirectoryIndexHandler,
             eventType: cloudfront.FunctionEventType.VIEWER_REQUEST,
           }],
+        },
+        ...staticAssetBehaviors,
+        'images/*': {
+          origin: s3Origin,
+          viewerProtocolPolicy: cloudfront.ViewerProtocolPolicy.REDIRECT_TO_HTTPS,
+          cachePolicy: imageCachePolicy,
+          responseHeadersPolicy: securityHeadersPolicy,
         },
       },
     })


### PR DESCRIPTION
Closes #205

## Live outage this fixes
`https://akli.dev/apps/pokedex` and `https://akli.dev/apps/sand-box` currently 404 on their JS/CSS assets (confirmed live: `/apps/pokedex/assets/index-C4bsAfJ0.js` → 404, same for sand-box's bundle). Root pages (`index.html`) still return 200, so the outage isn't obvious from a quick glance — but both apps are effectively blank/broken for real visitors right now.

## Root cause
CloudFront evaluates `CacheBehaviors` in list order — first match wins, not most-specific-match-wins. `additionalBehaviors` had `apps/pokedex*`/`apps/sand-box*` listed **after** the generic `*.js`/`*.css`/etc. patterns, so any asset request under those app paths matched the generic pattern first and routed to the shared `SiteBucket` origin instead of the app's own dedicated bucket (added in #193). `index.html` wasn't affected (`.html` isn't a matched extension), which is exactly why #193's own verification — which only checked root paths — looked correct while asset routing was silently broken underneath.

This bug has existed since #193 merged, but was invisible because `SiteBucket` still held the old, identical copies of these files as an unintentional fallback — until a separate cleanup issue (#195) deleted them and turned the latent bug into live 404s.

## Fix
Pure reorder: `apps/sand-box*`/`apps/pokedex*` now come before `...staticAssetBehaviors`/`images/*` in `additionalBehaviors`, so CloudFront matches the app-specific pattern first regardless of file extension. No behavior's `origin`, `cachePolicy`, `functionAssociations`, or anything else changed — only key order.

## Why this targets `main` directly, not the epic branch
This is isolated on purpose. The epic branch (`epic/per-app-s3-buckets-and-oidc-deploy-credentials`) currently also carries #194 (removal of the legacy `github-actions-deploy` IAM user) — a separate, already-verified-safe change, but not something that should ship bundled with an emergency hotfix mid-incident. This PR is cherry-picked to contain *only* the CloudFront fix, so it can deploy immediately without dragging in an unrelated destructive change. #194 will go out separately once this is confirmed resolved.

## How to verify
- `pnpm test` (458/458), `pnpm lint`, `pnpm exec tsc --noEmit` all clean.
- Diff is exactly 7 insertions / 7 deletions in `lib/akli-infrastructure-stack.ts` — a pure key reorder, confirmed via review.
- After merge, I'll verify live that the previously-404ing asset URLs return 200.