### PR TITLE
Deploy C: remove legacy IAM user, add regression test coverage

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,14 +75,13 @@ GitHub Actions workflow on `.github/workflows/deploy.yml`:
 - **PRs to main:** runs `cdk diff` to preview changes
 - **Push to main:** bootstraps, deploys all stacks, then invalidates the CloudFront cache
 
-Two IAM users with credentials stored in Secrets Manager (legacy, being phased out per-app in favour of OIDC — see below):
-- `github-actions-deploy` — S3 sync and CloudFront invalidation
+One IAM user with credentials stored in Secrets Manager, for this repo's own CDK bootstrap/deploy:
 - `cdk-github-actions` — CDK bootstrap and deploy
 
 A GitHub OIDC provider (`token.actions.githubusercontent.com`) and per-app IAM roles let `personal-website`, `pokedex`, and `sand-box` deploy without long-lived static credentials — each role trusts only its own repo on `main` and can only touch its own S3 bucket:
 - `personal-website-deploy`, `pokedex-deploy`, `sandbox-deploy`
 
-CloudFront still routes `apps/pokedex*`/`apps/sand-box*` to the shared site bucket until each app's own deploy migrates to OIDC and its dedicated bucket (in progress).
+CloudFront routes `apps/pokedex*`/`apps/sand-box*` to their own dedicated buckets (`PokedexBucket`/`SandboxBucket`). The legacy shared `github-actions-deploy` IAM user and its static-key credential, used before this OIDC migration, have been removed.
 
 ## Tags
 

--- a/lib/akli-infrastructure-stack.ts
+++ b/lib/akli-infrastructure-stack.ts
@@ -330,8 +330,7 @@ export class AkliInfrastructureStack extends Stack {
         resources: [`arn:aws:cloudfront::${this.account}:distribution/${distribution.distributionId}`],
       })
 
-    // Per-app GitHub Actions deploy Roles — OIDC-federated, replacing the legacy shared
-    // github-actions-deploy IAM User below (removed once all apps have migrated, see #194).
+    // Per-app GitHub Actions deploy Roles — OIDC-federated
     const personalWebsiteDeployRole = new iam.Role(this, 'PersonalWebsiteDeployRole', {
       roleName: 'personal-website-deploy',
       assumedBy: githubDeployPrincipal('personal-website'),
@@ -360,58 +359,6 @@ export class AkliInfrastructureStack extends Stack {
     })
     sandboxDeployRole.addToPolicy(s3AppAccessStatement(sandboxBucket))
     sandboxDeployRole.addToPolicy(cloudfrontInvalidationStatement())
-
-    // IAM user for GitHub Actions deployment
-    const deployUser = new iam.User(this, 'GitHubActionsUser', {
-      userName: 'github-actions-deploy',
-    })
-
-    // Access key for GitHub Actions - stored in Secrets Manager
-    const accessKey = new iam.AccessKey(this, 'GitHubActionsAccessKey', {
-      user: deployUser,
-    })
-
-    // Store GitHub Actions credentials in Secrets Manager
-    new secretsmanager.Secret(this, 'GitHubActionsCredentials', {
-      secretName: 'github-actions-credentials',
-      secretObjectValue: {
-        accessKeyId: SecretValue.unsafePlainText(accessKey.accessKeyId),
-        secretAccessKey: accessKey.secretAccessKey,
-      },
-      description: 'GitHub Actions deployment credentials',
-    })
-
-    // Policy for S3 and CloudFront access
-    const deployPolicy = new iam.Policy(this, 'GitHubActionsDeployPolicy', {
-      statements: [
-        new iam.PolicyStatement({
-          effect: iam.Effect.ALLOW,
-          actions: [
-            's3:GetObject',
-            's3:PutObject',
-            's3:DeleteObject',
-            's3:ListBucket',
-          ],
-          resources: [
-            siteBucket.bucketArn,
-            `${siteBucket.bucketArn}/*`,
-          ],
-        }),
-        new iam.PolicyStatement({
-          effect: iam.Effect.ALLOW,
-          actions: ['cloudfront:CreateInvalidation'],
-          resources: [`arn:aws:cloudfront::${this.account}:distribution/${distribution.distributionId}`],
-        }),
-        new iam.PolicyStatement({
-          effect: iam.Effect.ALLOW,
-          actions: ['lambda:UpdateFunctionCode', 'lambda:GetFunction'],
-          resources: [ssrFunction.functionArn],
-        }),
-      ],
-    })
-
-    // Attach policy to user
-    deployUser.attachInlinePolicy(deployPolicy)
 
     // IAM user for CDK GitHub Actions (separate user for infrastructure)
     const cdkUser = new iam.User(this, 'CDKGitHubActionsUser', {
@@ -469,11 +416,6 @@ export class AkliInfrastructureStack extends Stack {
     new CfnOutput(this, 'WWWWebsiteUrl', {
       value: `https://${WWW_DOMAIN_NAME}`,
       description: 'WWW Website URL',
-    })
-
-    new CfnOutput(this, 'GitHubActionsSecretsManagerName', {
-      value: 'github-actions-credentials',
-      description: 'Secrets Manager secret name for GitHub Actions credentials',
     })
 
     new CfnOutput(this, 'CDKGitHubActionsSecretsManagerName', {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "akli-infrastructure",
   "description": "Infrastructure as Code for akli.dev",
-  "version": "1.10.1",
+  "version": "1.10.2",
   "packageManager": "pnpm@11.9.0",
   "engines": {
     "node": ">=24"

--- a/test/akli-infrastructure.test.ts
+++ b/test/akli-infrastructure.test.ts
@@ -341,6 +341,40 @@ describe('AkliInfrastructureStack', () => {
 
       expect(s3OriginIds).toContain(jsAssetBehavior?.TargetOriginId)
     })
+
+    describe('apps/pokedex* and apps/sand-box* behaviours route to their own dedicated bucket origins', () => {
+      // Resolves a CacheBehaviors entry's TargetOriginId to the Origins[] entry it
+      // points at, then checks whether that origin's DomainName (an Fn::GetAtt on the
+      // bucket's RegionalDomainName) references the given bucket's logical ID. This is
+      // the exact bug class from #205: CloudFront behavior precedence meant apps/pokedex*
+      // and apps/sand-box* could silently resolve to the wrong bucket (or each other's).
+      function originLogicalBucketMatches(pathPattern: string, bucketLogicalIdPrefix: string): boolean {
+        const config = distributionConfig(cfnDistribution(template))
+        const cacheBehaviors = config.CacheBehaviors as CfnCacheBehavior[]
+        const origins = config.Origins as CfnOrigin[]
+
+        const behavior = cacheBehaviors.find((b) => b.PathPattern === pathPattern)
+        if (!behavior) throw new Error(`No CacheBehaviors entry found for PathPattern "${pathPattern}"`)
+
+        const origin = origins.find((o) => o.Id === behavior.TargetOriginId)
+        if (!origin) throw new Error(`No Origins entry found for TargetOriginId "${behavior.TargetOriginId}"`)
+
+        const [bucketLogicalId] = findResourceEntryByLogicalIdPrefix(template, 'AWS::S3::Bucket', bucketLogicalIdPrefix)
+        return referencesLogicalId(origin.DomainName, bucketLogicalId)
+      }
+
+      it("routes apps/pokedex* to an origin backed by PokedexBucket, and not SiteBucket or SandboxBucket", () => {
+        expect(originLogicalBucketMatches('apps/pokedex*', 'PokedexBucket')).toBe(true)
+        expect(originLogicalBucketMatches('apps/pokedex*', 'SiteBucket')).toBe(false)
+        expect(originLogicalBucketMatches('apps/pokedex*', 'SandboxBucket')).toBe(false)
+      })
+
+      it("routes apps/sand-box* to an origin backed by SandboxBucket, and not SiteBucket or PokedexBucket", () => {
+        expect(originLogicalBucketMatches('apps/sand-box*', 'SandboxBucket')).toBe(true)
+        expect(originLogicalBucketMatches('apps/sand-box*', 'SiteBucket')).toBe(false)
+        expect(originLogicalBucketMatches('apps/sand-box*', 'PokedexBucket')).toBe(false)
+      })
+    })
   })
 
   describe('Lambda Function URL', () => {


### PR DESCRIPTION
## What changed

Merges the rest of "Deploy C" of the **Per-App S3 Buckets & OIDC Deploy Credentials** milestone into `main` (PRD: `docs/prds/per-app-buckets-and-oidc-deploy.md`, epic tracker #197).

- **#194** — removes the legacy `github-actions-deploy` IAM User, its access key, and its `github-actions-credentials` Secrets Manager secret. **This is the real deletion** — the code has been sitting on the epic branch since PR #204, but nothing has actually removed the AWS resources yet, since the epic branch hasn't deployed until now.
- **#196** — adds regression-test coverage confirming `apps/pokedex*`/`apps/sand-box*` route to their own dedicated buckets, specifically designed to catch the #205 bug class (sabotage-tested against that exact bug before merging).
- The #205 hotfix (CloudFront behavior precedence) is already live on `main` from a prior isolated deploy — included here via merge, no new change.

Also bumps `package.json` to `1.10.2` and updates `README.md` (legacy IAM user removed, per-app CloudFront routing no longer "in progress").

## Real-world consequence of merging
This deploy **permanently deletes** the `github-actions-deploy` IAM User and its Secrets Manager secret from the live AWS account. This has been verified safe: all four app repos (`akli-infrastructure`, `pokedex`, `sand-box`, `personal-website`) completed their own OIDC migrations and had their `AWS_ACCESS_KEY_ID`/`AWS_SECRET_ACCESS_KEY` GitHub secrets removed *before* this issue was picked up — confirmed via real CI deploy runs in each repo. Nothing should still be depending on this credential.

## Pre-merge verification already done
- `pnpm test` (460/460), `pnpm lint`, `pnpm exec tsc --noEmit` all clean.
- `cdk diff` could not be run live in the dev sandbox (no Docker/AWS creds) — the removal was verified via source-level review as a pure deletion (no other resource touched), and the separate `cdk-github-actions` user was specifically confirmed untouched in review.

## After merge
- Confirm the CI deploy run succeeds, then verify live (e.g. `aws iam get-user --user-name github-actions-deploy` should now fail with `NoSuchEntity`) that the legacy user is actually gone.
- This closes out Deploy C and the milestone's core work — only the shared-factory extraction follow-up (#198) and the `AWS_`-naming polish issues in the app repos remain across the whole per-app-buckets/OIDC initiative.