### PR TITLE
PokedexHttpApi CORS allowlist missing pokedex.akli.dev origin

### DIFF
--- a/lib/pokedex-stack.ts
+++ b/lib/pokedex-stack.ts
@@ -84,7 +84,7 @@ export class PokedexStack extends Stack {
       apiName: 'pokedex-api',
       description: 'HTTP API Gateway for the Pokedex API',
       corsPreflight: {
-        allowOrigins: ['https://akli.dev'],
+        allowOrigins: ['https://akli.dev', 'https://pokedex.akli.dev'],
         allowMethods: [CorsHttpMethod.GET],
         allowHeaders: ['Content-Type'],
       },

--- a/test/pokedex-stack.test.ts
+++ b/test/pokedex-stack.test.ts
@@ -128,10 +128,10 @@ describe('PokedexStack', () => {
       })
     })
 
-    it('configures CORS to allow https://akli.dev', () => {
+    it('configures CORS to allow https://akli.dev and https://pokedex.akli.dev', () => {
       template.hasResourceProperties('AWS::ApiGatewayV2::Api', {
         CorsConfiguration: Match.objectLike({
-          AllowOrigins: Match.arrayWith(['https://akli.dev']),
+          AllowOrigins: Match.arrayWith(['https://akli.dev', 'https://pokedex.akli.dev']),
         }),
       })
     })


### PR DESCRIPTION
Closes #229

**Production incident fix** — pokedex.akli.dev is broken right now (every API call fails with a CORS error). Recommend merging and deploying promptly.

## What changed
`lib/pokedex-stack.ts:87` — `PokedexHttpApi`'s `corsPreflight.allowOrigins` now includes both `https://akli.dev` and `https://pokedex.akli.dev`, instead of just the old origin.

## Why
Pokedex was migrated to its own subdomain (`pokedex.akli.dev`, pokedex#56, merged/deployed). The API's CORS allowlist was never updated to match — it only permitted `https://akli.dev`. The API responds with HTTP 200, but the browser blocks reading the response because `Access-Control-Allow-Origin` doesn't include the requesting origin, so every fetch from the live app fails.

## How to verify
- `pnpm test` (510/510), `pnpm lint`, `pnpm exec tsc --noEmit`, `cdk synth --all` all pass
- New/updated CDK assertion test (`test/pokedex-stack.test.ts`) confirms both origins are present in `AllowOrigins`
- Post-deploy: `https://pokedex.akli.dev` should successfully fetch and render the Pokemon list with no CORS errors in the console — I'll verify this live once merged and deployed

## Decisions made
- Kept `https://akli.dev` in the allowlist alongside the new origin — the old path-based URL (`akli.dev/apps/pokedex`) still serves the old cached build until akli-infrastructure#216 (Deploy B) removes that routing, and that old build's requests originate from `https://akli.dev`, not the new subdomain. Both need to keep working during the transition.
- `/simplify`'s altitude review confirmed a hardcoded array literal is consistent with the existing codebase pattern (`auth-stack.ts`, `recipe-stack.ts` do the same) — no shared origin-list abstraction exists yet, and introducing one wasn't taken on as part of this fix (would be a separate repo-wide refactor).