### PR TITLE
Extract shared factory for hardened app buckets and CloudFront read grants

### DIFF
--- a/lib/akli-infrastructure-stack.ts
+++ b/lib/akli-infrastructure-stack.ts
@@ -1,6 +1,6 @@
 import * as path from 'path'
 import type { StackProps} from 'aws-cdk-lib';
-import { Stack, RemovalPolicy, CfnOutput, Duration, SecretValue, Fn } from 'aws-cdk-lib'
+import { Stack, CfnOutput, Duration, SecretValue, Fn } from 'aws-cdk-lib'
 import type * as certificatemanager from 'aws-cdk-lib/aws-certificatemanager'
 import * as cloudfront from 'aws-cdk-lib/aws-cloudfront'
 import * as origins from 'aws-cdk-lib/aws-cloudfront-origins'
@@ -9,10 +9,11 @@ import * as lambda from 'aws-cdk-lib/aws-lambda'
 import { NodejsFunction } from 'aws-cdk-lib/aws-lambda-nodejs'
 import * as route53 from 'aws-cdk-lib/aws-route53'
 import * as targets from 'aws-cdk-lib/aws-route53-targets'
-import * as s3 from 'aws-cdk-lib/aws-s3'
+import type * as s3 from 'aws-cdk-lib/aws-s3'
 import * as secretsmanager from 'aws-cdk-lib/aws-secretsmanager'
 import type { Construct } from 'constructs'
 import { createCachePolicy, createImageCachePolicy, createSecurityHeadersPolicy } from './cdn-policies'
+import { createHardenedAppBucket, grantCloudFrontRead } from './s3-policies'
 
 interface AkliInfrastructureStackProps extends StackProps {
   hostedZone: route53.IHostedZone
@@ -39,33 +40,15 @@ export class AkliInfrastructureStack extends Stack {
       secretStringValue: SecretValue.unsafePlainText(process.env.CDK_DEFAULT_REGION || ''),
     });
 
-    const siteBucket = new s3.Bucket(this, 'SiteBucket', {
-      blockPublicAccess: s3.BlockPublicAccess.BLOCK_ALL,
-      removalPolicy: RemovalPolicy.DESTROY,
-      autoDeleteObjects: true,
-      encryption: s3.BucketEncryption.S3_MANAGED,
-      enforceSSL: true,
-    })
+    const siteBucket = createHardenedAppBucket(this, 'SiteBucket')
 
     const originAccessControl = new cloudfront.S3OriginAccessControl(this, 'SiteOAC', {
       description: `OAC for ${DOMAIN_NAME}`,
     })
 
-    const pokedexBucket = new s3.Bucket(this, 'PokedexBucket', {
-      blockPublicAccess: s3.BlockPublicAccess.BLOCK_ALL,
-      removalPolicy: RemovalPolicy.DESTROY,
-      autoDeleteObjects: true,
-      encryption: s3.BucketEncryption.S3_MANAGED,
-      enforceSSL: true,
-    })
+    const pokedexBucket = createHardenedAppBucket(this, 'PokedexBucket')
 
-    const sandboxBucket = new s3.Bucket(this, 'SandboxBucket', {
-      blockPublicAccess: s3.BlockPublicAccess.BLOCK_ALL,
-      removalPolicy: RemovalPolicy.DESTROY,
-      autoDeleteObjects: true,
-      encryption: s3.BucketEncryption.S3_MANAGED,
-      enforceSSL: true,
-    })
+    const sandboxBucket = createHardenedAppBucket(this, 'SandboxBucket')
 
     const securityHeadersPolicy = createSecurityHeadersPolicy(this)
 
@@ -226,55 +209,13 @@ export class AkliInfrastructureStack extends Stack {
     })
 
     // Grant CloudFront access to S3 bucket
-    siteBucket.addToResourcePolicy(new iam.PolicyStatement({
-      sid: 'AllowCloudFrontServicePrincipal',
-      effect: iam.Effect.ALLOW,
-      principals: [new iam.ServicePrincipal('cloudfront.amazonaws.com')],
-      actions: ['s3:GetObject', 's3:ListBucket'],
-      resources: [
-        siteBucket.bucketArn,
-        `${siteBucket.bucketArn}/*`,
-      ],
-      conditions: {
-        StringEquals: {
-          'AWS:SourceArn': `arn:aws:cloudfront::${this.account}:distribution/${distribution.distributionId}`,
-        },
-      },
-    }))
+    grantCloudFrontRead(siteBucket, distribution, this.account)
 
     // Grant CloudFront access to Pokedex S3 bucket
-    pokedexBucket.addToResourcePolicy(new iam.PolicyStatement({
-      sid: 'AllowCloudFrontServicePrincipal',
-      effect: iam.Effect.ALLOW,
-      principals: [new iam.ServicePrincipal('cloudfront.amazonaws.com')],
-      actions: ['s3:GetObject', 's3:ListBucket'],
-      resources: [
-        pokedexBucket.bucketArn,
-        `${pokedexBucket.bucketArn}/*`,
-      ],
-      conditions: {
-        StringEquals: {
-          'AWS:SourceArn': `arn:aws:cloudfront::${this.account}:distribution/${distribution.distributionId}`,
-        },
-      },
-    }))
+    grantCloudFrontRead(pokedexBucket, distribution, this.account)
 
     // Grant CloudFront access to Sandbox S3 bucket
-    sandboxBucket.addToResourcePolicy(new iam.PolicyStatement({
-      sid: 'AllowCloudFrontServicePrincipal',
-      effect: iam.Effect.ALLOW,
-      principals: [new iam.ServicePrincipal('cloudfront.amazonaws.com')],
-      actions: ['s3:GetObject', 's3:ListBucket'],
-      resources: [
-        sandboxBucket.bucketArn,
-        `${sandboxBucket.bucketArn}/*`,
-      ],
-      conditions: {
-        StringEquals: {
-          'AWS:SourceArn': `arn:aws:cloudfront::${this.account}:distribution/${distribution.distributionId}`,
-        },
-      },
-    }))
+    grantCloudFrontRead(sandboxBucket, distribution, this.account)
 
     // DNS A record for apex domain
     new route53.ARecord(this, 'SiteAliasRecord', {

--- a/lib/s3-policies.ts
+++ b/lib/s3-policies.ts
@@ -1,0 +1,37 @@
+import { RemovalPolicy } from 'aws-cdk-lib'
+import type * as cloudfront from 'aws-cdk-lib/aws-cloudfront'
+import * as iam from 'aws-cdk-lib/aws-iam'
+import * as s3 from 'aws-cdk-lib/aws-s3'
+import type { Construct } from 'constructs'
+
+export function createHardenedAppBucket(scope: Construct, id: string): s3.Bucket {
+  return new s3.Bucket(scope, id, {
+    blockPublicAccess: s3.BlockPublicAccess.BLOCK_ALL,
+    removalPolicy: RemovalPolicy.DESTROY,
+    autoDeleteObjects: true,
+    encryption: s3.BucketEncryption.S3_MANAGED,
+    enforceSSL: true,
+  })
+}
+
+export function grantCloudFrontRead(
+  bucket: s3.Bucket,
+  distribution: cloudfront.Distribution,
+  account: string,
+): void {
+  bucket.addToResourcePolicy(new iam.PolicyStatement({
+    sid: 'AllowCloudFrontServicePrincipal',
+    effect: iam.Effect.ALLOW,
+    principals: [new iam.ServicePrincipal('cloudfront.amazonaws.com')],
+    actions: ['s3:GetObject', 's3:ListBucket'],
+    resources: [
+      bucket.bucketArn,
+      `${bucket.bucketArn}/*`,
+    ],
+    conditions: {
+      StringEquals: {
+        'AWS:SourceArn': `arn:aws:cloudfront::${account}:distribution/${distribution.distributionId}`,
+      },
+    },
+  }))
+}


### PR DESCRIPTION
Closes #198

## What changed
Extracts two duplicated code blocks — hardened-bucket props (`BlockPublicAccess.BLOCK_ALL`, `RemovalPolicy.DESTROY`+`autoDeleteObjects`, `BucketEncryption.S3_MANAGED`, `enforceSSL`) and the `AllowCloudFrontServicePrincipal` resource-policy grant — into two factory functions in a new `lib/s3-policies.ts`:
- `createHardenedAppBucket(scope, id)`
- `grantCloudFrontRead(bucket, distribution, account)`

Replaces all three call sites (`SiteBucket`, `PokedexBucket`, `SandboxBucket`) with the factories. Pure refactor — zero behavior change.

## Why
Follow-up surfaced by `/simplify` during #192's review. Removes ~70 lines of copy-pasted CDK config down to a handful of call sites, matching the existing `lib/cdn-policies.ts` factory-function precedent. The PRD anticipates a fourth bucket (Storybook) once that initiative resumes — without this extraction, that'd be a fourth copy-paste with no compiler enforcement that all four stay in sync.

## How to verify
**This touches three live, content-bearing S3 buckets — construct-ID stability was verified with extra scrutiny.** The three `createHardenedAppBucket(this, id)` calls use exactly `'SiteBucket'`/`'PokedexBucket'`/`'SandboxBucket'` — byte-identical to the pre-refactor construct IDs, confirmed via diff against the pre-refactor commit. This matters because any deviation would change the CloudFormation logical ID and make CDK try to *replace* (delete + recreate) a live bucket with real content.

- `pnpm test` — 460/460 passing, **zero changes to the test file** (confirms the synthesized template is unchanged — the strongest available signal in this sandboxed environment, which has no AWS credentials/Docker for a live `cdk diff`).
- `pnpm lint`/`pnpm exec tsc --noEmit` — clean.
- Both factory function bodies verified byte-identical in behavior to what was previously inlined three times (same props, same policy statement shape, same conditions).

## Decisions made
- New `lib/s3-policies.ts` rather than extending `lib/cdn-policies.ts` — that file's existing exports are pure-CloudFront constructs with no S3 involvement, while these two functions are S3-bucket-centric.

## Out of scope
No follow-ups filed — this closes #198's stated scope in full. This also closes out the last remaining `akli-infrastructure` issue from the per-app-buckets/OIDC milestone.