### PR TITLE
Add PokedexCert and SandboxCert to CertificateStack

### DIFF
--- a/lib/certificate-stack.ts
+++ b/lib/certificate-stack.ts
@@ -8,6 +8,8 @@ const DOMAIN_NAME = 'akli.dev'
 const WWW_DOMAIN_NAME = `www.${DOMAIN_NAME}`
 const API_DOMAIN_NAME = `api.${DOMAIN_NAME}`
 const IMAGES_DOMAIN_NAME = `images.${DOMAIN_NAME}`
+const POKEDEX_DOMAIN_NAME = `pokedex.${DOMAIN_NAME}`
+const SANDBOX_DOMAIN_NAME = `sandbox.${DOMAIN_NAME}`
 
 /**
  * Separate stack for ACM certificates and Route 53 hosted zone.
@@ -19,6 +21,8 @@ export class CertificateStack extends Stack {
   public readonly certificate: certificatemanager.Certificate
   public readonly apiCertificate: certificatemanager.Certificate
   public readonly imagesCertificate: certificatemanager.Certificate
+  public readonly pokedexCertificate: certificatemanager.Certificate
+  public readonly sandboxCertificate: certificatemanager.Certificate
 
   constructor(scope: Construct, id: string, props?: StackProps) {
     super(scope, id, props)
@@ -43,6 +47,18 @@ export class CertificateStack extends Stack {
     // Separate certificate for images.akli.dev — avoids replacing the site cert which would break cross-stack exports
     this.imagesCertificate = new certificatemanager.Certificate(this, 'ImagesCert', {
       domainName: IMAGES_DOMAIN_NAME,
+      validation: certificatemanager.CertificateValidation.fromDns(this.hostedZone),
+    })
+
+    // Separate certificate for pokedex.akli.dev — keeps the one-cert-per-subdomain convention rather than a SAN/wildcard
+    this.pokedexCertificate = new certificatemanager.Certificate(this, 'PokedexCert', {
+      domainName: POKEDEX_DOMAIN_NAME,
+      validation: certificatemanager.CertificateValidation.fromDns(this.hostedZone),
+    })
+
+    // Separate certificate for sandbox.akli.dev — keeps the one-cert-per-subdomain convention rather than a SAN/wildcard
+    this.sandboxCertificate = new certificatemanager.Certificate(this, 'SandboxCert', {
+      domainName: SANDBOX_DOMAIN_NAME,
       validation: certificatemanager.CertificateValidation.fromDns(this.hostedZone),
     })
   }

--- a/lib/certificate-stack.ts
+++ b/lib/certificate-stack.ts
@@ -50,13 +50,12 @@ export class CertificateStack extends Stack {
       validation: certificatemanager.CertificateValidation.fromDns(this.hostedZone),
     })
 
-    // Separate certificate for pokedex.akli.dev — keeps the one-cert-per-subdomain convention rather than a SAN/wildcard
+    // Per-app subdomain certificates — keep the one-cert-per-subdomain convention rather than a SAN/wildcard
     this.pokedexCertificate = new certificatemanager.Certificate(this, 'PokedexCert', {
       domainName: POKEDEX_DOMAIN_NAME,
       validation: certificatemanager.CertificateValidation.fromDns(this.hostedZone),
     })
 
-    // Separate certificate for sandbox.akli.dev — keeps the one-cert-per-subdomain convention rather than a SAN/wildcard
     this.sandboxCertificate = new certificatemanager.Certificate(this, 'SandboxCert', {
       domainName: SANDBOX_DOMAIN_NAME,
       validation: certificatemanager.CertificateValidation.fromDns(this.hostedZone),

--- a/test/certificate-stack.test.ts
+++ b/test/certificate-stack.test.ts
@@ -49,9 +49,33 @@ describe('CertificateStack', () => {
     })
   })
 
+  describe('Pokedex certificate', () => {
+    it('creates a dedicated certificate for pokedex.akli.dev with DNS validation', () => {
+      template.hasResourceProperties(
+        'AWS::CertificateManager::Certificate',
+        Match.objectLike({
+          DomainName: 'pokedex.akli.dev',
+          ValidationMethod: 'DNS',
+        }),
+      )
+    })
+  })
+
+  describe('Sandbox certificate', () => {
+    it('creates a dedicated certificate for sandbox.akli.dev with DNS validation', () => {
+      template.hasResourceProperties(
+        'AWS::CertificateManager::Certificate',
+        Match.objectLike({
+          DomainName: 'sandbox.akli.dev',
+          ValidationMethod: 'DNS',
+        }),
+      )
+    })
+  })
+
   describe('Certificate count', () => {
-    it('synthesises exactly three ACM certificates (Site, Api, Images)', () => {
-      template.resourceCountIs('AWS::CertificateManager::Certificate', 3)
+    it('synthesises exactly five ACM certificates (Site, Api, Images, Pokedex, Sandbox)', () => {
+      template.resourceCountIs('AWS::CertificateManager::Certificate', 5)
     })
   })
 


### PR DESCRIPTION
Closes #212

## What changed
Adds two new independent, DNS-validated ACM certificates to `CertificateStack` (us-east-1): `PokedexCert` (`pokedex.akli.dev`) and `SandboxCert` (`sandbox.akli.dev`), exposed as `public readonly pokedexCertificate`/`sandboxCertificate`. `SiteCert`, `ApiCert`, and `ImagesCert` are untouched.

## Why
First of two parallel prerequisites (alongside #213) for the Subdomain-Per-App Migration — `PokedexSiteStack`/`SandboxSiteStack` (#214) need their own dedicated certs to consume cross-stack, per `docs/prds/subdomain-per-app-migration.md`. The PRD explicitly rejected a shared/wildcard cert in favor of keeping the existing one-cert-per-subdomain convention.

## How to verify
- `pnpm test` — `test/certificate-stack.test.ts` asserts both new certs exist with `DomainName`/`ValidationMethod: DNS`, and that exactly 5 certs now synthesize.
- `pnpm build` — typechecks clean.
- Diff review: `SiteCert`/`ApiCert`/`ImagesCert` blocks are byte-identical to `main`.

## Decisions made
- Followed the existing precedent exactly (one dedicated `certificatemanager.Certificate` per subdomain, DNS validation against the existing hosted zone) — no SAN, no wildcard, matching `ApiCert`/`ImagesCert`.
- Property naming (`pokedexCertificate`, `sandboxCertificate`) follows the existing camelCase-named-by-purpose convention (`certificate`, `apiCertificate`, `imagesCertificate`).

## Out of scope (filed as follow-up issues)

- **#221** — Extract a shared `dnsValidatedCertificate()` helper covering `ApiCert`/`ImagesCert`/`PokedexCert`/`SandboxCert`, and parameterize the corresponding tests. Deferred because it would touch `ApiCert`/`ImagesCert` construction code that #212 explicitly scopes as "must remain untouched" — better done as its own reviewed change.