### PR TITLE
Deploy roles' CloudFront invalidation permission still scoped to old shared distribution

### DIFF
--- a/bin/akli-infrastructure.ts
+++ b/bin/akli-infrastructure.ts
@@ -98,6 +98,7 @@ new AppSiteStack(app, 'PokedexSiteStack', {
   hostedZone: certStack.hostedZone,
   certificate: certStack.pokedexCertificate,
   bucket: akliInfrastructureStack.pokedexBucket,
+  deployRole: akliInfrastructureStack.pokedexDeployRole,
   description: 'CloudFront distribution for pokedex.akli.dev',
   tags: {
     Project: 'akli-pokedex',
@@ -114,6 +115,7 @@ new AppSiteStack(app, 'SandboxSiteStack', {
   hostedZone: certStack.hostedZone,
   certificate: certStack.sandboxCertificate,
   bucket: akliInfrastructureStack.sandboxBucket,
+  deployRole: akliInfrastructureStack.sandboxDeployRole,
   description: 'CloudFront distribution for sandbox.akli.dev',
   tags: {
     Project: 'akli-sandbox',

--- a/lib/akli-infrastructure-stack.ts
+++ b/lib/akli-infrastructure-stack.ts
@@ -23,6 +23,8 @@ interface AkliInfrastructureStackProps extends StackProps {
 export class AkliInfrastructureStack extends Stack {
   public readonly pokedexBucket: s3.IBucket
   public readonly sandboxBucket: s3.IBucket
+  public readonly pokedexDeployRole: iam.IRole
+  public readonly sandboxDeployRole: iam.IRole
 
   constructor(scope: Construct, id: string, props: AkliInfrastructureStackProps) {
     super(scope, id, props)
@@ -296,7 +298,7 @@ export class AkliInfrastructureStack extends Stack {
       description: 'GitHub Actions OIDC deploy role for pokedex',
     })
     pokedexDeployRole.addToPolicy(s3AppAccessStatement(pokedexBucket))
-    pokedexDeployRole.addToPolicy(cloudfrontInvalidationStatement())
+    this.pokedexDeployRole = pokedexDeployRole
 
     const sandboxDeployRole = new iam.Role(this, 'SandboxDeployRole', {
       roleName: 'sandbox-deploy',
@@ -304,7 +306,7 @@ export class AkliInfrastructureStack extends Stack {
       description: 'GitHub Actions OIDC deploy role for sand-box',
     })
     sandboxDeployRole.addToPolicy(s3AppAccessStatement(sandboxBucket))
-    sandboxDeployRole.addToPolicy(cloudfrontInvalidationStatement())
+    this.sandboxDeployRole = sandboxDeployRole
 
     // IAM user for CDK GitHub Actions (separate user for infrastructure)
     const cdkUser = new iam.User(this, 'CDKGitHubActionsUser', {

--- a/lib/app-site-stack.ts
+++ b/lib/app-site-stack.ts
@@ -20,6 +20,8 @@ export interface AppSiteStackProps extends StackProps {
   certificate: certificatemanager.ICertificate
   /** Cross-stack bucket reference (PokedexBucket/SandboxBucket) */
   bucket: s3.IBucket
+  /** Cross-stack deploy role reference (PokedexDeployRole/SandboxDeployRole) — granted invalidation rights on this stack's own distribution below */
+  deployRole: iam.IRole
 }
 
 /**
@@ -31,7 +33,7 @@ export class AppSiteStack extends Stack {
   constructor(scope: Construct, id: string, props: AppSiteStackProps) {
     super(scope, id, props)
 
-    const { appName, recordName, hostedZone, certificate, bucket } = props
+    const { appName, recordName, hostedZone, certificate, bucket, deployRole } = props
     const domainName = `${recordName}.${hostedZone.zoneName}`
 
     const originAccessControl = new cloudfront.S3OriginAccessControl(this, `${appName}OAC`)
@@ -78,6 +80,23 @@ export class AppSiteStack extends Stack {
           responseHttpStatus: 200,
           responsePagePath: '/index.html',
         },
+      ],
+    })
+
+    // Standalone Policy construct (not deployRole.addToPolicy / grantCreateInvalidation)
+    // so the resulting AWS::IAM::Policy is parented under this stack, not the role's
+    // home stack. addToPolicy always attaches the Policy resource to the scope the Role
+    // was originally `new`'d in — using it here would create a reference from the main
+    // stack back to this distribution's ARN, forming a cycle with the existing
+    // main-stack -> site-stack bucket dependency.
+    new iam.Policy(this, `${appName}DistributionInvalidationPolicy`, {
+      roles: [deployRole],
+      statements: [
+        new iam.PolicyStatement({
+          effect: iam.Effect.ALLOW,
+          actions: ['cloudfront:CreateInvalidation'],
+          resources: [distribution.distributionArn],
+        }),
       ],
     })
 

--- a/test/akli-infrastructure.test.ts
+++ b/test/akli-infrastructure.test.ts
@@ -3,8 +3,9 @@ import { Match, Template } from 'aws-cdk-lib/assertions'
 import * as certificatemanager from 'aws-cdk-lib/aws-certificatemanager'
 import * as route53 from 'aws-cdk-lib/aws-route53'
 import { AkliInfrastructureStack } from '../lib/akli-infrastructure-stack'
+import { findResourceEntryByLogicalIdPrefix, findStatementByAction, referencesLogicalId } from './cdk-test-helpers'
+import type { CfnResource } from './cdk-test-helpers'
 
-type CfnResource = { Type: string; Properties: Record<string, unknown>; DeletionPolicy?: string; UpdateReplacePolicy?: string }
 type CfnOrigin = { Id: string; S3OriginConfig?: unknown; OriginAccessControlId?: unknown; DomainName?: Record<string, unknown>; CustomOriginConfig?: unknown }
 type CfnCacheBehavior = { PathPattern: string; TargetOriginId: string }
 type CfnPolicyStatement = { Sid?: string; Effect: string; Principal?: unknown; Action?: unknown; Resource?: unknown; Condition?: unknown }
@@ -14,24 +15,6 @@ function cfnDistribution(template: Template): CfnResource {
   const dist = Object.values(resources).find((r) => r.Type === 'AWS::CloudFront::Distribution')
   if (!dist) throw new Error('CloudFront::Distribution not found in template')
   return dist
-}
-
-// Finds the [logicalId, resource] entry for the given CFN type whose logical ID starts
-// with idPrefix. CDK appends an 8-character hash to the construct ID to form the logical
-// ID (e.g. construct ID 'PokedexBucket' -> logical ID 'PokedexBucketAB12CD34'), so an
-// exact-match lookup would never succeed. Pass '' as idPrefix to match on type alone.
-function findResourceEntryByLogicalIdPrefix(template: Template, type: string, idPrefix: string): [string, CfnResource] {
-  const resources = template.toJSON().Resources as Record<string, CfnResource>
-  const entries = Object.entries(resources).filter(
-    ([logicalId, r]) => r.Type === type && logicalId.startsWith(idPrefix),
-  )
-  if (entries.length === 0) throw new Error(`${type} with logical ID prefix "${idPrefix}" not found in template`)
-  if (entries.length > 1) {
-    throw new Error(
-      `Multiple ${type} resources match logical ID prefix "${idPrefix}": ${entries.map(([id]) => id).join(', ')}`,
-    )
-  }
-  return entries[0]
 }
 
 function findResourceByLogicalIdPrefix(template: Template, type: string, idPrefix: string): CfnResource {
@@ -101,16 +84,8 @@ function policyStatementsForRole(template: Template, roleLogicalId: string): Rec
   return statements
 }
 
-/** True if `logicalId` appears anywhere inside the (Ref / Fn::GetAtt / Fn::Join / Fn::Sub) structure of `value`. */
-function referencesLogicalId(value: unknown, logicalId: string): boolean {
-  return JSON.stringify(value).includes(logicalId)
-}
-
 function findLambdaStatement(statements: Record<string, unknown>[]): Record<string, unknown> | undefined {
-  return statements.find((s) => {
-    const actions = Array.isArray(s.Action) ? s.Action : [s.Action]
-    return actions.includes('lambda:UpdateFunctionCode')
-  })
+  return findStatementByAction(statements, 'lambda:UpdateFunctionCode')
 }
 
 function createTestStack(): Template {
@@ -634,11 +609,7 @@ describe('AkliInfrastructureStack', () => {
           const [roleLogicalId] = findResourceEntryByLogicalIdPrefix(template, 'AWS::IAM::Role', roleLogicalIdPrefix)
           const [distributionLogicalId] = findResourceEntryByLogicalIdPrefix(template, 'AWS::CloudFront::Distribution', '')
           const statements = policyStatementsForRole(template, roleLogicalId)
-
-          const invalidationStatement = statements.find((s) => {
-            const actions = Array.isArray(s.Action) ? s.Action : [s.Action]
-            return actions.includes('cloudfront:CreateInvalidation')
-          })
+          const invalidationStatement = findStatementByAction(statements, 'cloudfront:CreateInvalidation')
 
           expect(invalidationStatement).toBeDefined()
           expect(invalidationStatement?.Effect).toBe('Allow')
@@ -648,11 +619,7 @@ describe('AkliInfrastructureStack', () => {
         it('does not grant cloudfront:CreateInvalidation on the shared distribution (granted instead on its own AppSiteStack distribution — see app-site-stack.test.ts)', () => {
           const [roleLogicalId] = findResourceEntryByLogicalIdPrefix(template, 'AWS::IAM::Role', roleLogicalIdPrefix)
           const statements = policyStatementsForRole(template, roleLogicalId)
-
-          const invalidationStatement = statements.find((s) => {
-            const actions = Array.isArray(s.Action) ? s.Action : [s.Action]
-            return actions.includes('cloudfront:CreateInvalidation')
-          })
+          const invalidationStatement = findStatementByAction(statements, 'cloudfront:CreateInvalidation')
 
           expect(invalidationStatement).toBeUndefined()
         })

--- a/test/akli-infrastructure.test.ts
+++ b/test/akli-infrastructure.test.ts
@@ -547,22 +547,29 @@ describe('AkliInfrastructureStack', () => {
         repo: 'personal-website',
         bucketLogicalIdPrefix: 'SiteBucket',
         hasLambdaAccess: true,
+        // PersonalWebsiteDeployRole still invalidates the one shared distribution
+        // in this (main) stack. Pokedex/Sandbox deploy roles get their invalidation
+        // grant from their own AppSiteStack instead — see #227 and
+        // test/app-site-stack.test.ts.
+        sharedDistributionInvalidation: true,
       },
       {
         roleLogicalIdPrefix: 'PokedexDeployRole',
         repo: 'pokedex',
         bucketLogicalIdPrefix: 'PokedexBucket',
         hasLambdaAccess: false,
+        sharedDistributionInvalidation: false,
       },
       {
         roleLogicalIdPrefix: 'SandboxDeployRole',
         repo: 'sand-box',
         bucketLogicalIdPrefix: 'SandboxBucket',
         hasLambdaAccess: false,
+        sharedDistributionInvalidation: false,
       },
     ] as const
 
-    describe.each(DEPLOY_APPS)('$roleLogicalIdPrefix', ({ roleLogicalIdPrefix, repo, bucketLogicalIdPrefix, hasLambdaAccess }) => {
+    describe.each(DEPLOY_APPS)('$roleLogicalIdPrefix', ({ roleLogicalIdPrefix, repo, bucketLogicalIdPrefix, hasLambdaAccess, sharedDistributionInvalidation }) => {
       it(`trusts only repo:vandelay87/${repo}:ref:refs/heads/main via the GitHub OIDC provider`, () => {
         const [, role] = findResourceEntryByLogicalIdPrefix(template, 'AWS::IAM::Role', roleLogicalIdPrefix)
         const statements = trustPolicyStatements(role)
@@ -622,20 +629,34 @@ describe('AkliInfrastructureStack', () => {
         })
       }
 
-      it('grants cloudfront:CreateInvalidation scoped to the one shared distribution', () => {
-        const [roleLogicalId] = findResourceEntryByLogicalIdPrefix(template, 'AWS::IAM::Role', roleLogicalIdPrefix)
-        const [distributionLogicalId] = findResourceEntryByLogicalIdPrefix(template, 'AWS::CloudFront::Distribution', '')
-        const statements = policyStatementsForRole(template, roleLogicalId)
+      if (sharedDistributionInvalidation) {
+        it('grants cloudfront:CreateInvalidation scoped to the one shared distribution', () => {
+          const [roleLogicalId] = findResourceEntryByLogicalIdPrefix(template, 'AWS::IAM::Role', roleLogicalIdPrefix)
+          const [distributionLogicalId] = findResourceEntryByLogicalIdPrefix(template, 'AWS::CloudFront::Distribution', '')
+          const statements = policyStatementsForRole(template, roleLogicalId)
 
-        const invalidationStatement = statements.find((s) => {
-          const actions = Array.isArray(s.Action) ? s.Action : [s.Action]
-          return actions.includes('cloudfront:CreateInvalidation')
+          const invalidationStatement = statements.find((s) => {
+            const actions = Array.isArray(s.Action) ? s.Action : [s.Action]
+            return actions.includes('cloudfront:CreateInvalidation')
+          })
+
+          expect(invalidationStatement).toBeDefined()
+          expect(invalidationStatement?.Effect).toBe('Allow')
+          expect(referencesLogicalId(invalidationStatement?.Resource, distributionLogicalId)).toBe(true)
         })
+      } else {
+        it('does not grant cloudfront:CreateInvalidation on the shared distribution (granted instead on its own AppSiteStack distribution — see app-site-stack.test.ts)', () => {
+          const [roleLogicalId] = findResourceEntryByLogicalIdPrefix(template, 'AWS::IAM::Role', roleLogicalIdPrefix)
+          const statements = policyStatementsForRole(template, roleLogicalId)
 
-        expect(invalidationStatement).toBeDefined()
-        expect(invalidationStatement?.Effect).toBe('Allow')
-        expect(referencesLogicalId(invalidationStatement?.Resource, distributionLogicalId)).toBe(true)
-      })
+          const invalidationStatement = statements.find((s) => {
+            const actions = Array.isArray(s.Action) ? s.Action : [s.Action]
+            return actions.includes('cloudfront:CreateInvalidation')
+          })
+
+          expect(invalidationStatement).toBeUndefined()
+        })
+      }
     })
 
     it("no Role's policy references another app's bucket ARN (cross-app S3 isolation)", () => {

--- a/test/app-site-stack.test.ts
+++ b/test/app-site-stack.test.ts
@@ -1,6 +1,7 @@
 import * as cdk from 'aws-cdk-lib'
 import { Match, Template } from 'aws-cdk-lib/assertions'
 import * as certificatemanager from 'aws-cdk-lib/aws-certificatemanager'
+import * as iam from 'aws-cdk-lib/aws-iam'
 import * as route53 from 'aws-cdk-lib/aws-route53'
 import * as s3 from 'aws-cdk-lib/aws-s3'
 import { AppSiteStack } from '../lib/app-site-stack'
@@ -56,6 +57,12 @@ function createHarness(testCase: AppCase): Harness {
     bucketName: `test-${testCase.recordName}-bucket-123456789012`,
   })
 
+  // Deploy role lives on the owner stack, mirroring #227's
+  // AkliInfrastructureStack.pokedexDeployRole/sandboxDeployRole.
+  const deployRole = new iam.Role(bucketOwnerStack, `Test${testCase.appName}DeployRole`, {
+    assumedBy: new iam.ServicePrincipal('example.amazonaws.com'),
+  })
+
   const siteStack = new AppSiteStack(app, `${testCase.appName}SiteStack`, {
     env: { account: '123456789012', region: 'eu-west-2' },
     crossRegionReferences: true,
@@ -64,6 +71,7 @@ function createHarness(testCase: AppCase): Harness {
     hostedZone,
     certificate,
     bucket,
+    deployRole,
     tags: {
       Project: `akli-${testCase.recordName}`,
       Environment: 'production',

--- a/test/app-site-stack.test.ts
+++ b/test/app-site-stack.test.ts
@@ -99,6 +99,34 @@ type CfnDistributionResource = CfnResource & {
     }
   }
 }
+type CfnPolicyResource = CfnResource & {
+  Properties: {
+    PolicyDocument: { Statement: Record<string, unknown>[] }
+    Roles?: unknown[]
+  }
+}
+
+// Mirrors akli-infrastructure.test.ts's helper of the same name — CDK appends
+// an 8-character hash to the construct ID to form the logical ID, so an
+// exact-match lookup would never succeed.
+function findResourceEntryByLogicalIdPrefix(template: Template, type: string, idPrefix: string): [string, CfnResource] {
+  const resources = template.toJSON().Resources as Record<string, CfnResource>
+  const entries = Object.entries(resources).filter(
+    ([logicalId, r]) => r.Type === type && logicalId.startsWith(idPrefix),
+  )
+  if (entries.length === 0) throw new Error(`${type} with logical ID prefix "${idPrefix}" not found in template`)
+  if (entries.length > 1) {
+    throw new Error(
+      `Multiple ${type} resources match logical ID prefix "${idPrefix}": ${entries.map(([id]) => id).join(', ')}`,
+    )
+  }
+  return entries[0]
+}
+
+/** True if `logicalId` appears anywhere inside the (Ref / Fn::GetAtt / Fn::Join / Fn::Sub) structure of `value`. */
+function referencesLogicalId(value: unknown, logicalId: string): boolean {
+  return JSON.stringify(value).includes(logicalId)
+}
 
 // Per the PRD's "Note on testing precision": AppSiteStack instances are
 // separate Stack instances, each producing its own template with exactly
@@ -349,6 +377,69 @@ describe.each(CASES)('AppSiteStack ($appName)', (testCase) => {
       }
 
       expect(flagSet || isCrossRegionToken).toBe(true)
+    })
+  })
+
+  describe('Deploy role CloudFront invalidation policy (#227)', () => {
+    // Issue #227: PokedexDeployRole/SandboxDeployRole no longer get
+    // cloudfront:CreateInvalidation on the old shared distribution. Instead,
+    // AppSiteStack grants it here, scoped to this stack's own distribution's
+    // exact ARN (not a wildcard).
+    it(`creates an AWS::IAM::Policy (${testCase.appName}DistributionInvalidationPolicy) granting cloudfront:CreateInvalidation`, () => {
+      const [, policy] = findResourceEntryByLogicalIdPrefix(
+        harness.siteTemplate,
+        'AWS::IAM::Policy',
+        `${testCase.appName}DistributionInvalidationPolicy`,
+      ) as [string, CfnPolicyResource]
+
+      const statements = policy.Properties.PolicyDocument.Statement
+      const invalidationStatement = statements.find((s) => {
+        const actions = Array.isArray(s.Action) ? s.Action : [s.Action]
+        return actions.includes('cloudfront:CreateInvalidation')
+      })
+
+      expect(invalidationStatement).toBeDefined()
+      expect(invalidationStatement?.Effect).toBe('Allow')
+    })
+
+    it("scopes the invalidation grant to this stack's own distribution ARN (not a wildcard)", () => {
+      const [, policy] = findResourceEntryByLogicalIdPrefix(
+        harness.siteTemplate,
+        'AWS::IAM::Policy',
+        `${testCase.appName}DistributionInvalidationPolicy`,
+      ) as [string, CfnPolicyResource]
+      const [distributionLogicalId] = findResourceEntryByLogicalIdPrefix(
+        harness.siteTemplate,
+        'AWS::CloudFront::Distribution',
+        '',
+      )
+
+      const invalidationStatement = policy.Properties.PolicyDocument.Statement.find((s) => {
+        const actions = Array.isArray(s.Action) ? s.Action : [s.Action]
+        return actions.includes('cloudfront:CreateInvalidation')
+      })
+
+      // Must be an exact ARN reference (Fn::Join/Ref to this stack's own
+      // distribution), never a literal wildcard.
+      expect(invalidationStatement?.Resource).not.toBe('*')
+      expect(referencesLogicalId(invalidationStatement?.Resource, distributionLogicalId)).toBe(true)
+    })
+
+    it(`the policy's Roles references this app's deploy role (Test${testCase.appName}DeployRole), cross-stack via Fn::ImportValue`, () => {
+      const [, policy] = findResourceEntryByLogicalIdPrefix(
+        harness.siteTemplate,
+        'AWS::IAM::Policy',
+        `${testCase.appName}DistributionInvalidationPolicy`,
+      ) as [string, CfnPolicyResource]
+
+      // The deploy role lives on the owning stack (bucketOwnerStack, mirroring
+      // AkliInfrastructureStack), so within the site stack's own template this
+      // can never be a same-stack {Ref: roleLogicalId} — it comes through as a
+      // cross-stack Fn::ImportValue export string instead. Assert loosely (a
+      // substring check on the role's construct id), matching the
+      // JSON.stringify(...).includes(...) style `referencesLogicalId` already
+      // uses elsewhere, since the exact export name is hash-suffixed.
+      expect(referencesLogicalId(policy.Properties.Roles, `Test${testCase.appName}DeployRole`)).toBe(true)
     })
   })
 

--- a/test/app-site-stack.test.ts
+++ b/test/app-site-stack.test.ts
@@ -5,6 +5,8 @@ import * as iam from 'aws-cdk-lib/aws-iam'
 import * as route53 from 'aws-cdk-lib/aws-route53'
 import * as s3 from 'aws-cdk-lib/aws-s3'
 import { AppSiteStack } from '../lib/app-site-stack'
+import { findResourceEntryByLogicalIdPrefix, findStatementByAction, referencesLogicalId } from './cdk-test-helpers'
+import type { CfnResource } from './cdk-test-helpers'
 
 interface AppCase {
   appName: string
@@ -86,7 +88,6 @@ function createHarness(testCase: AppCase): Harness {
   }
 }
 
-type CfnResource = { Type: string; Properties: Record<string, unknown> }
 type CfnDistributionResource = CfnResource & {
   Properties: {
     DistributionConfig: {
@@ -104,28 +105,6 @@ type CfnPolicyResource = CfnResource & {
     PolicyDocument: { Statement: Record<string, unknown>[] }
     Roles?: unknown[]
   }
-}
-
-// Mirrors akli-infrastructure.test.ts's helper of the same name — CDK appends
-// an 8-character hash to the construct ID to form the logical ID, so an
-// exact-match lookup would never succeed.
-function findResourceEntryByLogicalIdPrefix(template: Template, type: string, idPrefix: string): [string, CfnResource] {
-  const resources = template.toJSON().Resources as Record<string, CfnResource>
-  const entries = Object.entries(resources).filter(
-    ([logicalId, r]) => r.Type === type && logicalId.startsWith(idPrefix),
-  )
-  if (entries.length === 0) throw new Error(`${type} with logical ID prefix "${idPrefix}" not found in template`)
-  if (entries.length > 1) {
-    throw new Error(
-      `Multiple ${type} resources match logical ID prefix "${idPrefix}": ${entries.map(([id]) => id).join(', ')}`,
-    )
-  }
-  return entries[0]
-}
-
-/** True if `logicalId` appears anywhere inside the (Ref / Fn::GetAtt / Fn::Join / Fn::Sub) structure of `value`. */
-function referencesLogicalId(value: unknown, logicalId: string): boolean {
-  return JSON.stringify(value).includes(logicalId)
 }
 
 // Per the PRD's "Note on testing precision": AppSiteStack instances are
@@ -385,39 +364,30 @@ describe.each(CASES)('AppSiteStack ($appName)', (testCase) => {
     // cloudfront:CreateInvalidation on the old shared distribution. Instead,
     // AppSiteStack grants it here, scoped to this stack's own distribution's
     // exact ARN (not a wildcard).
-    it(`creates an AWS::IAM::Policy (${testCase.appName}DistributionInvalidationPolicy) granting cloudfront:CreateInvalidation`, () => {
-      const [, policy] = findResourceEntryByLogicalIdPrefix(
+    let policy: CfnPolicyResource
+    let invalidationStatement: Record<string, unknown> | undefined
+
+    beforeEach(() => {
+      const [, resource] = findResourceEntryByLogicalIdPrefix(
         harness.siteTemplate,
         'AWS::IAM::Policy',
         `${testCase.appName}DistributionInvalidationPolicy`,
       ) as [string, CfnPolicyResource]
+      policy = resource
+      invalidationStatement = findStatementByAction(policy.Properties.PolicyDocument.Statement, 'cloudfront:CreateInvalidation')
+    })
 
-      const statements = policy.Properties.PolicyDocument.Statement
-      const invalidationStatement = statements.find((s) => {
-        const actions = Array.isArray(s.Action) ? s.Action : [s.Action]
-        return actions.includes('cloudfront:CreateInvalidation')
-      })
-
+    it(`creates an AWS::IAM::Policy (${testCase.appName}DistributionInvalidationPolicy) granting cloudfront:CreateInvalidation`, () => {
       expect(invalidationStatement).toBeDefined()
       expect(invalidationStatement?.Effect).toBe('Allow')
     })
 
     it("scopes the invalidation grant to this stack's own distribution ARN (not a wildcard)", () => {
-      const [, policy] = findResourceEntryByLogicalIdPrefix(
-        harness.siteTemplate,
-        'AWS::IAM::Policy',
-        `${testCase.appName}DistributionInvalidationPolicy`,
-      ) as [string, CfnPolicyResource]
       const [distributionLogicalId] = findResourceEntryByLogicalIdPrefix(
         harness.siteTemplate,
         'AWS::CloudFront::Distribution',
         '',
       )
-
-      const invalidationStatement = policy.Properties.PolicyDocument.Statement.find((s) => {
-        const actions = Array.isArray(s.Action) ? s.Action : [s.Action]
-        return actions.includes('cloudfront:CreateInvalidation')
-      })
 
       // Must be an exact ARN reference (Fn::Join/Ref to this stack's own
       // distribution), never a literal wildcard.
@@ -426,12 +396,6 @@ describe.each(CASES)('AppSiteStack ($appName)', (testCase) => {
     })
 
     it(`the policy's Roles references this app's deploy role (Test${testCase.appName}DeployRole), cross-stack via Fn::ImportValue`, () => {
-      const [, policy] = findResourceEntryByLogicalIdPrefix(
-        harness.siteTemplate,
-        'AWS::IAM::Policy',
-        `${testCase.appName}DistributionInvalidationPolicy`,
-      ) as [string, CfnPolicyResource]
-
       // The deploy role lives on the owning stack (bucketOwnerStack, mirroring
       // AkliInfrastructureStack), so within the site stack's own template this
       // can never be a same-stack {Ref: roleLogicalId} — it comes through as a

--- a/test/cdk-test-helpers.ts
+++ b/test/cdk-test-helpers.ts
@@ -1,0 +1,33 @@
+import type { Template } from 'aws-cdk-lib/assertions'
+
+export type CfnResource = { Type: string; Properties: Record<string, unknown>; DeletionPolicy?: string; UpdateReplacePolicy?: string }
+
+// Finds the [logicalId, resource] entry for the given CFN type whose logical ID starts
+// with idPrefix. CDK appends an 8-character hash to the construct ID to form the logical
+// ID (e.g. construct ID 'PokedexBucket' -> logical ID 'PokedexBucketAB12CD34'), so an
+// exact-match lookup would never succeed. Pass '' as idPrefix to match on type alone.
+export function findResourceEntryByLogicalIdPrefix(template: Template, type: string, idPrefix: string): [string, CfnResource] {
+  const resources = template.toJSON().Resources as Record<string, CfnResource>
+  const entries = Object.entries(resources).filter(
+    ([logicalId, r]) => r.Type === type && logicalId.startsWith(idPrefix),
+  )
+  if (entries.length === 0) throw new Error(`${type} with logical ID prefix "${idPrefix}" not found in template`)
+  if (entries.length > 1) {
+    throw new Error(
+      `Multiple ${type} resources match logical ID prefix "${idPrefix}": ${entries.map(([id]) => id).join(', ')}`,
+    )
+  }
+  return entries[0]
+}
+
+/** True if `logicalId` appears anywhere inside the (Ref / Fn::GetAtt / Fn::Join / Fn::Sub) structure of `value`. */
+export function referencesLogicalId(value: unknown, logicalId: string): boolean {
+  return JSON.stringify(value).includes(logicalId)
+}
+
+export function findStatementByAction(statements: Record<string, unknown>[], action: string): Record<string, unknown> | undefined {
+  return statements.find((s) => {
+    const actions = Array.isArray(s.Action) ? s.Action : [s.Action]
+    return actions.includes(action)
+  })
+}


### PR DESCRIPTION
Closes #227

## What changed
- `PokedexDeployRole`/`SandboxDeployRole` no longer receive `cloudfront:CreateInvalidation` on the old shared distribution — that grant was removed from `lib/akli-infrastructure-stack.ts`.
- Instead, `lib/app-site-stack.ts` (`AppSiteStack`, shared by `PokedexSiteStack`/`SandboxSiteStack`) now takes a `deployRole: iam.IRole` prop and creates a standalone `iam.Policy` construct granting that role `cloudfront:CreateInvalidation` scoped to **that stack's own distribution's exact ARN** (not a wildcard).
- `personalWebsiteDeployRole`'s existing grant on the shared distribution is unchanged.
- `AkliInfrastructureStack` now exposes `pokedexDeployRole`/`sandboxDeployRole` as public readonly properties (mirroring the existing `pokedexBucket`/`sandboxBucket` pattern) so `bin/akli-infrastructure.ts` can wire them into the site stacks.

## Why
Once each app's `AWS_CLOUDFRONT_DISTRIBUTION_ID` repo variable is updated to point at its new dedicated distribution (`PokedexSiteStack`/`SandboxSiteStack`, from the Subdomain-Per-App Migration), the deploy workflow's invalidation step would fail with AccessDenied — the IAM role never had permission on the new distribution. Confirmed live in AWS before filing: both `pokedex-deploy` and `sandbox-deploy`'s inline policies only referenced the old shared distribution's ARN.

## Architecture note (why not a simpler fix)
`PokedexSiteStack`/`SandboxSiteStack` already depend on `AkliInfrastructureStack` via a `bucket` prop. Granting the permission from the main stack side (`deployRole.addToPolicy(...)` referencing the site stack's `distribution.distributionArn`) would require CDK to resolve a reference in the opposite direction — a circular stack dependency that fails at `cdk synth`. `Role.addToPolicy()`/`Distribution.grantCreateInvalidation()` don't avoid this either, since both always parent the resulting `AWS::IAM::Policy` in the *role's* home stack (the main stack), regardless of which stack's code calls them.

The fix instead creates the `iam.Policy` construct inside `AppSiteStack` itself — same-stack reference to its own distribution ARN, one-directional cross-stack reference to the role only (same direction as the existing `bucket` dependency). Verified via `cdk synth --all` (no cycle error) and by inspecting the synthesized template directly: the new `PokedexDistributionInvalidationPolicy` resource lives in `PokedexSiteStack`'s own template, with `Roles` importing the role from `AkliInfrastructureStack` via `Fn::ImportValue`, and `Resource` an exact same-stack `Ref` to its own distribution — no wildcard.

## How to verify
- `pnpm build`, `pnpm test` (510/510), `pnpm lint` all pass
- `cdk synth --all` succeeds with no circular dependency error
- New CDK assertion tests in `test/app-site-stack.test.ts` confirm each app's own site-stack template has the correctly-scoped policy; updated tests in `test/akli-infrastructure.test.ts` confirm Pokedex/Sandbox roles no longer have any invalidation statement in the main stack (regression guard against the old grant reappearing there)
- **Not yet verifiable**: live IAM policy re-check against AWS — this repo deploys on push to `main`, so this only becomes checkable after merge. I'll re-verify the live policies myself once this lands.

## Decisions made
- IAM policies scoped to exact ARNs throughout — no wildcards introduced (per this repo's least-privilege convention).
- `personalWebsiteDeployRole` intentionally still uses the old shared-`cloudfrontInvalidationStatement()`-helper path, since personal-website's distribution genuinely still lives in the main stack (unlike Pokedex/Sandbox, which have already migrated to dedicated `AppSiteStack` distributions). This is a temporary two-mechanism state that collapses naturally if/when personal-website migrates onto `AppSiteStack` too — no action needed now, called out explicitly in the review.

## Out of scope
- `docs/prds/per-app-buckets-and-oidc-deploy.md` documents "CreateInvalidation is necessarily shared across all three Roles" as an accepted limitation — now stale given this fix. Cosmetic PRD-doc staleness, not required by this issue; left as-is.
- No follow-up issues filed — remaining `/simplify` observations (the `personalWebsiteDeployRole` two-mechanism note, and a suggestion to extract the hardcoded `'cloudfront:CreateInvalidation'` action string to a shared constant) were judged not worth a separate issue: both are low-risk, single-occurrence, and would be premature abstraction for one call site each.