### PR TITLE
Add CDK assertion tests for OIDC, roles, buckets, and behaviors

### DIFF
--- a/test/akli-infrastructure.test.ts
+++ b/test/akli-infrastructure.test.ts
@@ -341,6 +341,40 @@ describe('AkliInfrastructureStack', () => {
 
       expect(s3OriginIds).toContain(jsAssetBehavior?.TargetOriginId)
     })
+
+    describe('apps/pokedex* and apps/sand-box* behaviours route to their own dedicated bucket origins', () => {
+      // Resolves a CacheBehaviors entry's TargetOriginId to the Origins[] entry it
+      // points at, then checks whether that origin's DomainName (an Fn::GetAtt on the
+      // bucket's RegionalDomainName) references the given bucket's logical ID. This is
+      // the exact bug class from #205: CloudFront behavior precedence meant apps/pokedex*
+      // and apps/sand-box* could silently resolve to the wrong bucket (or each other's).
+      function originLogicalBucketMatches(pathPattern: string, bucketLogicalIdPrefix: string): boolean {
+        const config = distributionConfig(cfnDistribution(template))
+        const cacheBehaviors = config.CacheBehaviors as CfnCacheBehavior[]
+        const origins = config.Origins as CfnOrigin[]
+
+        const behavior = cacheBehaviors.find((b) => b.PathPattern === pathPattern)
+        if (!behavior) throw new Error(`No CacheBehaviors entry found for PathPattern "${pathPattern}"`)
+
+        const origin = origins.find((o) => o.Id === behavior.TargetOriginId)
+        if (!origin) throw new Error(`No Origins entry found for TargetOriginId "${behavior.TargetOriginId}"`)
+
+        const [bucketLogicalId] = findResourceEntryByLogicalIdPrefix(template, 'AWS::S3::Bucket', bucketLogicalIdPrefix)
+        return referencesLogicalId(origin.DomainName, bucketLogicalId)
+      }
+
+      it("routes apps/pokedex* to an origin backed by PokedexBucket, and not SiteBucket or SandboxBucket", () => {
+        expect(originLogicalBucketMatches('apps/pokedex*', 'PokedexBucket')).toBe(true)
+        expect(originLogicalBucketMatches('apps/pokedex*', 'SiteBucket')).toBe(false)
+        expect(originLogicalBucketMatches('apps/pokedex*', 'SandboxBucket')).toBe(false)
+      })
+
+      it("routes apps/sand-box* to an origin backed by SandboxBucket, and not SiteBucket or PokedexBucket", () => {
+        expect(originLogicalBucketMatches('apps/sand-box*', 'SandboxBucket')).toBe(true)
+        expect(originLogicalBucketMatches('apps/sand-box*', 'SiteBucket')).toBe(false)
+        expect(originLogicalBucketMatches('apps/sand-box*', 'PokedexBucket')).toBe(false)
+      })
+    })
   })
 
   describe('Lambda Function URL', () => {


### PR DESCRIPTION
Closes #196

## What changed
Adds two tests confirming CloudFront's `apps/pokedex*`/`apps/sand-box*` behaviors route to their own correct dedicated bucket origins — not the shared `SiteBucket`, and not each other's bucket. This is exactly the assertion that would have caught #205 (CloudFront behavior precedence silently misrouting these two path patterns to the wrong origin).

## Why
Part of the **Per-App S3 Buckets & OIDC Deploy Credentials** milestone (PRD: `docs/prds/per-app-buckets-and-oidc-deploy.md`, epic tracker #197). Most of this issue's stated acceptance criteria (OIDC provider tests, per-role trust policy tests, cross-app bucket isolation, per-bucket hardening) were already satisfied incidentally by tests written during #191/#192's own TDD work — confirmed via grep before starting. This PR closes the one genuine remaining gap.

## How to verify
- `pnpm test` — 460/460 passing (458 pre-existing + 2 new).
- `pnpm lint`/`pnpm exec tsc --noEmit` — clean.
- **The new tests were sabotage-tested against the actual #205 bug class**: temporarily reproduced that bug locally (pointed `apps/sand-box*` at `pokedexOrigin`), confirmed the new test failed exactly as expected, then reverted cleanly (`git diff lib/akli-infrastructure-stack.ts` is empty on this branch).

## Decisions made
- Both tests assert the positive case (behavior routes to its own bucket) AND both negative cases (does not route to either other bucket) — catches a same-wrong-bucket-for-both or partial-swap regression, not just a single miswiring.
- Reused all existing test helpers (`cfnDistribution`, `distributionConfig`, `findResourceEntryByLogicalIdPrefix`, `referencesLogicalId`) — no new resolution logic invented.

## Out of scope
No follow-ups filed — this closes #196's stated scope in full.