### PR TITLE
Expose PokedexBucket and SandboxBucket from AkliInfrastructureStack

### DIFF
--- a/lib/akli-infrastructure-stack.ts
+++ b/lib/akli-infrastructure-stack.ts
@@ -21,6 +21,9 @@ interface AkliInfrastructureStackProps extends StackProps {
 }
 
 export class AkliInfrastructureStack extends Stack {
+  public readonly pokedexBucket: s3.IBucket
+  public readonly sandboxBucket: s3.IBucket
+
   constructor(scope: Construct, id: string, props: AkliInfrastructureStackProps) {
     super(scope, id, props)
 
@@ -47,8 +50,10 @@ export class AkliInfrastructureStack extends Stack {
     })
 
     const pokedexBucket = createHardenedAppBucket(this, 'PokedexBucket')
+    this.pokedexBucket = pokedexBucket
 
     const sandboxBucket = createHardenedAppBucket(this, 'SandboxBucket')
+    this.sandboxBucket = sandboxBucket
 
     const securityHeadersPolicy = createSecurityHeadersPolicy(this)
 


### PR DESCRIPTION
Closes #213

## What changed
`AkliInfrastructureStack` now exposes `pokedexBucket`/`sandboxBucket` as `public readonly` properties (typed `s3.IBucket`), in addition to the existing local `const`s used internally.

## Why
Second of two parallel prerequisites (alongside #212) for the Subdomain-Per-App Migration — `PokedexSiteStack`/`SandboxSiteStack` (#214) need to cross-stack import these buckets via `s3.Bucket.fromBucketAttributes(...)`, per `docs/prds/subdomain-per-app-migration.md`.

## How to verify
- `pnpm test` — full suite (462/462) passes unchanged; no new assertions were required since this is a pure visibility change with no synthesized-template impact.
- `pnpm build` — typechecks clean.
- Diff review: `lib/akli-infrastructure-stack.ts:24-25` (new property declarations), `:52-56` (assignment after each bucket's creation).

## Decisions made
- Mirrored the existing `RecipeStack.imageBucket: s3.IBucket` precedent exactly, per the PRD's explicit instruction: local `const` keeps the concrete `s3.Bucket` type (required by `grantCloudFrontRead`'s signature further down the constructor), while the public property is narrowed to the `s3.IBucket` interface — matching how every other cross-stack export in this codebase is typed.
- No changes to bucket configuration (encryption, removal policy, public access block) — only exposure was added.

## Out of scope
- `/simplify` suggested collapsing `const pokedexBucket = ...; this.pokedexBucket = pokedexBucket` into a single `this.pokedexBucket = createHardenedAppBucket(...)` assignment. Not applied — this codebase's `grantCloudFrontRead()` requires the concrete `s3.Bucket` type, while the public property is deliberately narrowed to `s3.IBucket`; collapsing them would break that type-narrowing (or force an unnecessary cast). The two-statement form is intentional, matching `RecipeStack`'s existing pattern.