### PR TITLE
Extract shared bucket factory (pure refactor, no behavior change)

### DIFF
--- a/lib/akli-infrastructure-stack.ts
+++ b/lib/akli-infrastructure-stack.ts
@@ -1,6 +1,6 @@
 import * as path from 'path'
 import type { StackProps} from 'aws-cdk-lib';
-import { Stack, RemovalPolicy, CfnOutput, Duration, SecretValue, Fn } from 'aws-cdk-lib'
+import { Stack, CfnOutput, Duration, SecretValue, Fn } from 'aws-cdk-lib'
 import type * as certificatemanager from 'aws-cdk-lib/aws-certificatemanager'
 import * as cloudfront from 'aws-cdk-lib/aws-cloudfront'
 import * as origins from 'aws-cdk-lib/aws-cloudfront-origins'
@@ -9,10 +9,11 @@ import * as lambda from 'aws-cdk-lib/aws-lambda'
 import { NodejsFunction } from 'aws-cdk-lib/aws-lambda-nodejs'
 import * as route53 from 'aws-cdk-lib/aws-route53'
 import * as targets from 'aws-cdk-lib/aws-route53-targets'
-import * as s3 from 'aws-cdk-lib/aws-s3'
+import type * as s3 from 'aws-cdk-lib/aws-s3'
 import * as secretsmanager from 'aws-cdk-lib/aws-secretsmanager'
 import type { Construct } from 'constructs'
 import { createCachePolicy, createImageCachePolicy, createSecurityHeadersPolicy } from './cdn-policies'
+import { createHardenedAppBucket, grantCloudFrontRead } from './s3-policies'
 
 interface AkliInfrastructureStackProps extends StackProps {
   hostedZone: route53.IHostedZone
@@ -39,33 +40,15 @@ export class AkliInfrastructureStack extends Stack {
       secretStringValue: SecretValue.unsafePlainText(process.env.CDK_DEFAULT_REGION || ''),
     });
 
-    const siteBucket = new s3.Bucket(this, 'SiteBucket', {
-      blockPublicAccess: s3.BlockPublicAccess.BLOCK_ALL,
-      removalPolicy: RemovalPolicy.DESTROY,
-      autoDeleteObjects: true,
-      encryption: s3.BucketEncryption.S3_MANAGED,
-      enforceSSL: true,
-    })
+    const siteBucket = createHardenedAppBucket(this, 'SiteBucket')
 
     const originAccessControl = new cloudfront.S3OriginAccessControl(this, 'SiteOAC', {
       description: `OAC for ${DOMAIN_NAME}`,
     })
 
-    const pokedexBucket = new s3.Bucket(this, 'PokedexBucket', {
-      blockPublicAccess: s3.BlockPublicAccess.BLOCK_ALL,
-      removalPolicy: RemovalPolicy.DESTROY,
-      autoDeleteObjects: true,
-      encryption: s3.BucketEncryption.S3_MANAGED,
-      enforceSSL: true,
-    })
+    const pokedexBucket = createHardenedAppBucket(this, 'PokedexBucket')
 
-    const sandboxBucket = new s3.Bucket(this, 'SandboxBucket', {
-      blockPublicAccess: s3.BlockPublicAccess.BLOCK_ALL,
-      removalPolicy: RemovalPolicy.DESTROY,
-      autoDeleteObjects: true,
-      encryption: s3.BucketEncryption.S3_MANAGED,
-      enforceSSL: true,
-    })
+    const sandboxBucket = createHardenedAppBucket(this, 'SandboxBucket')
 
     const securityHeadersPolicy = createSecurityHeadersPolicy(this)
 
@@ -226,55 +209,13 @@ export class AkliInfrastructureStack extends Stack {
     })
 
     // Grant CloudFront access to S3 bucket
-    siteBucket.addToResourcePolicy(new iam.PolicyStatement({
-      sid: 'AllowCloudFrontServicePrincipal',
-      effect: iam.Effect.ALLOW,
-      principals: [new iam.ServicePrincipal('cloudfront.amazonaws.com')],
-      actions: ['s3:GetObject', 's3:ListBucket'],
-      resources: [
-        siteBucket.bucketArn,
-        `${siteBucket.bucketArn}/*`,
-      ],
-      conditions: {
-        StringEquals: {
-          'AWS:SourceArn': `arn:aws:cloudfront::${this.account}:distribution/${distribution.distributionId}`,
-        },
-      },
-    }))
+    grantCloudFrontRead(siteBucket, distribution, this.account)
 
     // Grant CloudFront access to Pokedex S3 bucket
-    pokedexBucket.addToResourcePolicy(new iam.PolicyStatement({
-      sid: 'AllowCloudFrontServicePrincipal',
-      effect: iam.Effect.ALLOW,
-      principals: [new iam.ServicePrincipal('cloudfront.amazonaws.com')],
-      actions: ['s3:GetObject', 's3:ListBucket'],
-      resources: [
-        pokedexBucket.bucketArn,
-        `${pokedexBucket.bucketArn}/*`,
-      ],
-      conditions: {
-        StringEquals: {
-          'AWS:SourceArn': `arn:aws:cloudfront::${this.account}:distribution/${distribution.distributionId}`,
-        },
-      },
-    }))
+    grantCloudFrontRead(pokedexBucket, distribution, this.account)
 
     // Grant CloudFront access to Sandbox S3 bucket
-    sandboxBucket.addToResourcePolicy(new iam.PolicyStatement({
-      sid: 'AllowCloudFrontServicePrincipal',
-      effect: iam.Effect.ALLOW,
-      principals: [new iam.ServicePrincipal('cloudfront.amazonaws.com')],
-      actions: ['s3:GetObject', 's3:ListBucket'],
-      resources: [
-        sandboxBucket.bucketArn,
-        `${sandboxBucket.bucketArn}/*`,
-      ],
-      conditions: {
-        StringEquals: {
-          'AWS:SourceArn': `arn:aws:cloudfront::${this.account}:distribution/${distribution.distributionId}`,
-        },
-      },
-    }))
+    grantCloudFrontRead(sandboxBucket, distribution, this.account)
 
     // DNS A record for apex domain
     new route53.ARecord(this, 'SiteAliasRecord', {

--- a/lib/s3-policies.ts
+++ b/lib/s3-policies.ts
@@ -1,0 +1,37 @@
+import { RemovalPolicy } from 'aws-cdk-lib'
+import type * as cloudfront from 'aws-cdk-lib/aws-cloudfront'
+import * as iam from 'aws-cdk-lib/aws-iam'
+import * as s3 from 'aws-cdk-lib/aws-s3'
+import type { Construct } from 'constructs'
+
+export function createHardenedAppBucket(scope: Construct, id: string): s3.Bucket {
+  return new s3.Bucket(scope, id, {
+    blockPublicAccess: s3.BlockPublicAccess.BLOCK_ALL,
+    removalPolicy: RemovalPolicy.DESTROY,
+    autoDeleteObjects: true,
+    encryption: s3.BucketEncryption.S3_MANAGED,
+    enforceSSL: true,
+  })
+}
+
+export function grantCloudFrontRead(
+  bucket: s3.Bucket,
+  distribution: cloudfront.Distribution,
+  account: string,
+): void {
+  bucket.addToResourcePolicy(new iam.PolicyStatement({
+    sid: 'AllowCloudFrontServicePrincipal',
+    effect: iam.Effect.ALLOW,
+    principals: [new iam.ServicePrincipal('cloudfront.amazonaws.com')],
+    actions: ['s3:GetObject', 's3:ListBucket'],
+    resources: [
+      bucket.bucketArn,
+      `${bucket.bucketArn}/*`,
+    ],
+    conditions: {
+      StringEquals: {
+        'AWS:SourceArn': `arn:aws:cloudfront::${account}:distribution/${distribution.distributionId}`,
+      },
+    },
+  }))
+}

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "akli-infrastructure",
   "description": "Infrastructure as Code for akli.dev",
-  "version": "1.10.2",
+  "version": "1.10.3",
   "packageManager": "pnpm@11.9.0",
   "engines": {
     "node": ">=24"


### PR DESCRIPTION
## What changed

Merges #198 into `main` — extracts the duplicated hardened-bucket props and CloudFront resource-policy grant (previously inlined three times for `SiteBucket`/`PokedexBucket`/`SandboxBucket`) into two factory functions in a new `lib/s3-policies.ts`. Pure refactor, zero behavior change.

Also bumps `package.json` to `1.10.3`.

## Real-world consequence of merging
This touches all three live, content-bearing S3 buckets' CDK definitions. Construct IDs (`'SiteBucket'`/`'PokedexBucket'`/`'SandboxBucket'`) are verified byte-identical to before the refactor — a dedicated review pass specifically checked this, since any deviation would make CloudFormation try to replace (delete + recreate) a live bucket. `cdk deploy` should show **no changes at all** to these three bucket resources (or possibly a metadata-only no-op) — if the CI deploy shows anything touching `SiteBucket`/`PokedexBucket`/`SandboxBucket` beyond a no-op, that's a signal something's wrong and worth investigating before it completes.

## Pre-merge verification already done
- `pnpm test` (460/460, **zero test-file changes** — the strongest available signal that the synthesized template is unchanged), `pnpm lint`, `pnpm exec tsc --noEmit` all clean.
- Both factory function bodies verified byte-identical in behavior to what was previously inlined.

## After merge
- Watch the CI deploy run — confirm it completes with no unexpected resource changes (ideally a no-op or CDKMetadata-only diff).
- This closes out the last `akli-infrastructure` issue from the per-app-buckets/OIDC milestone.